### PR TITLE
Fix issue with some user avatars

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -60,7 +60,8 @@
                                href="/search?q=@searchQuery@if(!you){&you=✓}"
                                
                                >
-                                <img src="@u.sizedAvatarUrl(38)" alt="Your Avatar - @u.login"> Projects
+                                <img src="@u.sizedAvatarUrl(38)" alt="Your Avatar - @u.login"
+                                    height="38"> Projects
                             </a>
                         }.getOrElse {
                             <a class="btn btn-primary pull-right" href="/login">


### PR DESCRIPTION
It's definitely a GitHub bug, which I have already reported, but as a workaround for now we can enforce image size to 38 pixels which seems to fix the problem.

Here is a screenshot of what it looked like:
![scaladex-avatar](https://cloud.githubusercontent.com/assets/3045108/19628797/e8827cc2-9965-11e6-8f1d-68cadc8a3d43.png)
