### PR TITLE
Add GitHub Topics, #380

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ The `contrib.git` repository is read-only for the Scaladex application
 (users can write on it, on Github).
 
 Data of the `[scaladex-index.git]` repository are written *only* by Scaladex.
-This repository contains the POMs and project information added by users (e.g. keywords).
+This repository contains the POMs and project information added by users.
 
 ## Bintray Data Pipeline
 

--- a/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
@@ -8,6 +8,7 @@ import maven.PomsReader
 import me.tongfei.progressbar._
 
 import com.sksamuel.elastic4s._
+import com.sksamuel.elastic4s.mappings
 import ElasticDsl._
 import mappings.FieldType._
 
@@ -30,7 +31,7 @@ class SeedElasticSearch(paths: DataPaths)(implicit val ec: ExecutionContext)
     val projectFields = List(
       field("organization").typed(StringType).index("not_analyzed"),
       field("repository").typed(StringType).index("not_analyzed"),
-      field("keywords").typed(StringType).index("not_analyzed"),
+      field("github").typed(ObjectType).inner(field("topics").typed(StringType).index("not_analyzed")),
       field("defaultArtifact").typed(StringType).index("no"),
       field("artifacts").typed(StringType).index("not_analyzed"),
       field("customScalaDoc").typed(StringType).index("no"),

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubModel.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubModel.scala
@@ -18,7 +18,7 @@ case class Repository(
     name: String, // cats
     owner: User,
     `private`: Boolean,
-    description: String,
+    description: Option[String],
     fork: Boolean,
     created_at: String, // format: "2015-01-28T20:26:48Z",
     updated_at: String,
@@ -63,3 +63,32 @@ case class Contributor(
     site_admin: Boolean,
     contributions: Int
 )
+
+
+
+// classes for GraphQL API, https://developer.github.com/v4/reference/
+// note that some classes are missing members, only got ones needed for topics
+
+case class GraphqlTopic(
+    name: String = "",
+    relatedTopics: List[GraphqlTopic] = null
+)
+
+case class GraphqlRepositoryTopic(
+    resourcePath: String = "",
+    topic: GraphqlTopic = null,
+    url: String = ""
+)
+
+case class GraphqlRepositoryTopicConnection(nodes: List[GraphqlRepositoryTopic] = null)
+
+case class GraphqlRepository(
+    name: String = "",
+    description: String = "",
+    repositoryTopics: GraphqlRepositoryTopicConnection = null
+)
+
+// if you want to query starting with anything other than repository, you will have to add it as a member here
+case class GraphqlData(repository: GraphqlRepository = null)
+
+case class GraphqlResult(data: GraphqlData = null)

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/package.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/package.scala
@@ -23,6 +23,9 @@ package object github extends Parsers {
   def githubRepoContributorsPath(paths: DataPaths, github: GithubRepo) =
     path(paths, github).resolve(Paths.get("contributors.json"))
 
+  def githubRepoTopicsPath(paths: DataPaths, github: GithubRepo) =
+    path(paths, github).resolve(Paths.get("topics.json"))
+
   /**
     * extracts the last page from a given link string
     * - <https://api.github.com/repositories/130013/issues?page=2>; rel="next", <https://api.github.com/repositories/130013/issues?page=23>; rel="last"

--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectForm.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectForm.scala
@@ -7,7 +7,6 @@ import model.Project
 case class ProjectForm(
     // project
     contributorsWanted: Boolean,
-    keywords: Set[String],
     defaultArtifact: Option[String],
     defaultStableVersion: Boolean,
     deprecated: Boolean,
@@ -20,7 +19,6 @@ case class ProjectForm(
   def update(project: Project): Project = {
     project.copy(
       contributorsWanted = contributorsWanted,
-      keywords = keywords,
       defaultArtifact =
         if (defaultArtifact.isDefined) defaultArtifact
         else project.defaultArtifact,
@@ -41,7 +39,6 @@ object ProjectForm {
     import project._
     new ProjectForm(
       contributorsWanted,
-      keywords,
       defaultArtifact,
       defaultStableVersion,
       deprecated,

--- a/doc/user/publish-scaladex.md
+++ b/doc/user/publish-scaladex.md
@@ -21,7 +21,6 @@ Generate a [GitHub personal access token](https://github.com/settings/tokens/new
 Add the following to your build.sbt file:
 
 ```scala
-scaladexKeywords in Scaladex := Seq("Foo", "Bar", "Baz")
 credentials in Scaladex += Credentials(Path.userHome / ".ivy2" / ".scaladex.credentials")
 /*
 realm=Scaladex Realm
@@ -47,11 +46,10 @@ process and verify that you have permission to the defined repository (SCM Tag)
 
 ### Configure the publish process
 
-There are some settings for the Plugin to control the output on Scaladex a bit, like adding keywords, show GitHub info,
-show GitHub Readme file, show GitHub contributors.
+There are some settings for the Plugin to control the output on Scaladex a bit, like showing GitHub info,
+showing GitHub Readme file, showing GitHub contributors.
 
 * **scaladexBaseUri**: This is the main uri to publish to _default_: `https://index.scala-lang.org`
-* **scaladexKeywords**: List of keywords for your artifact _default_: `empty`
 * **scaladexDownloadReadme**: A flag to download the README from GitHub. _default_: `true`
 * **scaladexDownloadInfo**: A flag to download the repository info from GitHub (eg: stars, forks, ...). _default_: `true`
 * **scaladexDownloadContributors**: A flag to download the contributors info from GitHub. _default_: `true`
@@ -91,8 +89,6 @@ PUT /publish
   readme=[true|false] (default: true)
   contributors=[true|false] (default: true)
   info=[true|false] (default: true)
-  keywords=foo (repeated parameter)
-  keywords=bar
 
 GET /publish?
   path=/org/example/foo_2.11/0.8.0/foo_2.11-0.8.0.pom

--- a/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
@@ -9,7 +9,6 @@ import misc.{GithubInfo, GithubRepo}
   * @param organization (ex: typelevel)
   * @param repository (ex: spark)
   * @param github github information representation
-  * @param keywords predefined keywords (ex: database)
   * @param defaultArtifact when we land on a project page (ex: typelevel/cats) specify an artifact to select by default
   * @param defaultStableVersion when selecting a default version avoid preReleases if possible (otherwise select latest version)
   * @param artifacts names for this project (ex: cats-core, cats-free, ...)
@@ -29,7 +28,6 @@ case class Project(
     organization: String,
     repository: String,
     github: Option[GithubInfo] = None,
-    keywords: Set[String] = Set(),
     defaultStableVersion: Boolean = true,
     defaultArtifact: Option[String],
     artifacts: List[String],

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
@@ -14,6 +14,7 @@ package ch.epfl.scala.index.model.misc
   * @param contributors list of contributor profiles
   * @param contributorCount how many contributors there are, used to sort search results by number of contributors
   * @param commits number of commits, calculated by contributors
+  * @param topics topics associated with the project
   */
 case class GithubInfo(
     readme: Option[String] = None,
@@ -26,5 +27,6 @@ case class GithubInfo(
     issues: Option[Int] = None,
     contributors: List[GithubContributor] = List(),
     contributorCount: Int = 0,
-    commits: Option[Int] = None
+    commits: Option[Int] = None,
+    topics: Set[String] = Set()
 )

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/SearchParams.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/SearchParams.scala
@@ -15,7 +15,7 @@ case class SearchParams(
     total: Int = SearchParams.resultsPerPage,
     targetFiltering: Option[ScalaTarget] = None,
     cli: Boolean = false,
-    keywords: List[String] = Nil,
+    topics: List[String] = Nil,
     targetTypes: List[String] = Nil,
     scalaVersions: List[String] = Nil,
     scalaJsVersions: List[String] = Nil,

--- a/sbtScaladex/src/main/scala/org.scala_lang.index.sbt/ScaladexPlugin.scala
+++ b/sbtScaladex/src/main/scala/org.scala_lang.index.sbt/ScaladexPlugin.scala
@@ -7,7 +7,6 @@ import Keys._
   * This is the scaladex publishing plugin which extends the main publish task
   * of SBT. Also the plugin does have some settings to configure scaladex.
   *
-  * - scaladexKeywords: the keywords for scaladex artifact which is used in search
   * - scaladexDownloadReadme: Flag if scaladex have access to download the Readme from the repository
   * - scaladexDownloadContributors: Flag if scaladex have access to download the contributors from the repository
   * - scaladexDownloadInfo: Flag if scaladex have access to download the info from the repository (forks, stars, watches)
@@ -18,8 +17,6 @@ object ScaladexPlugin extends AutoPlugin {
 
     /* defining the Scope Scaladex */
     lazy val Scaladex = config("scaladex") extend Compile
-    lazy val scaladexKeywords =
-      settingKey[Seq[String]]("list of keywords for your package in scaladex")
     lazy val scaladexDownloadReadme =
       settingKey[Boolean]("should we download the readme file from the scm tag")
     lazy val scaladexDownloadInfo =
@@ -31,7 +28,6 @@ object ScaladexPlugin extends AutoPlugin {
 
     /** define base scaladex options */
     lazy val baseScaladexSettings = Seq(
-      scaladexKeywords := Seq(),
       scaladexDownloadContributors := true,
       scaladexDownloadInfo := true,
       scaladexDownloadReadme := true,
@@ -56,9 +52,8 @@ object ScaladexPlugin extends AutoPlugin {
                 "contributors" -> scaladexDownloadContributors.value,
                 "path" -> "" // need to be at the end!
               )
-              val keywords = scaladexKeywords.value.map(key => "keywords" -> key)
 
-              val url = baseUri + basePath + (keywords ++ params).map {
+              val url = baseUri + basePath + params.map {
 
                 case (k, v) => s"$k=$v"
               }.mkString("&")

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
@@ -17,7 +17,7 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
   private def frontPage(userInfo: Option[UserInfo]) = {
     import dataRepository._
     for {
-      keywords <- keywords()
+      topics <- topics()
       targetTypes <- targetTypes()
       scalaVersions <- scalaVersions()
       scalaJsVersions <- scalaJsVersions()
@@ -33,9 +33,10 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
         xs.map(v => s"$label:$v").mkString("search?q=", " OR ", "")
 
       val ecosystems = Map(
-        "Akka" -> query("keywords")("akka-extension",
-                                    "akka-http-extension",
-                                    "akka-persistence-plugin"),
+        "Akka" -> query("topics")("akka",
+                                    "akka-http",
+                                    "akka-persistence",
+                                    "akka-streams"),
         "Scala.js" -> "search?targets=scala.js_0.6",
         "Spark" -> query("depends-on")("apache/spark-streaming",
                                        "apache/spark-graphx",
@@ -48,7 +49,7 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
       val excludedScalaVersions = Set("2.9", "2.8")
 
       views.html.frontpage(
-        keywords,
+        topics,
         targetTypes,
         scalaVersions.filterNot { case (version, _) => excludedScalaVersions.contains(version) },
         scalaJsVersions,

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/ProjectPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/ProjectPages.scala
@@ -31,12 +31,10 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
     val user = userState.map(_.user)
     if (canEdit(owner, repo, userState)) {
       for {
-        keywords <- dataRepository.keywords()
         project <- dataRepository.project(Project.Reference(owner, repo))
       } yield {
         project.map { p =>
-          val allKeywords = (p.keywords ++ keywords.map(_._1).toSet).toList.sorted
-          (OK, views.project.html.editproject(p, allKeywords, user))
+          (OK, views.project.html.editproject(p, user))
         }.getOrElse((NotFound, views.html.notfound(user)))
       }
     } else Future.successful((Forbidden, views.html.forbidden(user)))
@@ -97,7 +95,6 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
             formFieldSeq { fields =>
               formFields(
                 'contributorsWanted.as[Boolean] ? false,
-                'keywords.*,
                 'defaultArtifact.?,
                 'defaultStableVersion.as[Boolean] ? false,
                 'deprecated.as[Boolean] ? false,
@@ -106,7 +103,6 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
                 'customScalaDoc.?
               ) {
                 (contributorsWanted,
-                 keywords,
                  defaultArtifact,
                  defaultStableVersion,
                  deprecated,
@@ -131,7 +127,6 @@ class ProjectPages(dataRepository: DataRepository, session: GithubUserSession) {
                       Project.Reference(organization, repository),
                       ProjectForm(
                         contributorsWanted,
-                        keywords.toSet,
                         defaultArtifact,
                         defaultStableVersion,
                         deprecated,

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
@@ -26,7 +26,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
     complete(
       for {
         (pagination, projects) <- find(params)
-        keywords <- keywords(params)
+        topics <- topics(params)
         targetTypes <- targetTypes(params)
         scalaVersions <- scalaVersions(params)
         scalaJsVersions <- scalaJsVersions(params)
@@ -39,7 +39,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
           projects,
           getUser(userId).map(_.user),
           params.userRepos.nonEmpty,
-          keywords,
+          topics,
           targetTypes,
           scalaVersions,
           scalaJsVersions,
@@ -54,7 +54,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
       ('q ? "*",
        'page.as[Int] ? 1,
        'sort.?,
-       'keywords.*,
+       'topics.*,
        'targetTypes.*,
        'scalaVersions.*,
        'scalaJsVersions.*,
@@ -63,7 +63,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
       case (q,
             page,
             sort,
-            keywords,
+            topics,
             targetTypes,
             scalaVersions,
             scalaJsVersions,
@@ -75,7 +75,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
           page,
           sort,
           userRepos,
-          keywords = keywords.toList,
+          topics = topics.toList,
           targetTypes = targetTypes.toList,
           scalaVersions = scalaVersions.toList,
           scalaJsVersions = scalaJsVersions.toList,

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/api/PublishApi.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/api/PublishApi.scala
@@ -128,9 +128,8 @@ class PublishApi(paths: DataPaths, dataRepository: DataRepository, github: Githu
             'created.as(DateTimeUn) ? DateTime.now,
             'readme.as[Boolean] ? true,
             'contributors.as[Boolean] ? true,
-            'info.as[Boolean] ? true,
-            'keywords.as[String].*
-          ) { (path, created, readme, contributors, info, keywords) =>
+            'info.as[Boolean] ? true
+          ) { (path, created, readme, contributors, info) =>
             entity(as[String]) { data =>
               extractCredentials { credentials =>
                 authenticateBasicAsync(realm = "Scaladex Realm", githubAuthenticator(credentials)) {
@@ -144,8 +143,7 @@ class PublishApi(paths: DataPaths, dataRepository: DataRepository, github: Githu
                       userState,
                       info,
                       contributors,
-                      readme,
-                      keywords.toSet
+                      readme
                     )
 
                     complete((actor ? publishData).mapTo[(StatusCode, String)].map(s => s))

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishData.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishData.scala
@@ -22,7 +22,6 @@ import java.nio.file.{Files, Path}
   * @param downloadInfo flag for downloading info
   * @param downloadContributors flag for downloading contributors
   * @param downloadReadme flag for downloading the readme file
-  * @param keywords the keywords for the project
   */
 private[api] case class PublishData(
     path: String,
@@ -32,8 +31,7 @@ private[api] case class PublishData(
     userState: UserState,
     downloadInfo: Boolean,
     downloadContributors: Boolean,
-    downloadReadme: Boolean,
-    keywords: Set[String]
+    downloadReadme: Boolean
 ) {
 
   lazy val isPom: Boolean = path matches """.*\.pom"""

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishProcess.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishProcess.scala
@@ -170,7 +170,6 @@ private[api] class PublishProcess(paths: DataPaths, dataRepository: DataReposito
       cachedReleases = upserts(cachedReleases, projectReference, newReleases)
 
       val updatedProject = newProject.copy(
-        keywords = data.keywords,
         liveData = true
       )
 

--- a/template/src/main/scala/ch.epfl.scala.index.views/package.scala
+++ b/template/src/main/scala/ch.epfl.scala.index.views/package.scala
@@ -41,7 +41,7 @@ package object html {
 
     uri
       .appendQuery("sort", params.sorting)
-      .appendQuery("keywords", params.keywords.toList)
+      .appendQuery("topics", params.topics.toList)
       .appendQuery("targetTypes", params.targetTypes.toList)
       .appendQuery("scalaVersions", params.scalaVersions.toList)
       .appendQuery("scalaJsVersions", params.scalaJsVersions.toList)

--- a/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
@@ -3,7 +3,7 @@
 @import ch.epfl.scala.index.model.misc.{Url, UserInfo}
 @import ch.epfl.scala.index.model.misc.SearchParams
 
-@(keywords: List[(String, Long)],
+@(topics: List[(String, Long)],
   targetTypes: List[(String, Long)],
   scalaVersions: List[(String, Long)],
   scalaJsVersions: List[(String, Long)],
@@ -24,9 +24,9 @@
                 <div class="col-md-8 col-md-offset-2">
                     <h1>The Scala Library Index</h1> @searchinput(SearchParams(), false, Some(totalProjects), Some(totalReleases))
                     <ul class="tag">
-                        <li><strong>Keywords:</strong></li>
-                        @for((keyword, count) <- keywords) {
-                            <li><a href="/search?q=*&keywords=@keyword">@keyword (@count)</a></li>
+                        <li><strong>Topics:</strong></li>
+                        @for((topic, count) <- topics) {
+                            <li><a href="/search?q=*&topics=@topic">@topic (@count)</a></li>
                         }
                     </ul>
                     <ul class="tag">

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/editproject.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/editproject.scala.html
@@ -4,7 +4,7 @@
 @import ch.epfl.scala.index.model.misc._
 @import ch.epfl.scala.index.model.release._
 
-@(project: Project, keywords: List[String], user: Option[UserInfo])
+@(project: Project, user: Option[UserInfo])
 
 @main(title = s"Edit ${project.repository}", showSearch = true, user) {
   <main id="container-project">
@@ -20,19 +20,6 @@
               <div class="form-group">
                 <input type="checkbox" name="contributorsWanted" @if(project.contributorsWanted){ checked }> 
                 <img src="/assets/img/contributors_tag.png" alt="Contributors Wanted">
-              </div>
-
-              <div class="form-group">
-                <label for="keywords_multiple">Keywords</label>
-                <select
-                  name="keywords"
-                  class="js-keywords-multiple js-states form-control"
-                  id="keywords_multiple"
-                  multiple="multiple">
-                @for(keyword <- keywords) {
-                  <option value="@keyword" @if(project.keywords.contains(keyword)){selected}>@keyword</option>
-                }
-                </select>
               </div>
 
               <div class="form-group">

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/headproject.scala.html
@@ -45,12 +45,14 @@
               Github <i class="fa fa-github fa-lg"></i>
             </a>
           }
-          @if(!project.keywords.isEmpty) {
-            <ul class="list-inline">
-            @for(keyword <- project.keywords) {
-              <li><a href="/search?q=keywords:@keyword">@keyword</a></li>
+          @for(github <- project.github) {
+            @if(!github.topics.isEmpty) {
+              <ul class="list-inline">
+                @for(topic <- github.topics) {
+                  <li><a href="/search?q=topics:@topic">@topic</a></li>
+                }
+              </ul>
             }
-            </ul>
           }
         </div>
       </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/filter.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/filter.scala.html
@@ -2,7 +2,7 @@
 @import ch.epfl.scala.index.model.misc.{Pagination, SearchParams}
 
 @(params: SearchParams,
-  keywords: List[(String, Long)],
+  topics: List[(String, Long)],
   targetTypes: List[(String, Long)],
   scalaVersions: List[(String, Long)],
   scalaJsVersions: List[(String, Long)],
@@ -75,17 +75,17 @@
       }
     </fieldset>
     <fieldset>
-      <legend>Keywords</legend>
+      <legend>Topics</legend>
       <ul>
-      @for((keyword, count) <- keywords.toList.sortBy(_._1)) {
+        @for((topic, count) <- topics.toList.sortBy(_._1)) {
         <li>
           <label>
-            <input type="checkbox" @if(params.keywords.contains(keyword)) { checked }
-                   name="keywords" value="@keyword" onclick="this.form.submit()">
-            @keyword (@count)
+            <input type="checkbox" @if(params.topics.contains(topic)) { checked }
+                   name="topics" value="@topic" onclick="this.form.submit()">
+            @topic (@count)
           </label>
         </li>
-      }
+        }
       </ul>
     </fieldset>
 

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/result.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/result.scala.html
@@ -12,7 +12,7 @@
   projects: List[Project],
   user: Option[UserInfo],
   you: Boolean,
-  keywords: List[(String, Long)],
+  topics: List[(String, Long)],
   targetTypes: List[(String, Long)],
   scalaVersions: List[(String, Long)],
   scalaJsVersions: List[(String, Long)],
@@ -36,7 +36,7 @@
   <div class="col-md-3">
     @filter(
       params,
-      keywords,
+      topics,
       targetTypes,
       scalaVersions,
       scalaJsVersions,

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
@@ -48,12 +48,16 @@
         <div class="col-md-4">
           <div class="stats">
             <div>
-            @for(keyword <- project.keywords) {
-              <span class="item-filter-tag">
-                <a href="/search?q=keywords:@keyword">
-                  @keyword
-                </a>
-              </span>
+            @for(github <- project.github) {
+              @if(!github.topics.isEmpty) {
+                @for(topic <- github.topics) {
+                  <span class="item-filter-tag">
+                    <a href="/search?q=topics:@topic">
+                      @topic
+                    </a>
+                  </span>
+                }
+              }
             }
             </div>
 

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/searchresult.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/searchresult.scala.html
@@ -11,7 +11,7 @@
   projects: List[Project],
   user: Option[UserInfo],
   you: Boolean,
-  keywords: List[(String, Long)],
+  topics: List[(String, Long)],
   targetTypes: List[(String, Long)],
   scalaVersions: List[(String, Long)],
   scalaJsVersions: List[(String, Long)],
@@ -20,7 +20,7 @@
   <main id="container-search">
     <div class="container">
       @result(params, uri, pagination, projects,
-              user, you, keywords, targetTypes,
+              user, you, topics, targetTypes,
               scalaVersions, scalaJsVersions, scalaNativeVersions)
       </div>
     </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/sorting.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/sorting.scala.html
@@ -12,9 +12,6 @@
     }
     <input type="hidden" name="page" value="@pagination.current">
     
-    @for(keyword <- params.keywords){
-      <input type="hidden" name="keywords" value="@keyword">
-    }
     @for(tpe <- params.targetTypes){
       <input type="hidden" name="targetTypes" value="@tpe">
     }

--- a/template/src/main/twirl/ch.epfl.scala.index.views/searchinput.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/searchinput.scala.html
@@ -13,8 +13,8 @@
         @if(you){
           <input type="hidden" name="you" value="✓">
         }
-        @for(keyword <- params.keywords){
-          <input type="hidden" name="keywords" value="@keyword">
+        @for(topic <- params.topics){
+          <input type="hidden" name="topics" value="@topic">
         }
         @for(tpe <- params.targetTypes){
           <input type="hidden" name="targetTypes" value="@tpe">


### PR DESCRIPTION
This fixes #380

Notes:

* **Replaced  keywords with topics** - I removed a project's keywords and replaced them with topics. I discussed this with @heathermiller  and we thought that it would be better for Scaladex to support Github's topics instead of Scaladex's own keywords since a lot of projects are already using topics (way more than the number of projects using keywords). Merging topics and keywords would get messy from a coding perspective so I thought it was best to remove keywords. It should be possible for all the projects that had keywords to now use topics since I verified that all projects with keywords have a github repo.

* **Added live updates to project page** - As discussed with @heathermiller , I added a method to update a project's repo info (including topics) and readme whenever that project's page is loaded. See the `liveUpdate` method in `DataRepository.scala` which gets called in `projectPage`. This may cause the page to take a second or two longer to load but I didn't notice any significant lag while testing locally. If this causes too much lag or if it causes scaladex to hit the GraphQL API rate limit, I can look into other options like utilizing [Github's Webhooks](https://developer.github.com/webhooks/).

* **GraphQL API rate limit error** - I was getting an error when downloading topics through the GraphQL API about abusing the rate limit. I fixed it by adding a delay in `processTopicsResponse` in `GithubDownload.scala` if the error happens. I'm not sure why I was getting the error (I'm using the same code from the Rest API code that alternates between using 3 API keys, I verified the keys still had lots of calls remaining after getting the error). I reached out to github support a couple weeks ago but they're still looking into it.

* **Did not use Sangria (GraphQL Client for Scala)** - [Sangria](http://sangria-graphql.org/) is more useful if you have your own GraphQL API you need to implement containing your data (Ex. If you were github and you were making a GraphQL API). It makes it easy to define your schema, to define how to process queries on your schema (not as useful if you’re using someone else’s GraphQL API like how Scaladex is using Github's GraphQL API, lots of overhead). Queries with sangria are just strings so you don’t get anything extra by using Sangria for making queries. You can make Sangria objects for the result of a query, but I was able to just save the results to a json file and then parse it later using case classes (the same way Scaladex downloads/parses repo info and readme files using Github's REST API).
