### PR TITLE
Make 'Contributors Wanted' badge hyperlink to all such projects

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
@@ -53,7 +53,7 @@
       <div class="col-md-4">
         <div class="artifact-project">
           @if(project.contributorsWanted){
-            <img src="/assets/img/contributors_tag.png" alt="Contributors Wanted">
+            <a href="/search?q=contributorsWanted:true"><img src="/assets/img/contributors_tag.png" alt="Contributors Wanted"></a>
           }
           <form action="/@project.reference.organization/@project.reference.repository" action="GET">
             <select


### PR DESCRIPTION
Per https://github.com/scalacenter/scaladex/issues/309#issuecomment-269647840, this makes clicking the "Contributors Wanted" badge link to https://index.scala-lang.org/search?q=contributorsWanted:true so users can find all such projects.

Longer term, https://github.com/scalacenter/scaladex/issues/309#issuecomment-269676545 is probably the desired implementation but is also more involved.

More discussion can be found on #309