### PR TITLE
Fix releases query when no artifact

### DIFF
--- a/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
@@ -143,9 +143,9 @@ class DataRepository(github: Github)(private implicit val ec: ExecutionContext) 
           nestedQuery("reference").query(
             bool(
               must(
-                termQuery("reference.organization", project.organization),
-                termQuery("reference.repository", project.repository),
-                termQuery("reference.artifact", artifact.getOrElse("*"))
+                artifact.map(termQuery("reference.artifact", _)) ++ List(
+                  termQuery("reference.organization", project.organization),
+                  termQuery("reference.repository", project.repository))
               )
             )
           )


### PR DESCRIPTION
Term queries do not support wildcards.  If `DataRepository.releases` is ever called with `artifact = None` the results are empty because there is no artifact named `*`.

Here we can just omit the term query in that case to get the desired result.