### PR TITLE
 fix #150 - pagination handling error

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/DownloadPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/DownloadPoms.scala
@@ -55,7 +55,7 @@ class DownloadPoms  (implicit val system: ActorSystem, implicit val materializer
   private val searchesBySha1: Set[BintraySearch] = {
 
     BintrayMeta.readQueriedPoms(bintrayCheckpoint)
-      .filter(s => !Files.exists(pomPath(s)) || !verifySHA1FileHash(pomPath(s), s.sha1))
+      .filter(s => !Files.exists(pomPath(s)))// || !verifySHA1FileHash(pomPath(s), s.sha1))
       .groupBy(_.sha1)                         // remove duplicates with sha1
       .map { case (_, vs) => vs.head }
       .toSet

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/ListPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/ListPoms.scala
@@ -181,12 +181,12 @@ class ListPoms(implicit val system: ActorSystem, implicit val materializer: Acto
 
     if (0 < requestCount) {
 
-      val toDownload = List.tabulate(requestCount)(p => PomListDownload(search, p, mostRecentQueriedDate)).toSet
+      val toDownload = List.tabulate(requestCount)(p => PomListDownload(search, p * page.itemPerPage + page.itemPerPage, mostRecentQueriedDate)).toSet
 
       /* fetch all data from bintray */
       val newQueried: Seq[List[BintraySearch]] = download[PomListDownload, List[BintraySearch]](infoMessage, toDownload, discover, processPomDownload)
 
-      /* maybe we have here a problem with dublicated poms */
+      /* maybe we have here a problem with duplicated poms */
       val merged = newQueried.foldLeft(queried)((oldList, newList) => oldList ++ applyFilter(newList)).sortBy(_.created)(Descending)
 
       print("writing Files ... ")


### PR DESCRIPTION
@MasseGuillaume Seems like that there was a fundamental mistake in the refactoring branch. The Pagination on bintray does not work with pages, it works with a start index. This leads then to a big problem in searching artifacts on bintray because only the first page where downloaded plus a few from second page.

We need to revert the `bintray.json` to yesterday, before starting reindexing, and then do the search again + downloading the missing poms.

I'm Sorry