### PR TITLE
Display artifact’s binary targets in the result list

### DIFF
--- a/server/src/main/assets/css/partials/_main.scss
+++ b/server/src/main/assets/css/partials/_main.scss
@@ -228,12 +228,11 @@ main {
         margin: 0;
         border-bottom: 1px solid rgba($gray-dark, 0.12);
         h4,
+        .targets,
+        .homepage,
         .description {
             padding-left: 16px;
             margin-bottom: 0;
-            display: inline-block;
-        }
-        .homepage {
             display: inline-block;
         }
         h4 {

--- a/template/src/main/twirl/ch.epfl.scala.index.views/result.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/result.scala.html
@@ -52,7 +52,17 @@
                 <a href="/@project.reference.organization/@project.reference.repository">
                   <h4>@project.reference.organization/@project.reference.repository</h4>
                 </a>
-
+                @defining({
+                  val prefix = "scala_"
+                  project.targets
+                    .collect { case t if t.startsWith(prefix) => t.drop(prefix.length) }
+                    .to[List].sorted(Ordering.String.reverse)
+                    .mkString(", ")
+                }) { targets =>
+                  @if(targets.nonEmpty) {
+                    <span class="targets">@targets</span>
+                  }
+                }
                 @for(github <- project.github) {
                   @for(homepage <- github.homepage) {
                     @if(!homepage.target.isEmpty) {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/332812/21813885/e509ae46-d757-11e6-91ae-e4751273825a.png)

After:
![after](https://cloud.githubusercontent.com/assets/332812/21813893/eb8de2dc-d757-11e6-992f-6e7d8f0f230d.png)

What do you think?

Fixes #288.