### PR TITLE
Update list of missing Scala 2.12 dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,7 @@ lazy val commonSettings = Seq(
     scalaVersion := "2.11.8",
     // 2.12.0
     // missing
-    //   akka-http-core
-    //   ammonite-repl
+    //   play-ws
     scalacOptions := Seq(
       "-deprecation",
       "-encoding",


### PR DESCRIPTION
`akka-http-core` and `ammonite-repl` both seem to have Scala 2.12 compatible builds.  However, Play support for 2.12 is coming in the yet unreleased 2.6 (playframework/playframework#6691) so the `play-ws` dependency has no available target at the moment.

This updates the `build.sbt` to reflect these facts.