### PR TITLE
Closes #90 - filter for scala.js

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
@@ -61,7 +61,8 @@ class SeedElasticSearch(implicit val ec: ExecutionContext) extends ProjectProtoc
       println("creating index")
       Await.result(esClient.execute {
         create.index(indexName).mappings(mapping(collectionName).fields(
-          field("keywords") typed StringType,
+          field("keywords") typed StringType index "not_analyzed",
+          field("support") typed StringType index "not_analyzed",
           field("parentOrganization") typed StringType index "not_analyzed",
           field("firstUpdate").typed(DateType),
           field("lastUpdate").typed(DateType),

--- a/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
@@ -28,7 +28,10 @@ case class Project(
 
   created: Option[String] = None,
   
-  lastUpdate: Option[String] = None
+  lastUpdate: Option[String] = None,
+
+  /** add support for Scala_2.11, Scala_2.12, spark, scala-js */
+  support: List[String] = Nil
 ) {
   def githubRepo = GithubRepo(reference.organization, reference.repository)
 }

--- a/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
@@ -120,7 +120,10 @@ case class MavenReference(
 case class ScalaTargets(scalaVersion: SemanticVersion, scalaJsVersion: Option[SemanticVersion] = None) {
 
   /** simple modifier for display a nice name */
-  lazy val name = scalaJsVersion.map(v => s"Scala.js ${v.toString} ($scalaVersion)").getOrElse(s"Scala $scalaVersion")
+  lazy val name: String = scalaJsVersion.map(v => s"Scala.js ${v.toString} ($scalaVersion)").getOrElse(s"Scala $scalaVersion")
+
+  /** converting the scala version for support tags in elastic  - only major.minor to have small list */
+  lazy val supportName: String = scalaJsVersion.map(v => s"scala.js_${v.major}.${v.minor}").getOrElse(s"scala_${scalaVersion.major}.${scalaVersion.minor}")
 
   /** simple modifier for ordering */
   lazy val orderName: String = scalaJsVersion.map(v => s"${scalaVersion.toString.replace(".", "")}_${v.toString.replace(".", "")}").getOrElse(scalaVersion.toString.replace(".", ""))

--- a/server/src/main/scala/ch.epfl.scala.index.server/Server.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/Server.scala
@@ -43,9 +43,10 @@ object Server {
     def frontPage(userInfo: Option[UserInfo]) = {
       for {
         keywords <- sharedApi.keywords()
+        support <- sharedApi.support()
         latestProjects <- sharedApi.latestProjects()
         latestReleases <- sharedApi.latestReleases()
-      } yield views.html.frontpage(keywords, latestProjects, latestReleases, userInfo)
+      } yield views.html.frontpage(keywords, support, latestProjects, latestReleases, userInfo)
     }
 
     def artifactPage(reference: Artifact.Reference, version: Option[SemanticVersion], user: Option[UserInfo]) = {

--- a/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
@@ -2,7 +2,7 @@
 @import ch.epfl.scala.index.model.Release
 @import ch.epfl.scala.index.model.UserInfo
 @import ch.epfl.scala.index.model.Url
-@(keywords: Map[String, Long], latestProjects: List[Project], latestReleases: List[Release], user: Option[UserInfo])
+@(keywords: Map[String, Long], support: Map[String, Long], latestProjects: List[Project], latestReleases: List[Release], user: Option[UserInfo])
 @main(title = "Home", showSearch = false, searchQuery = "", user) {
 <main id="container-home">
     <section class="content-search-home">
@@ -11,9 +11,16 @@
                 <div class="col-md-8 col-md-offset-2">
                     <h1>The Scala Library Index</h1> @searchinput()
                     <ul class="tag">
-                    @for((keyword, count) <- keywords) {
-                        <li><a href="/search?q=keywords:@keyword">@keyword (@count)</a></li>
-                    }
+                        <li><strong>Support:</strong></li>
+                        @for((sup, count) <- support) {
+                            <li><a href="/search?q=support:@sup.replace("/", """\/""")">@sup (@count)</a></li>
+                        }
+                    </ul>
+
+                    <ul class="tag">
+                        @for((keyword, count) <- keywords) {
+                            <li><a href="/search?q=keywords:@keyword">@keyword (@count)</a></li>
+                        }
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Implementing a featured/supported tag cloud which contains all found
Scala versions (major.minor) and also scala-js versions. On Top of that
there are featured artefacts like spark and akka. This tag will list
all artefacts which depends on aka or spark.

Also fixes a bug with tag cloud if there is a “-“ in the tag. Now they
are displayed correct.