### PR TITLE
Fix Topics for 2.12, #380

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/elastic/SeedElasticSearch.scala
@@ -37,9 +37,7 @@ class SeedElasticSearch(paths: DataPaths)(implicit val ec: ExecutionContext)
       keywordField("cliArtifacts").index(false),
       keywordField("targets"),
       keywordField("dependencies"),
-      nestedField("github").fields(
-        keywordField("topics")
-      ),
+      objectField("github").fields(keywordField("topics")),
       dateField("created"),
       dateField("updated")
     )


### PR DESCRIPTION
This fixes #380 

Fixed `SeedElasticSearch.scala` to make "github" field an object field (not a nested field)

Fixed downloading topics (`GithubDownload.scala` and `PlayWsDownloader.scala`) to avoid resource error:
`[AsyncHttpClient-3-1] ERROR p.s.a.i.n.u.c.D.rejectedExecution - Failed to submit a listener notification task. Event loop shut down?`