### PR TITLE
Hyperlink Statistics and Footer Logos

### DIFF
--- a/server/src/main/assets/css/partials/_main.scss
+++ b/server/src/main/assets/css/partials/_main.scss
@@ -370,6 +370,9 @@ main {
                     }
                 }
             }
+            a {
+                color: inherit;
+            }
         }
         .install {
             .nav-tabs > li:not(.active) > a {

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -94,8 +94,8 @@
                     </ul>
                 </div>
                 <div class="col-md-2">
-                    <img src="/assets/img/scala-center-logo.png" alt="powered by Scala Center">
-                    <img src="/assets/img/Bintray.png" alt="powered by Bintray">
+                    <a href="https://scala.epfl.ch/"><img src="/assets/img/scala-center-logo.png" alt="powered by Scala Center"></a>
+                    <a href="https://www.jfrog.com/bintray/"><img src="/assets/img/Bintray.png" alt="powered by Bintray"></a>
                 </div>
                 <div class="col-md-2">
                 </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/dependents.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/dependents.scala.html
@@ -1,6 +1,6 @@
 @import ch.epfl.scala.index.model.{Release, Project}
 @(project: Project, release: Release)
-<div class="dependents box">
+<div class="dependents box" id="dependents">
   <h4>
     <a href="/search?q=dependencies:@project.reference.organization/@release.reference.artifact">
       Artifact Dependents

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
@@ -11,7 +11,7 @@
         <div class="info-project">
           <h1>
             <a href="/@project.organization">@project.organization</a> / 
-            <a href="https://github.com/@project.organization/@project.repository" 
+            <a href="https://github.com/@project.githubRepo"
               target="_blank">
               <i class="fa fa-github fa-lg"></i>
               @project.repository

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
@@ -24,7 +24,7 @@
               <h1>[DEPRECATED]</h1>
             </div>
             }
-            @project.github.map(gh => statistic(gh, project.releaseCount, release.reverseDependencies.size))
+            @project.github.map(gh => statistic(gh, project.githubRepo, project.releaseCount, release.reverseDependencies.size))
             @install(release, project.cliArtifacts)
             @documentation(release, project)
             @project.github.map(gh => contributors(gh.contributors))

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/statistic.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/statistic.scala.html
@@ -1,19 +1,20 @@
 @import ch.epfl.scala.index.model.misc.GithubInfo
-@(github: GithubInfo, releasesCount: Int, dependentsCount: Int)
+@import ch.epfl.scala.index.model.misc.GithubRepo
+@(github: GithubInfo, repo: GithubRepo, releasesCount: Int, dependentsCount: Int)
 
 <div class="statistic box">
   <h4>Statistics</h4>
   <div class="row">
     <div >
       <ul class="row">
-        <li class="col-md-6 col-sm-6"><i class="fa fa-eye"></i> @github.watchers watchers</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-users"></i> @github.contributors.size Contributors</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-star"></i> @github.stars Stars</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-code-fork"></i> @github.forks Forks</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-history"></i> @github.commits Commits</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-exclamation-circle"></i> @github.issues Open issues</li>
+        <a href="https://github.com/@repo/watchers"><li class="col-md-6 col-sm-6"><i class="fa fa-eye"></i> @github.watchers watchers</li></a>
+        <a href="https://github.com/@repo/graphs/contributors"><li class="col-md-6 col-sm-6"><i class="fa fa-users"></i> @github.contributors.size Contributors</li></a>
+        <a href="https://github.com/@repo/stargazers"><li class="col-md-6 col-sm-6"><i class="fa fa-star"></i> @github.stars Stars</li></a>
+        <a href="https://github.com/@repo/network"><li class="col-md-6 col-sm-6"><i class="fa fa-code-fork"></i> @github.forks Forks</li></a>
+        <a href="https://github.com/@repo/commits"><li class="col-md-6 col-sm-6"><i class="fa fa-history"></i> @github.commits Commits</li></a>
+        <a href="https://github.com/@repo/issues"><li class="col-md-6 col-sm-6"><i class="fa fa-exclamation-circle"></i> @github.issues Open issues</li></a>
         <li class="col-md-6 col-sm-6"><i class="fa fa-tag"></i> @releasesCount Releases</li>
-        <li class="col-md-6 col-sm-6"><i class="fa fa-sitemap"></i> @dependentsCount Dependents</li>
+        <a href="#dependents"><li class="col-md-6 col-sm-6"><i class="fa fa-sitemap"></i> @dependentsCount Dependents</li></a>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
As a user, I expect logos to be hyperlinked so that I can easily navigate to get more information.
As a user, I expect statistics to be hyperlinked so I can verify the claim or get more information.

The only statistic not hyperlinked by this is Releases since I was not sure the clear place to go for that information.

The footer logos are "Scala Center" and "JFrog Bintray"