### PR TITLE
Add parallelism to front page and search page

### DIFF
--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/FrontPage.scala
@@ -16,17 +16,27 @@ class FrontPage(dataRepository: DataRepository, session: GithubUserSession) {
 
   private def frontPage(userInfo: Option[UserInfo]) = {
     import dataRepository._
+    val topicsF = topics()
+    val targetTypesF = targetTypes()
+    val scalaVersionsF = scalaVersions()
+    val scalaJsVersionsF = scalaJsVersions()
+    val scalaNativeVersionsF = scalaNativeVersions()
+    val mostDependedUponF = mostDependedUpon()
+    val latestProjectsF = latestProjects()
+    val latestReleasesF = latestReleases()
+    val totalProjectsF = totalProjects()
+    val totalReleasesF = totalReleases()
     for {
-      topics <- topics()
-      targetTypes <- targetTypes()
-      scalaVersions <- scalaVersions()
-      scalaJsVersions <- scalaJsVersions()
-      scalaNativeVersions <- scalaNativeVersions()
-      mostDependedUpon <- mostDependedUpon()
-      latestProjects <- latestProjects()
-      latestReleases <- latestReleases()
-      totalProjects <- totalProjects()
-      totalReleases <- totalReleases()
+      topics <- topicsF
+      targetTypes <- targetTypesF
+      scalaVersions <- scalaVersionsF
+      scalaJsVersions <- scalaJsVersionsF
+      scalaNativeVersions <- scalaNativeVersionsF
+      mostDependedUpon <- mostDependedUponF
+      latestProjects <- latestProjectsF
+      latestReleases <- latestReleasesF
+      totalProjects <- totalProjectsF
+      totalReleases <- totalReleasesF
     } yield {
 
       def query(label: String)(xs: String*): String =

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/SearchPages.scala
@@ -23,15 +23,23 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
   import dataRepository._
 
   private def search(params: SearchParams, userId: Option[UUID], uri: String) = {
-    complete(
+    complete {
+      val resultsF = find(params)
+      val topicsF = topics(Some(params))
+      val targetTypesF = targetTypes(Some(params))
+      val scalaVersionsF = scalaVersions(Some(params))
+      val scalaJsVersionsF = scalaJsVersions(Some(params))
+      val scalaNativeVersionsF = scalaNativeVersions(Some(params))
+      val queryIsTopicF = queryIsTopic(params.queryString)
+
       for {
-        (pagination, projects) <- find(params)
-        topics <- topics(Some(params))
-        targetTypes <- targetTypes(Some(params))
-        scalaVersions <- scalaVersions(Some(params))
-        scalaJsVersions <- scalaJsVersions(Some(params))
-        scalaNativeVersions <- scalaNativeVersions(Some(params))
-        queryIsTopic <- queryIsTopic(params.queryString)
+        (pagination, projects) <- resultsF
+        topics <- topicsF
+        targetTypes <- targetTypesF
+        scalaVersions <- scalaVersionsF
+        scalaJsVersions <- scalaJsVersionsF
+        scalaNativeVersions <- scalaNativeVersionsF
+        queryIsTopic <- queryIsTopicF
       } yield {
         searchresult(
           params,
@@ -48,7 +56,7 @@ class SearchPages(dataRepository: DataRepository, session: GithubUserSession) {
           queryIsTopic
         )
       }
-    )
+    }
   }
 
   def searchParams(userId: Option[UUID]): Directive1[SearchParams] =


### PR DESCRIPTION
@MasseGuillaume As discussed, these changes fix loading the front page and search page to each get the independent data they need (search results, topics, scala versions, ...) in parallel.

I didn't notice much of a speed-up in page load times while testing locally but maybe the server will have better results.