### PR TITLE
Made page title come before site tite in title bar

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -7,7 +7,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Scaladex ! @title</title>
+    <title>@title ! Scaladex</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!--meta name="description" content="Description...">
     <meta name="author" content="Author..."-->


### PR DESCRIPTION
This puts the page title before the site title.  This puts the most pertinent information first improving usability.

Pages are now titles (example):
 > akka ! Scaladex

instead of,
 > Scaladex ! akka

When having multiple tabs open, many browsers narrow the tab reducing the number of visible characters.  Prior to this change, a user would have many tabs open all indicating "Scalad..." but would not be able to tell at a glance what project they were for.  With this change it is more likely a user will be able to identify a tab without switching to it.