### PR TITLE
Add twitter cards for project pages

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,11 @@
+project {
+  git = true
+}
+
+includeCurlyBraceInSelectChains = false
+optIn {
+  breakChainOnFirstMethodDot = false
+}
+
+style = default
 maxColumn = 100
-project.git = true

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import ScalaJSHelper._
 import org.scalajs.sbtplugin.cross.CrossProject
 
-scalafmtConfig in ThisBuild := Some(file(".scalafmt"))
-
 lazy val akkaVersion = "2.4.11"
 lazy val upickleVersion = "0.4.1"
 lazy val scalatagsVersion = "0.6.1"
@@ -147,7 +145,6 @@ lazy val sbtScaladex = project
                                                           "-Dplugin.version=" + version.value),
     scriptedBufferLog := false,
     bintrayRepository := "sbt-plugins",
-    bintrayOrganization := None,
-    scalafmt := {}
+    bintrayOrganization := None
   )
   .enablePlugins(BintrayPlugin)

--- a/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
@@ -64,14 +64,17 @@ class SeedElasticSearch(paths: DataPaths)(implicit val ec: ExecutionContext)
     )
 
     println("creating index")
-    Await.result(esClient.execute {
-      create
-        .index(indexName)
-        .mappings(
-          mapping(projectsCollection).fields(projectFields: _*),
-          mapping(releasesCollection).fields(releasesFields: _*)
-        )
-    }, Duration.Inf)
+    Await.result(
+      esClient.execute {
+        create
+          .index(indexName)
+          .mappings(
+            mapping(projectsCollection).fields(projectFields: _*),
+            mapping(releasesCollection).fields(releasesFields: _*)
+          )
+      },
+      Duration.Inf
+    )
 
     println("loading update data")
     val projectConverter = new ProjectConvert(paths)

