### PR TITLE
Add contributor count and filter #271

### DIFF
--- a/.esdata/config/scripts/contributors_size.groovy
+++ b/.esdata/config/scripts/contributors_size.groovy
@@ -1,0 +1,1 @@
+if (_source.containsKey('github')) _source['github'].contributors.size() else 0

--- a/.esdata/config/scripts/contributors_size.groovy
+++ b/.esdata/config/scripts/contributors_size.groovy
@@ -1,1 +1,0 @@
-if (_source.containsKey('github')) _source['github'].contributors.size() else 0

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ target/
 core
 .sass-cache
 .idea
-.esdata/
+.esdata/*
+!.esdata/config
 amm
 sbt
 server/scaladex.log
@@ -10,3 +11,4 @@ index/
 contrib/
 bin/.coursier
 bin/.scalafmt
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ target/
 core
 .sass-cache
 .idea
-.esdata/*
-!.esdata/config
+.esdata/
 amm
 sbt
 server/scaladex.log

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
@@ -28,6 +28,7 @@ object GithubReader {
       info.copy(
         readme = readme(paths, github).toOption,
         contributors = contributorList,
+        contributorCount = contributorList.size,
         commits = Some(contributorList.foldLeft(0)(_ + _.contributions))
       )
     }.toOption

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
@@ -12,6 +12,7 @@ package ch.epfl.scala.index.model.misc
   * @param watchers number of subscribers to this repo
   * @param issues number of open issues for this repo
   * @param contributors list of contributor profiles
+  * @param contributorCount how many contributors there are, used to sort search results by number of contributors
   * @param commits number of commits, calculated by contributors
   */
 case class GithubInfo(
@@ -24,5 +25,6 @@ case class GithubInfo(
     watchers: Option[Int] = None,
     issues: Option[Int] = None,
     contributors: List[GithubContributor] = List(),
+    contributorCount: Int = 0,
     commits: Option[Int] = None
 )

--- a/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
@@ -12,7 +12,6 @@ import ElasticDsl._
 import ch.epfl.scala.index.data.DataPaths
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction.Modifier
 import org.elasticsearch.search.sort.SortOrder
-import org.elasticsearch.script.ScriptService.ScriptType
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,7 +35,7 @@ class DataRepository(github: Github, paths: DataPaths)(private implicit val ec: 
       case Some("dependentCount") =>
         fieldSort("dependentCount") missing "0" order SortOrder.DESC mode MultiMode.Avg
       case Some("contributors") =>
-        scriptSort(script("contributors_size") scriptType ScriptType.FILE) typed "number" order SortOrder.DESC
+        fieldSort("github.contributorCount") missing "0" order SortOrder.DESC mode MultiMode.Avg
       case Some("relevant") => scoreSort
       case Some("created") => fieldSort("created") order SortOrder.DESC
       case Some("updated") => fieldSort("updated") order SortOrder.DESC

--- a/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
@@ -12,6 +12,7 @@ import ElasticDsl._
 import ch.epfl.scala.index.data.DataPaths
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction.Modifier
 import org.elasticsearch.search.sort.SortOrder
+import org.elasticsearch.script.ScriptService.ScriptType
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,6 +35,8 @@ class DataRepository(github: Github, paths: DataPaths)(private implicit val ec: 
         fieldSort("github.forks") missing "0" order SortOrder.DESC mode MultiMode.Avg
       case Some("dependentCount") =>
         fieldSort("dependentCount") missing "0" order SortOrder.DESC mode MultiMode.Avg
+      case Some("contributors") =>
+        scriptSort(script("contributors_size") scriptType ScriptType.FILE) typed "number" order SortOrder.DESC
       case Some("relevant") => scoreSort
       case Some("created") => fieldSort("created") order SortOrder.DESC
       case Some("updated") => fieldSort("updated") order SortOrder.DESC

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
@@ -69,6 +69,9 @@
                   <a data-toggle="tooltip" data-placement="bottom" title="Forks" href="#">@forks <i class="fa fa-code-fork"></i></a>
                 </span>
               }
+              <span>
+                <a data-toggle="tooltip" data-placement="bottom" title="Contributors" href="#">@github.contributors.size <i class="fa fa-users"></i></a>
+              </span>
             }
             </div>
           </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/sorting.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/sorting.scala.html
@@ -57,6 +57,10 @@
         class="btn btn-default @if(params.sorting.contains("forks")) { active }">
         Forks
       </button>
+      <button name="sort" value="contributors" type="submit"
+        class="btn btn-default @if(params.sorting.contains("contributors")) { active }">
+        Contributors
+      </button>
     </div>
   </form>
 </div>


### PR DESCRIPTION
Started looking into this so I could get familiar with Scaladex before my GSOC project officially starts. I got a solution working but there's a few issues.

This fixes #271 

### Scripting Language Error

I kept getting an error about the default scripting language (Groovy) not being supported when I tried adding scripting to sort the results of a query by the number of contributors for a repo (see `DataRepository.scala`). This was weird  because the Groovy scripting language is built-in to elasticsearch (es) according to the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html). I wasn't able to fix it so instead I downloaded es v2.4.1 from their website and pointed my scaladex es instance to the es instance I downloaded by setting `elasticsearch = remote` in the `org.scala_lang.index.data` config. This fixed the error. I left the config to `elasticsearch = local` in my PR to keep it consistent with how it was.

