### PR TITLE
Fix rate limit errors with Github API #431

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Then create the following file `../scaladex-dev-credentials/application.conf`
 ```
 org.scala_lang.index {
   data {
-    github = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    github = ["XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]
   }
 }
 ```

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadSbtPlugins.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadSbtPlugins.scala
@@ -18,7 +18,6 @@ import org.json4s.JsonAST.JValue
 import org.slf4j.LoggerFactory
 import play.api.libs.ws.{WSClient, WSResponse}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
@@ -31,6 +30,8 @@ final class BintrayDownloadSbtPlugins(
 )(implicit val materializer: Materializer, val system: ActorSystem)
     extends PlayWsDownloader
     with BintrayProtocol {
+
+  import system.dispatcher
 
   val bintrayClient = new BintrayClient(paths)
   import bintrayClient._

--- a/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
@@ -47,7 +47,7 @@ class RelevanceTest
   }
 
   test("match for scalafix") {
-    first("scalafix")("scalacenter", "scalafix")
+    top("scalafix", List("scalacenter" -> "scalafix"))
   }
 
   // fails


### PR DESCRIPTION
@heathermiller @MasseGuillaume

This fixes #431 by updating the code that downloads repo info from Github to avoid getting errors about hitting the Github API rate limit and abuse rate limit (see #431 for more info about those errors).

I created a personal Scaladex Github [account](https://github.com/scaladex-personal) and a machine Scaladex [account](https://github.com/scaladex-machine) and generated 1 Github API token for each account which adheres to Github's terms of service of using at most 2 tokens when hitting their API (1 token from a personal account and 1 token from a machine account). I will commit these tokens to the scaladex-credentials repo once this PR is deployed.

This PR is similar to the solution described in #431:
* Instead of splitting up the step that downloads the Github info into 2 steps (as mentioned in my previous solution), the code uses one step like it did before and if it hits the rate limit, it [pauses](https://github.com/scalacenter/scaladex/pull/470/files#diff-e03c541cf1bd7ec0322a9a6571160bebR379) until the rate limit resets. The progress bar keeps printing the same thing while the thread is paused which is annoying but I couldn't find a way around this (there's an open [issue](https://github.com/ctongfei/progressbar/issues/17) with `ctongfei/progressbar` to be able to pause it)
* The download step hits the Github API [serially](https://github.com/scalacenter/scaladex/pull/470/files#diff-9b0b9f250047a450506bda2259c11537R199)

The whole `data/reStart github` step takes around 1.5 hours now (~50 mins downloading, ~40 mins pausing)
