### PR TITLE
Correct clone URLs in contributors guide

### DIFF
--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -7,9 +7,9 @@
 ## How to run Scaladex locally:
 
 ```bash
-git clone git@github.com:scalacenter/scaladex.git
-git clone git@github.com:scalacenter/scaladex-index.git index
-git clone git@github.com:scalacenter/scaladex-contrib.git contrib
+git clone https://github.com/scalacenter/scaladex.git
+git clone --depth=1 https://github.com/scalacenter/scaladex-index.git index
+git clone --depth=1 https://github.com/scalacenter/scaladex-contrib.git contrib
 cd scaladex
 sbt
 ```


### PR DESCRIPTION
The git links used would fail with `Permission denied (publickey)`.  Using the http links solves this issue.

Also set depth for the index data because they are large and intended as read-only anyway.