### PR TITLE
Fix ordering of targets in search results

### DIFF
--- a/template/src/main/scala/ch.epfl.scala.index.views/package.scala
+++ b/template/src/main/scala/ch.epfl.scala.index.views/package.scala
@@ -108,7 +108,8 @@ package object html {
     val prefix = "scala_"
     project.targets
       .collect { case t if t.startsWith(prefix) => t.drop(prefix.length) }
-      .to[List].sorted(Ordering.String.reverse)
+      .map(SemanticVersion.apply).flatten
+      .to[List].sorted(SemanticVersion.ordering.reverse)
       .mkString(", ")
   }
 }


### PR DESCRIPTION
Fixes #363.

![ordering-fix](https://cloud.githubusercontent.com/assets/3045108/22109791/8a806c72-de59-11e6-98cb-e5a379472fc8.png)
