### PR TITLE
Corrects behavior of missing project/artifact page

### DIFF
--- a/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
@@ -246,7 +246,7 @@ class DataRepository(github: Github)(private implicit val ec: ExecutionContext) 
                   selection: ReleaseSelection): Future[Option[(Project, ReleaseOptions)]] = {
     val projectAndReleases = this.projectAndReleases(projectRef, selection)
 
-    projectAndReleases.collect {
+    projectAndReleases.map {
       case Some((project, releases)) =>
         DefaultRelease(project.repository,
                        selection,
@@ -254,6 +254,7 @@ class DataRepository(github: Github)(private implicit val ec: ExecutionContext) 
                        project.defaultStableVersion)
           .map(sel =>
             (project, sel.copy(artifacts = project.artifacts)))
+      case None => None
     }
   }
 
@@ -279,7 +280,7 @@ class DataRepository(github: Github)(private implicit val ec: ExecutionContext) 
                    selection: ReleaseSelection): Future[Option[(Project, List[Release], Release)]] = {
     val projectAndReleases = this.projectAndReleases(projectRef, selection)
 
-    projectAndReleases.collect {
+    projectAndReleases.map {
       case Some((project, releases)) =>
         DefaultRelease(project.repository,
           selection,
@@ -287,6 +288,7 @@ class DataRepository(github: Github)(private implicit val ec: ExecutionContext) 
           project.defaultStableVersion)
           .map(sel =>
             (project, releases, sel.release))
+      case None => None
     }
   }
 


### PR DESCRIPTION
The matching on a `Future` was not exhaustive causing a lack of results to result in a server error rather than a 404 page.

This fixes a bug introduced #340 which can be experienced by trying to access a page such as: https://scaladex.scala-lang.org/scala/this-is-not-a-project
