### PR TITLE
Change the browser-tab title

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
@@ -16,7 +16,7 @@
   totalProjects: Long,
   totalReleases: Long)
 
-@main(title = "Home", showSearch = false, user) {
+@main(title = "Scaladex", showSearch = false, user) {
 <main id="container-home">
     <section class="content-search-home">
         <div class="container">


### PR DESCRIPTION
Currently, the title in the browser tab for the Scaladex homepage says "Home", which is unhelpful, especially when folks are bookmarking.  Changing this to "Scaladex".