### PR TITLE
Contributing Info UI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,8 @@ lazy val client = project
   .settings(commonSettings)
   .settings(
     skip in packageJSDependencies := false,
-    jsDependencies += "org.webjars.bower" % "raven-js" % "3.11.0" / "dist/raven.js" minified "dist/raven.min.js"
+    jsDependencies += "org.webjars.bower" % "raven-js" % "3.11.0" / "dist/raven.js" minified "dist/raven.min.js",
+    libraryDependencies += "be.doeraene" %%% "scalajs-jquery" % "0.9.1"
   )
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(sharedJS)

--- a/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
+++ b/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
@@ -5,17 +5,18 @@ import autowire._
 import api._
 import rpc.AutowireClient
 import org.scalajs.dom
-import org.scalajs.dom.ext.{KeyCode, Ajax}
-
+import org.scalajs.dom.ext.{Ajax, KeyCode}
 import org.scalajs.dom.{Event, KeyboardEvent, document}
-import org.scalajs.dom.raw.{Element, HTMLInputElement, HTMLUListElement, Node}
+import org.scalajs.dom.raw._
+import org.scalajs.jquery.jQuery
 
 import scalatags.JsDom.all._
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scalajs.js.JSApp
 import scala.scalajs.js.UndefOr
-
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
 import scala.concurrent.Future
 import scala.util.Try
 @JSExportTopLevel("ch.epfl.scala.index.client.Client")