**So I'm not sure if my scaladex es instance wasn't setup properly or if there's actually something missing from the scaladex repo that needs to be added to support Groovy scripting.**

The es instance I downloaded has a `modules` directory which contained the module for the Groovy language (`lang-groovy`). I couldn't find any such directory in the scaladex repo and I noticed that `.esdata` is the configured home directory for es so this is where the `modules` folder would be but `.esdata` is in the `.gitignore` so it's not tracked under source control. But even after setting up scaladex and running the server, `.esdata` didn't contain a `modules` folder.

Additionally, I used the nodes info API to confirm that the es instance I downloaded has the module for Groovy by doing `curl  http://localhost:9200/_nodes/plugins` and seeing the resulting list of modules. When I did the same thing for my scaladex es instance, the resulting list of modules was empty.

### Security

I found 2 ways to run the Groovy script to sort the results of a query by the number of contributors for a repo:

1. Put the code for the script in a file and reference this file when doing the sorting - [docs](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html#modules-scripting)

This doesn't have any security issues but requires putting the script file in the `.esdata/config/scripts` directory which was being ignored by source control. This is what I implemented in my PR.

2. Use dynamic inline scripting by passing the code for the script as text when doing the sorting

This would involve removing `.esdata/config/scripts/contributors_size.groovy`, updating `DataRepository.scala` to use an inline script instead of a script file and setting the `script.engine.groovy.inline.search` es config to `true`.

New `DataRepository.scala`:
```scala
...
val sortQuery = ...
      case Some("contributors") =>
        scriptSort("""if (_source.containsKey('github')) _source['github'].contributors.size() else 0""") typed "number" order SortOrder.DESC
```

New `ch.epfl.scala.index.data/elastic/package.scala`:
```scala
...
val esSettings =
        Settings.settingsBuilder().put("path.home", base.resolve(".esdata").toString())
            .put("script.engine.groovy.inline.search", true) 
      ElasticClient.local(esSettings.build)
```

Allowing dynamic inline script has some security [issues](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html#enable-dynamic-scripting). Es has sandboxed and non-sandboxed scripting languages. I couldn't get the code working for the sandboxed languages so I used a non-sandboxed language, Groovy. The problem with allowing users to run inline scripts with a non-sandboxed language is that users will have the same access to your box as the user that es is running as. The docs recommend doing things like not running es as root user and having a proxy between es and your users, I'm not sure if scaladex is already doing these or not.

Additionally, the `search` part of the `script.engine.groovy.inline.search` config means it only allows search operations (Search api, Percolator api and Suggester api) to execute inline Groovy scripts. So you can't execute inline Groovy scripts when doing `update` operations for example. This may or may not be secure enough for scaladex.

**So which option is best to run the Groovy script?**