### PR TITLE
Makes the organization page redirect to search

### DIFF
--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
@@ -44,25 +44,8 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
         }
       } ~
         path(Segment) { organization =>
-          optionalSession(refreshable, usingCookies) { userId =>
-            parameters('page.as[Int] ? 1, 'sort.?) { (page, sorting) =>
-              pathEnd {
-                val query = s"organization:$organization"
-                complete(
-                  dataRepository.findWithReleases(query, page, sorting).map {
-                    case (pagination, projectsAndReleases) =>
-                      searchresult(query,
-                                   organization,
-                                   sorting,
-                                   pagination,
-                                   projectsAndReleases,
-                                   getUser(userId).map(_.user),
-                                   you = false)
-                  }
-                )
-              }
-            }
-          }
+          val query = s"organization:$organization"
+          redirect(s"/search?q=$query", StatusCodes.TemporaryRedirect)
         }
     }
 }


### PR DESCRIPTION
This reduces duplication on the site by making it so there are no longer two places to search for an organization's projects.

This makes it less likely that links to "/organization" will proliferate, leaving that path available (less likely to break external references) if an organization page is ever added.

With this change, navigating to:

> https://scaladex.scala-lang.org/akka

takes the user to:
> https://scaladex.scala-lang.org/search?q=organization:akka