### PR TITLE
Check if gitter room exists by making http request

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/github/package.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/package.scala
@@ -29,6 +29,9 @@ package object github extends Parsers {
   def githubRepoCommunityProfilePath(paths: DataPaths, github: GithubRepo) =
     path(paths, github).resolve(Paths.get("community.json"))
 
+  def githubRepoChatroomPath(paths: DataPaths, github: GithubRepo) =
+    path(paths, github).resolve(Paths.get("chatroom.txt"))
+
   /**
     * extracts the last page from a given link string
     * - <https://api.github.com/repositories/130013/issues?page=2>; rel="next", <https://api.github.com/repositories/130013/issues?page=23>; rel="last"

--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
@@ -344,9 +344,7 @@ class ProjectConvert(paths: DataPaths) extends BintrayProtocol {
               defaultArtifact =
                 releaseOptions.map(_.release.reference.artifact),
               created = min,
-              updated = max,
-              chatroom = github.flatMap(_.readme.flatMap(readme =>
-                GithubReader.chatroom(githubRepo, readme)))
+              updated = max
             )
 
           (seed, releases)
@@ -508,8 +506,7 @@ object ProjectConvert {
       defaultArtifact: Option[String],
       releaseCount: Int,
       created: Option[String],
-      updated: Option[String],
-      chatroom: Option[Url]
+      updated: Option[String]
   ) {
 
     def reference = Project.Reference(organization, repository)
@@ -534,8 +531,7 @@ object ProjectConvert {
         scalaJsVersion = scalaJsVersion,
         scalaNativeVersion = scalaNativeVersion,
         dependencies = dependencies,
-        dependentCount = dependentCount,
-        chatroom = chatroom
+        dependentCount = dependentCount
       )
   }
 

--- a/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
@@ -31,7 +31,6 @@ import misc.{GithubInfo, GithubRepo, Url}
   * @param dependencies to aggregate most depended upon libs (ex: spark, play framework, ...)
   * @param dependentCount Number of artifacts that depends on at least one release of at least one artifact of this project
   * @param primaryTopic most significative topic (ex: Circe: json)
-  * @param chatroom link to project chatroom (ex: https://gitter.im/scalacenter/scaladex)
   */
 case class Project(
     organization: String,
@@ -58,8 +57,7 @@ case class Project(
     scalaNativeVersion: Set[String],
     dependencies: Set[String],
     dependentCount: Int,
-    primaryTopic: Option[String] = None,
-    chatroom: Option[Url] = None
+    primaryTopic: Option[String] = None
 ) {
 
   def reference = Project.Reference(organization, repository)

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
@@ -16,6 +16,7 @@ package ch.epfl.scala.index.model.misc
   * @param commits number of commits, calculated by contributors
   * @param topics topics associated with the project
   * @param contributingGuide CONTRIBUTING.md
+  * @param chatroom link to chatroom (ex: https://gitter.im/scalacenter/scaladex)
   * @param beginnerIssuesLabel label used to tag beginner-friendly issues
   * @param beginnerIssues list of beginner-friendly issues for the project
   */
@@ -35,6 +36,7 @@ case class GithubInfo(
     commits: Option[Int] = None,
     topics: Set[String] = Set(),
     contributingGuide: Option[Url] = None,
+    chatroom: Option[Url] = None,
     beginnerIssuesLabel: Option[String] = None,
     beginnerIssues: List[GithubIssue] = List()
 )


### PR DESCRIPTION
This is related to #119.

Moved the `chatroom` field from `Project` to `GithubInfo` so that it can get set when rest of stuff is being downloaded from Github. It gets set by making a http GET to https://gitter.im/{org}/{repo} and if that request returns a `200`, the url will be saved to `chatroom.txt` which gets parsed in `GithubReader`. 

And I'm planning on adding a field to the edit project page where maintainers can manually set the link for their project's chatroom (in case the automatic process above didn't work or if they use another chatroom besides gitter).

Also [fixed](https://github.com/scalacenter/scaladex/compare/master...chatroom-gitter#diff-101331e07214cf2d6fb80a630b7f5926R56) a bug with `GithubReader.readme`  where it would use a newline as a separator between every character when parsing the readme. Refactored the code so it matches the [original code](https://github.com/scalacenter/scaladex/blob/eccde7a528f5f6cda3808a589a19ffdb325647b1/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala#L47) from a couple commits ago to correctly use a newline as separator between lines of the readme (instead of between every character).

And I ran `scalafmt` on my changes.