@@ -24,6 +25,11 @@ object Client {
   private val searchId = "search"
   private val resultElementId = "list-result"
   private var completionSelection = CompletionSelection.empty
+
+  // used to access methods from bootstrap-select library like .selectpicker("val")
+  // see https://silviomoreto.github.io/bootstrap-select/methods/
+  private def getIssuesSelect =
+    jQuery("#selectedBeginnerIssues").asInstanceOf[js.Dynamic]
 
   private def getResultList: Option[Element] = getElement(resultElementId)
 
@@ -167,14 +173,108 @@ object Client {
         timeout = 0,
         headers = headersWithCreds
       )
-      .onSuccess {
-        case xhr =>
-          el.innerHTML = xhr.responseText
+      .foreach { xhr =>
+        el.innerHTML = xhr.responseText
       }
+  }
+
+  @js.native
+  trait Issue extends js.Object {
+    val html_url: String = js.native
+    val number: Int = js.native
+    val title: String = js.native
+  }
+
+  private def getIssueJson(issue: Issue): String = {
+    s"""{ "number":${issue.number}, "title":"${issue.title}", "url":{"target":"${issue.html_url}"} }"""
+  }
+
+  private def getIssuesListener(
+      token: Option[String]
+  )(event: dom.Event): Unit = {
+    getIssues(token)
+  }
+
+  private def getIssues(token: Option[String],
+                        showSelected: Boolean = false): Unit = {
+    getElement("beginnerIssuesLabel").foreach { issuesLabelEl =>
+      val label = issuesLabelEl.getInput.value
+      if (!label.isEmpty) {
+        val organization =
+          issuesLabelEl.attributes.getNamedItem("data-organization").value
+        val repository =
+          issuesLabelEl.attributes.getNamedItem("data-repository").value
+
+        val headers = Map(
+          "Accept" -> "application/vnd.github.VERSION.raw+json"
+        )
+
+        val headersWithCreds =
+          token
+            .map(t => headers + ("Authorization" -> s"bearer $t"))
+            .getOrElse(headers)
+
+        Ajax
+          .get(
+            url =
+              s"https://api.github.com/repos/$organization/$repository/issues?state=open&labels=$label",
+            data = "",
+            timeout = 0,
+            headers = headersWithCreds
+          )
+          .foreach { xhr =>
+            val rawIssues = js.JSON.parse(xhr.responseText)
+            val issues = rawIssues.asInstanceOf[js.Array[Issue]]
+            getElement("selectedBeginnerIssues").foreach { el =>
+              val options = issues.map { issue =>
+                s"""<option value='${getIssueJson(issue)}' title="#${issue.number}"> #${issue.number} - ${issue.title}</option>"""
+              }
+              val selectEl = el.asInstanceOf[HTMLSelectElement]
+              selectEl.innerHTML = options.mkString
+              getElement("beginnerIssues").foreach { beginnerIssuesEl =>
+                val beginnerIssuesJson =
+                  s"[${issues.map(getIssueJson).mkString(",")}]"
+                beginnerIssuesEl.getInput.value = beginnerIssuesJson
+              }
+
+              disableBeginnerIssues(false)
+
+              if (showSelected) {
+                val selectedIssueNumbers: Array[Int] =
+                  if (!el.getAttribute("data-selected").isEmpty)
+                    el.getAttribute("data-selected").split(",").map(_.toInt)
+                  else Array()
+                val selectedIssueValues = issues.collect {
+                  case issue if selectedIssueNumbers.contains(issue.number) =>
+                    getIssueJson(issue)
+                }
+                getIssuesSelect.selectpicker("val",
+                                             selectedIssueValues.toJSArray)
+              }
+            }
+          }
+      } else {
+        getElement("selectedBeginnerIssues").foreach { el =>
+          val selectEl = el.asInstanceOf[HTMLSelectElement]
+          selectEl.innerHTML = ""
+          getElement("beginnerIssues").foreach { beginnerIssuesEl =>
+            beginnerIssuesEl.getInput.value = ""
+          }
+          disableBeginnerIssues(true)
+        }
+      }
+    }
+  }
+
+  private def disableBeginnerIssues(disable: Boolean): Unit = {
+    jQuery("#selectedBeginnerIssues").prop("disabled", disable)
+    getIssuesSelect.selectpicker("refresh")
+    getIssuesSelect.selectpicker("deselectAll")
   }
 
   @JSExport
   def main(token: UndefOr[String]): Unit = {
+
     getSearchBox.foreach { searchBox =>
       searchBox.addEventListener[Event]("input", runSearch _)
       searchBox.addEventListener[KeyboardEvent]("keydown", navigate _)
@@ -183,5 +283,12 @@ object Client {
     getElement("README").foreach { readmeEl =>
       fetchAndReplaceReadme(readmeEl, token.toOption)
     }
+
+    getElement("beginnerIssuesLabel").foreach { el =>
+      el.addEventListener[Event]("change", getIssuesListener(token.toOption) _)
+    }
+
+    getIssues(token.toOption, true)
+
   }
 }

--- a/data/src/main/scala/ch.epfl.scala.index.data/Main.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/Main.scala
@@ -1,6 +1,10 @@
 package ch.epfl.scala.index.data
 
-import bintray.{BintrayDownloadPoms, BintrayListPoms, BintrayDownloadSbtPlugins}
+import bintray.{
+  BintrayDownloadPoms,
+  BintrayListPoms,
+  BintrayDownloadSbtPlugins
+}
 import cleanup.{NonStandardLib, GithubRepoExtractor}
 import elastic.SeedElasticSearch
 import github.GithubDownload
@@ -64,6 +68,7 @@ object Main {
       DataPaths(pathFromArgs.take(3))
     }
 
+    val githubDownload = new GithubDownload(getPathFromArgs)
     val steps = List(
       // List POMs of Bintray
       Step("list")({ () =>
@@ -92,9 +97,11 @@ object Main {
         () => new BintrayDownloadSbtPlugins(getPathFromArgs).run()
       ),
       // Download additional information about projects from Github
-      Step("github")(() => new GithubDownload(getPathFromArgs).run()),
+      Step("github")(() => githubDownload.run()),
       // Re-create the ElasticSearch index
-      Step("elastic")(() => new SeedElasticSearch(getPathFromArgs).run())
+      Step("elastic")(
+        () => new SeedElasticSearch(getPathFromArgs, githubDownload).run()
+      )
     )
 
     def updateClaims(): Unit = {

--- a/data/src/main/scala/ch.epfl.scala.index.data/SubIndex.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/SubIndex.scala
@@ -109,7 +109,8 @@ object SubIndex extends BintrayProtocol {
         .map(bintray => write[BintraySearch](bintray))
         .mkString(nl)
 
-    writeFile(destination.meta(LocalPomRepository.Bintray), filteredBintrayMeta)
+    writeFile(destination.meta(LocalPomRepository.Bintray),
+              filteredBintrayMeta)
 
     def copyMetas(forRepo: LocalPomRepository): Unit = {
       val shas = shasFor(forRepo)

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
@@ -54,7 +54,8 @@ class BintrayListPoms(paths: DataPaths)(
                        page: PomListDownload): WSRequest = {
     val query = page.lastSearchDate.fold(Seq[(String, String)]())(
       after => Seq("created_after" -> (after.toLocalDateTime.toString + "Z"))
-    ) ++ Seq("name" -> s"${page.query}*.pom", "start_pos" -> page.page.toString)
+    ) ++ Seq("name" -> s"${page.query}*.pom",
+             "start_pos" -> page.page.toString)
 
     withAuth(wsClient.url(s"$bintrayApi/search/file"))
       .withQueryStringParameters(query: _*)

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubModel.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubModel.scala
@@ -65,8 +65,10 @@ object V3 {
   )
 
   case class CommunityProfile(files: CommunityFiles)
-  case class CommunityFiles(contributing: ContributingFile)
+  case class CommunityFiles(contributing: ContributingFile,
+                            code_of_conduct: CodeOfConductFile)
   case class ContributingFile(html_url: Option[String])
+  case class CodeOfConductFile(html_url: Option[String])
 }
 
 // classes for GraphQL API, https://developer.github.com/v4/reference/

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubReader.scala
@@ -40,6 +40,7 @@ object GithubReader {
         topics = topics(paths, github).getOrElse(List()).toSet,
         beginnerIssues = beginnerIssues(paths, github).getOrElse(List()),
         contributingGuide = contributingGuide(paths, github).getOrElse(None),
+        codeOfConduct = codeOfConduct(paths, github).getOrElse(None),
         chatroom = chatroom(paths, github).toOption
       )
     }.toOption
@@ -151,14 +152,13 @@ object GithubReader {
           GithubIssue(
             issue.number,
             issue.title,
-            issue.bodyText,
             Url(issue.url)
         )
       )
   }
 
   /**
-   * read the contributing guide from file if exists
+   * read the link to the contributing guide from file if exists
    * @param github the git repo
    * @return
    */
@@ -174,7 +174,23 @@ object GithubReader {
   }
 
   /**
-   * read the chatroom from file if it exists
+   * read the link to the code of conduct from file if exists
+   * @param github the git repo
+   * @return
+   */
+  def codeOfConduct(paths: DataPaths, github: GithubRepo): Try[Option[Url]] =
+    Try {
+
+      import Json4s._
+
+      val communityProfilePath = githubRepoCommunityProfilePath(paths, github)
+      val communityProfile =
+        read[V3.CommunityProfile](communityProfilePath)
+      communityProfile.files.code_of_conduct.html_url.map(Url(_))
+    }
+
+  /**
+   * read the link to the chatroom from file if it exists
    * @return
    */
   def chatroom(paths: DataPaths, github: GithubRepo): Try[Url] = Try {

--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
@@ -17,7 +17,8 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.slf4j.LoggerFactory
 
-class ProjectConvert(paths: DataPaths) extends BintrayProtocol {
+class ProjectConvert(paths: DataPaths, githubDownload: GithubDownload)
+    extends BintrayProtocol {
 
   private val format = ISODateTimeFormat.dateTime.withOffsetParsed
 
@@ -354,7 +355,8 @@ class ProjectConvert(paths: DataPaths) extends BintrayProtocol {
               github = github,
               artifacts = releaseOptions.map(_.artifacts.sorted).getOrElse(Nil),
               releaseCount = releaseCount,
-              defaultArtifact = releaseOptions.map(_.release.reference.artifact),
+              defaultArtifact =
+                releaseOptions.map(_.release.reference.artifact),
               created = min,
               updated = max
             )
@@ -507,7 +509,7 @@ class ProjectConvert(paths: DataPaths) extends BintrayProtocol {
           if (stored) {
             storedProjects
               .get(project.reference)
-              .map(_.update(project))
+              .map(_.update(project, paths, githubDownload, fromStored = true))
               .getOrElse(project)
           } else project
 

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubInfo.scala
@@ -16,9 +16,12 @@ package ch.epfl.scala.index.model.misc
  * @param commits number of commits, calculated by contributors
  * @param topics topics associated with the project
  * @param contributingGuide CONTRIBUTING.md
+ * @param codeOfConduct link to code of conduct
  * @param chatroom link to chatroom (ex: https://gitter.im/scalacenter/scaladex)
  * @param beginnerIssuesLabel label used to tag beginner-friendly issues
  * @param beginnerIssues list of beginner-friendly issues for the project
+ * @param selectedBeginnerIssues list of beginner-friendly issues selected by maintainer which show in UI
+ * @param filteredBeginnerIssues list of beginner-friendly issues that were filtered by contributing search
  */
 case class GithubInfo(
     name: String = "",
@@ -36,7 +39,21 @@ case class GithubInfo(
     commits: Option[Int] = None,
     topics: Set[String] = Set(),
     contributingGuide: Option[Url] = None,
+    codeOfConduct: Option[Url] = None,
     chatroom: Option[Url] = None,
     beginnerIssuesLabel: Option[String] = None,
-    beginnerIssues: List[GithubIssue] = List()
-)
+    beginnerIssues: List[GithubIssue] = List(),
+    selectedBeginnerIssues: List[GithubIssue] = List(),
+    filteredBeginnerIssues: List[GithubIssue] = List()
+) {
+  def displayIssues: List[GithubIssue] = {
+    if (!filteredBeginnerIssues.isEmpty) {
+      filteredBeginnerIssues
+    } else {
+      val selectedIssueNumbers = selectedBeginnerIssues.map(_.number)
+      val remainingIssues =
+        beginnerIssues.filter(x => !selectedIssueNumbers.contains(x.number))
+      selectedBeginnerIssues ++ remainingIssues
+    }
+  }
+}

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubIssue.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/GithubIssue.scala
@@ -1,8 +1,5 @@
 package ch.epfl.scala.index.model.misc
 
-case class GithubIssue(number: Int,
-                       title: String,
-                       description: String,
-                       url: Url) {
+case class GithubIssue(number: Int, title: String, url: Url) {
   override def toString = s"#$number - $title"
 }

--- a/model/src/main/scala/ch.epfl.scala.index.model/misc/SearchParams.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/misc/SearchParams.scala
@@ -19,5 +19,6 @@ case class SearchParams(
     targetTypes: List[String] = Nil,
     scalaVersions: List[String] = Nil,
     scalaJsVersions: List[String] = Nil,
-    scalaNativeVersions: List[String] = Nil
+    scalaNativeVersions: List[String] = Nil,
+    contributingSearch: Boolean = false
 )

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/DefaultReleaseTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/DefaultReleaseTests.scala
@@ -93,7 +93,11 @@ class DefaultReleaseTests extends FunSpec {
       )
 
       val result =
-        DefaultRelease(repository, ReleaseSelection.empty, releases, None, true)
+        DefaultRelease(repository,
+                       ReleaseSelection.empty,
+                       releases,
+                       None,
+                       true)
 
       val versions: List[SemanticVersion] =
         List(

--- a/server/src/main/assets/css/partials/_main.scss
+++ b/server/src/main/assets/css/partials/_main.scss
@@ -172,6 +172,42 @@ main {
             @include box-shadow(0 1px 15px rgba(0, 0, 0, 0.15));
         }
     }
+
+    .contributing-projects {
+        @extend .recent-projects;
+        h2 {
+            margin-bottom: 0;
+        }
+        h4 {
+            margin-bottom: ($line-height-computed * 1.5);
+        }
+        .content-contributing-project {
+            @extend .content-project;
+            height: 350px;
+            h4 {
+                margin: 0;
+                display: inline-block;
+                padding-left: 15px;
+                width: 90%;
+            }
+            img {
+                width: 28px;
+                height: auto;
+                float: left;
+            }
+            a {
+                display: block;
+                padding-bottom: 10px;
+                color: $gray;
+                &:hover,
+                &:focus {
+                    color: $brand-primary;
+                    text-decoration: underline;
+                }
+            }
+            td { padding-left: 20px; }
+        }
+    }
 }
 
 // Result page
@@ -297,6 +333,14 @@ main {
                 color: $brand-primary;
             }
         }
+    }
+    .contributing-result {
+        a {
+            display: block;
+            padding-bottom: 10px;
+        }
+        td { padding-left: 80px; }
+        p { padding-bottom: 20px; }
     }
 }
 
@@ -444,6 +488,19 @@ main {
                 position: relative;
                 margin-left: 5px;
             }
+        }
+        .project-contributing-info {
+            a {
+                display: block;
+                padding-bottom: 10px;
+                color: $gray;
+                &:hover,
+                &:focus {
+                    color: $brand-primary;
+                    text-decoration: underline;
+                }
+            }
+            td { padding-left: 30px; }
         }
     }
     .collaborators {
@@ -601,3 +658,5 @@ html, body {
     }
   }
 }
+
+.white { color: #fff; }

--- a/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/DataRepository.scala
@@ -6,6 +6,7 @@ import model.misc._
 
 import data.DataPaths
 import data.project.ProjectForm
+import data.github.GithubDownload
 
 import release._
 import misc.Pagination
@@ -24,14 +25,17 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future, Await}
 import scala.concurrent.duration.Duration
+import scala.util.Random
 
 /**
  * @param github  Github client
  * @param paths   Paths to the files storing the index
  */
-class DataRepository(github: Github, paths: DataPaths)(
-    private implicit val ec: ExecutionContext
-) {
+class DataRepository(
+    github: Github,
+    paths: DataPaths,
+    githubDownload: GithubDownload
+)(private implicit val ec: ExecutionContext) {
 
   private def hideId(p: Project) = p.copy(id = None)
 
@@ -53,6 +57,15 @@ class DataRepository(github: Github, paths: DataPaths)(
       case _                => scoreSort order SortOrder.DESC
     }
 
+  val contributingQuery =
+    boolQuery().must(
+      List(
+        nestedQuery("github.beginnerIssues",
+                    existsQuery("github.beginnerIssues")),
+        existsQuery("github.contributingGuide"),
+        existsQuery("github.chatroom")
+      )
+    )
   private def clamp(page: Int): Int =
     if (page <= 0) 1 else page
 
@@ -179,6 +192,13 @@ class DataRepository(github: Github, paths: DataPaths)(
         topic => boolQuery().should(termQuery("github.topics", topic))
       )
 
+    val contributingSearchQuery =
+      if (params.contributingSearch) {
+        List(contributingQuery)
+      } else {
+        Nil
+      }
+
     val mustQueriesRepos: List[QueryDefinition] = {
       if (params.userRepos.nonEmpty) {
         val reposQueries =
@@ -202,14 +222,15 @@ class DataRepository(github: Github, paths: DataPaths)(
 
     val queryIsATopic = cachedTopics.contains(params.queryString)
 
-    functionScoreQuery(
+    val query = functionScoreQuery(
       boolQuery()
         .must(
           mustQueriesRepos ++
             cliQuery ++
             topicsQuery ++
             targetsQuery(params) ++
-            targetFiltering(params)
+            targetFiltering(params) ++
+            contributingSearchQuery
         )
         .should(
           List(
@@ -230,6 +251,13 @@ class DataRepository(github: Github, paths: DataPaths)(
               if (queryIsATopic) 100
               else 2
             ),
+            nestedQuery("github.beginnerIssues",
+                        termQuery("github.beginnerIssues.title", escaped))
+              .inner(innerHits("issues").size(7))
+              .boost(
+                if (params.contributingSearch) 20
+                else 1
+              ),
             stringQ
           )
         )
@@ -245,6 +273,10 @@ class DataRepository(github: Github, paths: DataPaths)(
           .factor(0.1)
       )
       .boostMode("sum")
+
+    if (params.contributingSearch && !params.queryString.isEmpty)
+      query.minScore(15)
+    else query
   }
 
   def total(queryString: String): Future[Long] = {
@@ -362,7 +394,9 @@ class DataRepository(github: Github, paths: DataPaths)(
   def updateProject(projectRef: Project.Reference,
                     form: ProjectForm): Future[Boolean] = {
     for {
-      updatedProject <- project(projectRef).map(_.map(p => form.update(p)))
+      updatedProject <- project(projectRef).map(
+        _.map(p => form.update(p, paths, githubDownload))
+      )
       ret <- updatedProject
         .flatMap { project =>
           project.id.map { id =>
@@ -490,6 +524,20 @@ class DataRepository(github: Github, paths: DataPaths)(
         search(indexName / releasesCollection)
       }
       .map(_.totalHits)
+  }
+
+  def contributingProjects() = {
+    esClient
+      .execute {
+        search(indexName / projectsCollection)
+          .query(
+            functionScoreQuery(contributingQuery)
+              .scorers(randomScore(scala.util.Random.nextInt(10000)))
+              .boostMode("sum")
+          )
+          .limit(frontPageCount)
+      }
+      .map(_.to[Project].toList)
   }
 
   private def addParamsIfMissing(p: Option[SearchParams],

--- a/server/src/main/scala/ch.epfl.scala.index.server/Github.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/Github.scala
@@ -133,7 +133,8 @@ class Github(implicit system: ActorSystem, materializer: ActorMaterializer)
                   .map(_.toList)
                   .map(_.collect { case (scala.util.Success(v), _) => v })
                   .flatMap(
-                    s => Future.sequence(s.map(r2 => Unmarshal(r2).to[List[T]]))
+                    s =>
+                      Future.sequence(s.map(r2 => Unmarshal(r2).to[List[T]]))
                   )
                   .map(_.flatten)
               } else Future.successful(Nil)

--- a/server/src/main/scala/ch.epfl.scala.index.server/Server.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/Server.scala
@@ -6,6 +6,7 @@ import routes.api._
 import data.DataPaths
 import data.util.PidLock
 import data.elastic._
+import data.github.GithubDownload
 
 import TwirlSupport._
 
@@ -58,7 +59,7 @@ object Server {
     val paths = DataPaths(pathFromArgs)
 
     val github = new Github
-    val data = new DataRepository(github, paths)
+    val data = new DataRepository(github, paths, new GithubDownload(paths))
     val session = new GithubUserSession(config)
 
     import session._

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
@@ -26,6 +26,8 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
     val latestReleasesF = latestReleases()
     val totalProjectsF = totalProjects()
     val totalReleasesF = totalReleases()
+    val contributingProjectsF = contributingProjects()
+
     for {
       topics <- topicsF
       targetTypes <- targetTypesF
@@ -37,6 +39,7 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
       latestReleases <- latestReleasesF
       totalProjects <- totalProjectsF
       totalReleases <- totalReleasesF
+      contributingProjects <- contributingProjectsF
     } yield {
 
       def query(label: String)(xs: String*): String =
@@ -68,7 +71,8 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
         userInfo,
         ecosystems,
         totalProjects,
-        totalReleases
+        totalReleases,
+        contributingProjects
       )
     }
   }

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
@@ -69,7 +69,8 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
        'scalaVersions.*,
        'scalaJsVersions.*,
        'scalaNativeVersions.*,
-       'you.?)
+       'you.?,
+       'contributingSearch.as[Boolean] ? false)
     ).tmap {
       case (q,
             page,
@@ -79,7 +80,8 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
             scalaVersions,
             scalaJsVersions,
             scalaNativeVersions,
-            you) =>
+            you,
+            contributingSearch) =>
         val userRepos =
           you.flatMap(_ => getUser(userId).map(_.repos)).getOrElse(Set())
         SearchParams(
@@ -91,7 +93,8 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
           targetTypes = targetTypes.toList,
           scalaVersions = scalaVersions.toList,
           scalaJsVersions = scalaJsVersions.toList,
-          scalaNativeVersions = scalaNativeVersions.toList
+          scalaNativeVersions = scalaNativeVersions.toList,
+          contributingSearch = contributingSearch
         )
     }
 

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishProcess.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/PublishProcess.scala
@@ -125,7 +125,9 @@ private[api] class PublishProcess(paths: DataPaths,
     val path = data.tempPath.getParent
 
     val downloadParentPomsStep =
-      new DownloadParentPoms(LocalPomRepository.MavenCentral, paths, Some(path))
+      new DownloadParentPoms(LocalPomRepository.MavenCentral,
+                             paths,
+                             Some(path))
 
     downloadParentPomsStep.run()
 
@@ -162,11 +164,11 @@ private[api] class PublishProcess(paths: DataPaths,
                           data: PublishData): Future[Unit] = {
     println("updating " + pom.artifactId)
 
-    new GithubDownload(paths, Some(data.credentials))
-      .run(repo,
-           data.downloadInfo,
-           data.downloadReadme,
-           data.downloadContributors)
+    val githubDownload = new GithubDownload(paths, Some(data.credentials))
+    githubDownload.run(repo,
+                       data.downloadInfo,
+                       data.downloadReadme,
+                       data.downloadContributors)
 
     val githubRepoExtractor = new GithubRepoExtractor(paths)
     val Some(GithubRepo(organization, repository)) = githubRepoExtractor(pom)
@@ -182,7 +184,7 @@ private[api] class PublishProcess(paths: DataPaths,
 
       Meta.append(paths, Meta(data.hash, data.path, data.created), repository)
 
-      val converter = new ProjectConvert(paths)
+      val converter = new ProjectConvert(paths, githubDownload)
 
       val (newProject, newReleases) = converter(
         pomsRepoSha = List((pom, repository, data.hash)),

--- a/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
@@ -8,6 +8,7 @@ import model.SemanticVersion
 
 import data.DataPaths
 import data.elastic._
+import data.github.GithubDownload
 
 import org.scalatest._
 
@@ -28,7 +29,7 @@ class RelevanceTest
 
   val paths = DataPaths(Nil)
   val github = new Github
-  val data = new DataRepository(github, paths)
+  val data = new DataRepository(github, paths, new GithubDownload(paths))
 
   blockUntilYellow()
 
@@ -211,7 +212,8 @@ class RelevanceTest
   private def compare(
       params: SearchParams,
       expected: List[(String, String)],
-      assertFun: (List[Project.Reference], List[Project.Reference]) => Assertion
+      assertFun: (List[Project.Reference],
+                  List[Project.Reference]) => Assertion
   ): Future[Assertion] = {
 
     val expectedRefs = expected.map {

--- a/template/src/main/scala/ch.epfl.scala.index.views/package.scala
+++ b/template/src/main/scala/ch.epfl.scala.index.views/package.scala
@@ -47,7 +47,7 @@ package object html {
                     pagination: Pagination,
                     you: Boolean): Int => Uri = page => {
 
-    uri
+    val newUri = uri
       .appendQuery("sort", params.sorting)
       .appendQuery("topics", params.topics.toList)
       .appendQuery("targetTypes", params.targetTypes.toList)
@@ -57,6 +57,13 @@ package object html {
       .appendQuery("you", you)
       .appendQuery("q" -> params.queryString)
       .appendQuery("page" -> page.toString)
+
+    if (params.contributingSearch)
+      newUri.appendQuery(
+        "contributingSearch" -> params.contributingSearch.toString
+      )
+    else newUri
+
   }
 
   // https://www.reddit.com/r/scala/comments/4n73zz/scala_puzzle_gooooooogle_pagination/d41jor5

--- a/template/src/main/twirl/ch.epfl.scala.index.views/contributingInfo.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/contributingInfo.scala.html
@@ -1,0 +1,64 @@
+@import ch.epfl.scala.index.model.Project
+@import ch.epfl.scala.index.model.misc.SearchParams
+
+@(project: Project, hideProjectInfo: Boolean = false, params: Option[SearchParams] = None)
+
+@if(!hideProjectInfo) {
+    <a href="/@project.reference.organization/@project.reference.repository">
+        <img src="@{project.github.flatMap(_.logo.map(_.target)).getOrElse("/assets/img/avatar-list.png")}" alt="project logo">
+
+        <h4>@project.reference.organization/@project.reference.repository</h4>
+    </a>
+
+    @for(github <- project.github) {
+      @for(description <- github.description) {
+        <p class="description">@description</p>
+      }
+    }
+}
+@for(github <- project.github) {
+  @params.filter(_.contributingSearch).map { p =>
+    @for(issue <- github.displayIssues.take(6)) {
+        <a href="@issue.url.target" target="_blank">@issue</a>
+    }
+    @if(6 < github.displayIssues.length) {
+        @for(label <- github.beginnerIssuesLabel) {
+            @if(!github.filteredBeginnerIssues.isEmpty) {
+                <a href='https://github.com/@{project.githubRepo}/issues?utf8=✓&q=is:open label:"@label" @{p.queryString}'
+                target="_blank">More Issues ...</a>
+            } else {
+                <a href="https://github.com/@{project.githubRepo}/labels/@{label}"
+                target="_blank">More Issues ...</a>
+            }
+        }
+    }
+  }.getOrElse {
+    @for(issue <- github.displayIssues.take(3)) {
+        <a href="@issue.url.target" target="_blank">@issue</a>
+    }
+    @if(3 < github.displayIssues.length) {
+        @for(label <- github.beginnerIssuesLabel) {
+            <a href="https://github.com/@{project.githubRepo}/labels/@{label}"
+            target="_blank">More Issues ...</a>
+        }
+    }
+  }
+   @for(contributingGuide <- github.contributingGuide; chatroom <- github.chatroom) {
+        <table>
+            <tr>
+              <td>
+                  <a href="@contributingGuide.target" target="_blank">Contributing Guide</a>
+              </td>
+              <td>
+                  <a href="@chatroom.target" target="_blank">Chatroom</a>
+              </td>
+              @for(codeOfConduct <- github.codeOfConduct) {
+                  <td>
+                      <a href="@codeOfConduct.target" target="_blank">Code of Conduct</a>
+                  </td>
+              }
+            </tr>
+        </table>
+    }
+
+}

--- a/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
@@ -14,7 +14,8 @@
   user: Option[UserInfo],
   ecosystems: Map[String, String],
   totalProjects: Long,
-  totalReleases: Long)
+  totalReleases: Long,
+  contributingProjects: List[Project])
 
 @main(title = "Scaladex", showSearch = false, user) {
 <main id="container-home">
@@ -70,6 +71,21 @@
                         }
                     </ul>
                 </div>
+            </div>
+        </div>
+    </section>
+    <section class="contributing-projects">
+        <div class="container">
+            <h2 class="text-center">Looking for a project to contribute to?</h2>
+            <h4 class="text-center">Each project below has beginner-friendly issues which are great places to start contributing.<br>To find more projects, use the <a href="/search?q=&contributingSearch=true">Contributing Search</a></h4>
+            <div class="row">
+                @for(project <- contributingProjects){
+                    <div class="col-md-4 col-sm-6">
+                        <div class="content-contributing-project box">
+                            @contributingInfo(project)
+                      </div>
+                    </div>
+                }
             </div>
         </div>
     </section>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -59,6 +59,12 @@
 
                         @if(showSearch) {
                             @searchinput(params, you, totalProjects, totalReleases, queryIsTopic)
+                        } else {
+                            <div class="col-md-9">
+                                <p class="white">New Feature: Projects with Contributing Info
+                                show up on the front page and in the Contributing Search page. Maintainers can
+                                give their project Contributing Info in the Edit page.</p>
+                            </div>
                         }
 
                         @user.map{ u =>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/editproject.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/editproject.scala.html
@@ -4,7 +4,7 @@
 @import ch.epfl.scala.index.model.misc._
 @import ch.epfl.scala.index.model.release._
 
-@(project: Project, user: Option[UserInfo])
+@(project: Project, user: Option[UserInfo], beginnerIssuesJson: String)
 
 @main(title = s"Edit ${project.repository}", showSearch = true, user) {
   <main id="container-project">
@@ -79,6 +79,50 @@
                   }
                   </select>
                 </div>
+
+                <fieldset>
+                  <legend>Contributing Info</legend>
+                  <div class="form-group">
+                    <label for="beginnerIssuesLabel">Beginner Issues Label</label>
+                    <input id="beginnerIssuesLabel" name="beginnerIssuesLabel" value="@github.beginnerIssuesLabel.getOrElse("")"
+                      placeholder="Label used to mark beginner-friendly Issues on Github"
+                      class="form-control list-group-item" data-organization="@project.reference.organization"
+                      data-repository="@project.reference.repository">
+                  </div>
+                  <div class="form-group">
+                    <label for="selectedBeginnerIssues">Selected Beginner Issues</label>
+                    <p>Select which issues will be shown on the front page, Contributing Search page
+                     and project page. If none are selected, the first couple issues created with the
+                     beginner issues label will be shown.</p>
+                    <select
+                      id="selectedBeginnerIssues"
+                      name="selectedBeginnerIssues"
+                      data-live-search="true"
+                      class="selectpicker" data-style="btn-primary"
+                      multiple data-max-options="3"
+                      data-selected="@github.selectedBeginnerIssues.map(_.number).mkString(",")">
+                    </select>
+                    <input type="hidden" name="beginnerIssues" id="beginnerIssues" value="@beginnerIssuesJson">
+                  </div>
+                  <div class="form-group">
+                    <label for="chatroom">Chatroom</label>
+                    <input name="chatroom" value="@github.chatroom.getOrElse(Url("")).target"
+                      class="form-control list-group-item"
+                      placeholder="Link to chatroom (Ex. https://gitter.im/scalacenter/scaladex)">
+                  </div>
+                  <div class="form-group">
+                    <label for="contributingGuide">Contributing Guide</label>
+                    <input name="contributingGuide" value="@github.contributingGuide.getOrElse(Url("")).target"
+                      placeholder="Link to contributing guide (Ex. https://github.com/scalacenter/scaladex/blob/master/CONTRIBUTING.md)"
+                      class="form-control list-group-item">
+                  </div>
+                  <div class="form-group">
+                    <label for="codeOfConduct">Code of Conduct</label>
+                    <input name="codeOfConduct" value="@github.codeOfConduct.getOrElse(Url("")).target"
+                      placeholder="Link to code of conduct (Ex. https://github.com/playframework/playframework/blob/master/CODE_OF_CONDUCT.md)"
+                      class="form-control list-group-item">
+                  </div>
+                </fieldset>
               }
 
               <fieldset>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/project.scala.html
@@ -30,6 +30,7 @@
             </div>
             }
             @project.github.map(gh => statistic(gh, project.githubRepo, project.releaseCount, release.uniqueOrderedReverseDependencies.size))
+            @projectContributingInfo(project)
             @install(release, project.cliArtifacts)
             @documentation(release, project)
             @project.github.map(gh => contributors(gh.contributors))

--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/projectContributingInfo.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/projectContributingInfo.scala.html
@@ -1,0 +1,16 @@
+@import ch.epfl.scala.index.model.Project
+@import ch.epfl.scala.index.views.html._
+
+@(project: Project)
+
+@project.github.map { github =>
+    @if(!github.beginnerIssues.isEmpty && github.chatroom.isDefined && github.contributingGuide.isDefined) {
+        <div class="box project-contributing-info">
+          <h4>Contributing Info</h4>
+          <p>Beginner-friendly Issues:</p>
+          <div>
+            @contributingInfo(project, true)
+          </div>
+        </div>
+    }
+}

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/filter.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/filter.scala.html
@@ -12,6 +12,12 @@
 
 <div class="filters">
   <form action="/search" action="GET">
+    @if(params.contributingSearch) {
+      <a class="btn btn-primary" href="/search?q=">Normal Search</a>
+      <input type="hidden" name="contributingSearch" value="true">
+    } else {
+      <a class="btn btn-primary" href="/search?q=&contributingSearch=true">Contributing Search</a>
+    }
     <h3>Filters</h3>
     <fieldset>
       <legend>Target</legend>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/result.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/result.scala.html
@@ -18,6 +18,13 @@
   scalaJsVersions: List[(String, Long)],
   scalaNativeVersions: List[(String, Long)])
 
+@if(params.contributingSearch){
+  <h2 class="text-center">Contributing Search</h2>
+  <div class="row">
+    <h4 class="text-center">All the projects below have beginner-friendly issues which are great places to start contributing</h4>
+  </div>
+}
+
 <div class="row">
   <div class="col-md-2">
     <div class="result-count">
@@ -46,7 +53,7 @@
     )
   </div>      
   <div class="col-md-9">
-    @resultList(projects)
+    @resultList(projects, params)
     @paginate(pagination, paginationUri(params, uri, pagination, you))
   </div>
 </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
@@ -1,6 +1,7 @@
 @import ch.epfl.scala.index.views.html._
 @import ch.epfl.scala.index.model.Project
-@(projects: List[Project])
+@import ch.epfl.scala.index.model.misc.SearchParams
+@(projects: List[Project], params: SearchParams)
 
 <ol class="list-result box">
   @for(project <- projects){
@@ -8,42 +9,48 @@
     <a href="/@project.reference.organization/@project.reference.repository">
       <div class="row">
         <div class="col-md-8">
-          <div>
-            <img src="@{project.github.flatMap(_.logo.map(_.target)).getOrElse("/assets/img/avatar-list.png")}" alt="project logo">
-            <h4>@project.reference.organization/@project.reference.repository</h4>
+          @if(params.contributingSearch){
+            <div class="contributing-result">
+              @contributingInfo(project, params = Some(params))
+            </div>
+          } else {
+            <div>
+              <img src="@{project.github.flatMap(_.logo.map(_.target)).getOrElse("/assets/img/avatar-list.png")}" alt="project logo">
+              <h4>@project.reference.organization/@project.reference.repository</h4>
 
-            @for(github <- project.github) {
-              @for(description <- github.description) {
-                <p class="description">@description</p>
+              @for(github <- project.github) {
+                @for(description <- github.description) {
+                  <p class="description">@description</p>
+                }
               }
-            }
-            @if(project.scalaVersion.nonEmpty){
-              <div>
-                Scala (JVM): 
-                @for(v <- sortVersions(project.scalaVersion, scala = true)) {
-                  <span class="targets">@v</span>  
-                } 
-              </div>
-            }
+              @if(project.scalaVersion.nonEmpty){
+                <div>
+                  Scala (JVM):
+                  @for(v <- sortVersions(project.scalaVersion, scala = true)) {
+                    <span class="targets">@v</span>
+                  }
+                </div>
+              }
 
-            @if(project.scalaJsVersion.nonEmpty){
-              <div>
-                Scala.js: 
-                @for(v <- sortVersions(project.scalaJsVersion)) {
-                  <span class="targets">@v</span>  
-                }
-              </div> 
-            }
+              @if(project.scalaJsVersion.nonEmpty){
+                <div>
+                  Scala.js:
+                  @for(v <- sortVersions(project.scalaJsVersion)) {
+                    <span class="targets">@v</span>
+                  }
+                </div>
+              }
 
-            @if(project.scalaNativeVersion.nonEmpty){
-              <div>
-                Scala-Native: 
-                @for(v <- sortVersions(project.scalaNativeVersion)) {
-                  <span class="targets">@v</span>  
-                }
-              </div>
-            }
-          </div>
+              @if(project.scalaNativeVersion.nonEmpty){
+                <div>
+                  Scala-Native:
+                  @for(v <- sortVersions(project.scalaNativeVersion)) {
+                    <span class="targets">@v</span>
+                  }
+                </div>
+              }
+            </div>
+          }
         </div>
         <div class="col-md-4">
           <div class="stats">

--- a/template/src/main/twirl/ch.epfl.scala.index.views/searchinput.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/searchinput.scala.html
@@ -9,7 +9,12 @@
             value = "@params.queryString"
           }
           name="q" id="search" type="text" class="form-control"
-          placeholder="Search @for(projects <- totalProjects; releases <- totalReleases) {within @projects projects and @releases releases}">
+          @if(params.contributingSearch){
+            placeholder="Search beginner-friendly projects and issues"
+          } else {
+            placeholder="Search @for(projects <- totalProjects; releases <- totalReleases) {within @projects projects and @releases releases}"
+          }
+          >
         @if(you){
           <input type="hidden" name="you" value="✓">
         }
@@ -31,6 +36,10 @@
         @for(scalaNativeVersion <- params.scalaNativeVersions){
           <input type="hidden" name="scalaNativeVersions" value="@scalaNativeVersion">
         }
+
+          @if(params.contributingSearch) {
+            <input type="hidden" name="contributingSearch" value="@{params.contributingSearch}">
+          }
     </form>
     <span class="form-control-feedback"><i class="fa fa-search"></i></span>
     <div class="autocomplete">


### PR DESCRIPTION
@heathermiller @MasseGuillaume @julienrf 

New features:
* Front Page - added contributing info section, displays contributing info panels for randomly selected projects that have contributing info (beginner issues, chatroom, contributing guide)
* Contributing Search - added search param to search page that filters projects that have contributing info displays contributing info in the search results, http://localhost:8080/search?q=*&contributingSearch=true
* Edit Project Page - added fields for beginner issues label, chatroom link, contributing guide link. When the beginner issues label is set, issues with that label are fetched and stored for the project as beginner issues. Alternatively, you can set the beginner issues label in `projects.json` and when the data is re-indexed, it will fetch and store issues with that label for the project
* Project Page - added contributing info panel on the right which only shows for projects that have contributing info

TODO:
* let maintainer set which specific issues are displayed for their project after they set beginner issues label in the edit project page

I tried pushing this code to the dev server but got some memory errors when trying to run it, I'll let you know when those are resolved so you can see things for yourself.

Front Page:

<img width="1280" alt="frontpage" src="https://user-images.githubusercontent.com/8866443/28524024-e6344bd0-704c-11e7-9be0-22246d16a097.png">

Search Page:

<img width="1280" alt="searchpage" src="https://user-images.githubusercontent.com/8866443/28524027-ed48e3c2-704c-11e7-882d-c37c60788584.png">

Project Page:

<img width="1280" alt="projectpage" src="https://user-images.githubusercontent.com/8866443/28524039-f53a2afa-704c-11e7-9733-2f32f298da49.png">