--- a/model/src/main/scala/ch.epfl.scala.index.model/License.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/License.scala
@@ -68,7 +68,8 @@ object License {
   val TypesafeSubscriptionAgreement = License(
     "Typesafe Subscription Agreement",
     "Typesafe Subscription Agreement",
-    Some("http://downloads.typesafe.com/website/legal/TypesafeSubscriptionAgreement.pdf"))
+    Some("http://downloads.typesafe.com/website/legal/TypesafeSubscriptionAgreement.pdf")
+  )
   val Unlicense = spdx("Unlicense", "The Unlicense")
   val W3C = spdx("W3C", "W3C Software Notice and License")
   val WTFPL = spdx("WTFPL", "Do What The F*ck You Want To Public License")

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/HeadMeta.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/HeadMeta.scala
@@ -1,0 +1,9 @@
+package ch.epfl.scala.index.model.misc
+
+/**
+  * A meta tag in head.
+  *
+  * @param name The name attribute
+  * @param content The content attribute
+  */
+case class HeadMeta(name: String, content: String)

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/TwitterSummaryCard.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/TwitterSummaryCard.scala
@@ -1,0 +1,32 @@
+package ch.epfl.scala.index.model
+package misc
+
+/**
+  * A twitter summary card, see https://dev.twitter.com/cards/types/summary.
+  *
+  * @param site The Twitter handle (including @) of the site
+  * @param title The title of the card
+  * @param description A description.  Truncated, not all clients show it
+  * @param image URL to an image representing the content
+  * @param imageAlt Alt text for the image
+  */
+case class TwitterSummaryCard(site: String,
+                              title: String,
+                              description: String,
+                              image: Option[Url] = None,
+                              imageAlt: Option[String] = None) {
+  val card: String = "summary"
+
+  /**
+    * Convert the twitter card to a corresponding list of meta tags.
+    */
+  def toHeadMeta: Seq[HeadMeta] =
+    Seq(
+      HeadMeta(name = "twitter:card", content = card),
+      HeadMeta(name = "twitter:site", content = site),
+      HeadMeta(name = "twitter:title", content = title),
+      HeadMeta(name = "twitter:description", content = description)
+    ) ++
+      image.map(c => HeadMeta(name = "twitter:image", content = c.target)) ++
+      imageAlt.map(c => HeadMeta(name = "twitter:image:alt", content = c))
+}

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/DefaultReleaseTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/DefaultReleaseTests.scala
@@ -50,35 +50,37 @@ object DefaultReleaseTests extends org.specs2.mutable.Specification {
       val organization = "typelevel"
       val repository = "cats"
       val groupdId = "org.typelevel"
-      val releases = prepare(organization,
-                             repository,
-                             groupdId,
-                             List(
-                               ("cats-core_2.11", "0.6.0"),
-                               ("cats-core_2.11", "0.6.0-M2"),
-                               ("cats-core_2.11", "0.6.0-M1"),
-                               ("cats-core_2.11", "0.5.0"),
-                               ("cats-core_2.11", "0.4.1"),
-                               ("cats-core_2.11", "0.4.0"),
-                               ("cats-core_2.10", "0.6.0"),
-                               ("cats-core_2.10", "0.6.0-M2"),
-                               ("cats-core_2.10", "0.6.0-M1"),
-                               ("cats-core_2.10", "0.5.0"),
-                               ("cats-core_2.10", "0.4.1"),
-                               ("cats-core_2.10", "0.4.0"),
-                               ("cats-core_sjs0.6_2.11", "0.6.0"),
-                               ("cats-core_sjs0.6_2.11", "0.6.0-M2"),
-                               ("cats-core_sjs0.6_2.11", "0.6.0-M1"),
-                               ("cats-core_sjs0.6_2.11", "0.5.0"),
-                               ("cats-core_sjs0.6_2.11", "0.4.1"),
-                               ("cats-core_sjs0.6_2.11", "0.4.0"),
-                               ("cats-core_sjs0.6_2.10", "0.6.0"),
-                               ("cats-core_sjs0.6_2.10", "0.6.0-M2"),
-                               ("cats-core_sjs0.6_2.10", "0.6.0-M1"),
-                               ("cats-core_sjs0.6_2.10", "0.5.0"),
-                               ("cats-core_sjs0.6_2.10", "0.4.1"),
-                               ("cats-core_sjs0.6_2.10", "0.4.0")
-                             ))
+      val releases = prepare(
+        organization,
+        repository,
+        groupdId,
+        List(
+          ("cats-core_2.11", "0.6.0"),
+          ("cats-core_2.11", "0.6.0-M2"),
+          ("cats-core_2.11", "0.6.0-M1"),
+          ("cats-core_2.11", "0.5.0"),
+          ("cats-core_2.11", "0.4.1"),
+          ("cats-core_2.11", "0.4.0"),
+          ("cats-core_2.10", "0.6.0"),
+          ("cats-core_2.10", "0.6.0-M2"),
+          ("cats-core_2.10", "0.6.0-M1"),
+          ("cats-core_2.10", "0.5.0"),
+          ("cats-core_2.10", "0.4.1"),
+          ("cats-core_2.10", "0.4.0"),
+          ("cats-core_sjs0.6_2.11", "0.6.0"),
+          ("cats-core_sjs0.6_2.11", "0.6.0-M2"),
+          ("cats-core_sjs0.6_2.11", "0.6.0-M1"),
+          ("cats-core_sjs0.6_2.11", "0.5.0"),
+          ("cats-core_sjs0.6_2.11", "0.4.1"),
+          ("cats-core_sjs0.6_2.11", "0.4.0"),
+          ("cats-core_sjs0.6_2.10", "0.6.0"),
+          ("cats-core_sjs0.6_2.10", "0.6.0-M2"),
+          ("cats-core_sjs0.6_2.10", "0.6.0-M1"),
+          ("cats-core_sjs0.6_2.10", "0.5.0"),
+          ("cats-core_sjs0.6_2.10", "0.4.1"),
+          ("cats-core_sjs0.6_2.10", "0.4.0")
+        )
+      )
 
       val result =
         DefaultRelease(repository, ReleaseSelection(None, None, None), releases, None, true)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.4")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.madoushi.sbt" % "sbt-sass" % "0.9.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.11")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.4")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/Oauth2.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/Oauth2.scala
