### PR TITLE
Bring back parallelism for downloading poms

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadPoms.scala
@@ -153,7 +153,8 @@ class BintrayDownloadPoms(paths: DataPaths)(
     download[BintraySearch, Unit]("Downloading POMs",
                                   searchesBySha1,
                                   downloadRequest,
-                                  processPomDownload)
+                                  processPomDownload,
+                                  parallelism = 32)
     ()
   }
 }

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
@@ -220,7 +220,8 @@ class BintrayListPoms(paths: DataPaths)(
       download[PomListDownload, List[BintraySearch]](infoMessage,
                                                      toDownload,
                                                      discover,
-                                                     processSearch)
+                                                     processSearch,
+                                                     parallelism = 1)
 
     /* maybe we have here a problem with duplicated poms */
     val merged = newQueried

--- a/data/src/main/scala/ch.epfl.scala.index.data/download/PlayWsDownloader.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/download/PlayWsDownloader.scala
@@ -77,7 +77,8 @@ trait PlayWsDownloader {
       message: String,
       toDownload: Set[T],
       downloadUrl: (AhcWSClient, T) => WSRequest,
-      process: (T, WSResponse) => R
+      process: (T, WSResponse) => R,
+      parallelism: Int
   ): Seq[R] = {
 
     val client = wsClient

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubDownload.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubDownload.scala
@@ -655,7 +655,8 @@ class GithubDownload(paths: DataPaths,
     download[GithubRepo, Unit]("Checking Gitter Chatroom Links",
                                githubRepos,
                                gitterUrl,
-                               processChatroomResponse)
+                               processChatroomResponse,
+                               parallelism = 32)
 
     downloadGraphql[(GithubRepo, String), Unit](
       "Downloading Beginner Issues",
@@ -720,7 +721,8 @@ class GithubDownload(paths: DataPaths,
     download[GithubRepo, Unit]("Checking Gitter Chatroom Links",
                                Set(repo),
                                gitterUrl,
-                               processChatroomResponse)
+                               processChatroomResponse,
+                               parallelism = 32)
 
     ()
   }

--- a/data/src/main/scala/ch.epfl.scala.index.data/maven/DownloadParentPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/maven/DownloadParentPoms.scala
@@ -101,7 +101,8 @@ class DownloadParentPoms(repository: LocalPomRepository,
         download[Dependency, Int]("Download parent POMs",
                                   parentPomsToDownload,
                                   downloadRequest,
-                                  processResponse)
+                                  processResponse,
+                                  parallelism = 32)
       val failedDownloads = downloaded.sum
 
       log.warn(s"failed downloads: $failedDownloads")


### PR DESCRIPTION
Fix changes from https://github.com/scalacenter/scaladex/commit/159ced1c566c2355afbfc482ab76f10c022c301d to make pom downloading parallel like how it used to be