### PR TITLE
fix #167 - show github organization or user icon

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
@@ -58,7 +58,7 @@ object GithubReader {
     GithubInfo(
       homepage = repository.homepage.map(h => Url(h)),
       description = Some(repository.description),
-      logo = repository.organization.map(o => Url(o.avatar_url)),
+      logo = Some(Url(repository.owner.avatar_url)),
       stars = Some(repository.stargazers_count),
       forks = Some(repository.forks),
       watchers = Some(repository.subscribers_count),


### PR DESCRIPTION
If there is no organization, the user icon was not shown instead.