@@ -21,13 +21,15 @@ class OAuth2(github: Github, session: GithubUserSession) {
     get {
       path("login") {
         headerValueByType[Referer]() { referer =>
-          redirect(Uri("https://github.com/login/oauth/authorize").withQuery(
-                     Query(
-                       "client_id" -> github.clientId,
-                       "scope" -> "read:org",
-                       "state" -> referer.value
-                     )),
-                   TemporaryRedirect)
+          redirect(
+            Uri("https://github.com/login/oauth/authorize").withQuery(
+              Query(
+                "client_id" -> github.clientId,
+                "scope" -> "read:org",
+                "state" -> referer.value
+              )),
+            TemporaryRedirect
+          )
         }
       } ~
         path("logout") {

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/ProjectPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/ProjectPages.scala
@@ -60,6 +60,16 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
       .map(_.map {
         case (project, options) =>
           import options._
+          val twitterCard = for {
+            github <- project.github
+            description <- github.description
+          } yield
+            TwitterSummaryCard(
+              site = "@scala_lang",
+              title = s"${project.organization}/${project.repository}",
+              description = description,
+              image = github.logo
+            )
 
           (OK,
            views.project.html.project(
@@ -69,10 +79,12 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
              targets,
              release,
              user,
-             canEdit(owner, repo, userState)
+             canEdit(owner, repo, userState),
+             twitterCard
            ))
       }.getOrElse((NotFound, views.html.notfound(user))))
   }
+
   val routes =
     post {
       path("edit" / Segment / Segment) { (organization, repository) =>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -1,7 +1,9 @@
 @import ch.epfl.scala.index.model._
-@import ch.epfl.scala.index.model.misc.{UserInfo, SearchParams}
+@import ch.epfl.scala.index.model.misc.{UserInfo, SearchParams, HeadMeta}
 
-@(title: String, showSearch: Boolean, user: Option[UserInfo], params: SearchParams = SearchParams(), you: Boolean = false)(content: Html)
+@(title: String, showSearch: Boolean, user: Option[UserInfo],
+  params: SearchParams = SearchParams(), you: Boolean = false,
+  extraMeta: Seq[HeadMeta] = Seq.empty)(content: Html)
 
 <!DOCTYPE HTML>
 <html lang="en">
@@ -30,6 +32,10 @@
     <!-- iOS Safari -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+    @for(meta <- extraMeta) {
+      <meta name="@meta.name" content="@meta.content">
+    }
   </head>
 
   <body>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
@@ -4,10 +4,12 @@
 @import ch.epfl.scala.index.model.misc._
 @import ch.epfl.scala.index.model.release._
 
-@(project: Project, artifacts: List[String], versions: List[SemanticVersion], 
-  targets: List[ScalaTarget], release: Release, user: Option[UserInfo], canEdit: Boolean)
+@(project: Project, artifacts: List[String], versions: List[SemanticVersion],
+  targets: List[ScalaTarget], release: Release, user: Option[UserInfo],
+  canEdit: Boolean, twitterCard: Option[TwitterSummaryCard])
 
-@main(title = project.repository, showSearch = true, user) {
+@main(title = project.repository, showSearch = true, user,
+      extraMeta = twitterCard.toSeq.map(_.toHeadMeta).flatten) {
   <main id="container-project">
     @headproject(project, artifacts, versions, targets, release, canEdit)
     <div class="container">


### PR DESCRIPTION
See #239.

Adds twitter cards for all projects that have an associated GitHub project with a proper description; uses the avatar of the user/org as image, if any.

Also includes the commits from #372, but I can rebase after #372 is merged, or remove those commits from this PR if you like.