### PR TITLE
Add parallelism when hitting github api

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/download/PlayWsDownloader.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/download/PlayWsDownloader.scala
@@ -86,7 +86,7 @@ trait PlayWsDownloader {
 
     def processDownloads = {
 
-      Source(toDownload).mapAsyncUnordered(parallelism = 1) { item =>
+      Source(toDownload).mapAsyncUnordered(parallelism) { item =>
         val request = downloadUrl(client, item)
         val response = request.get
 
@@ -196,7 +196,7 @@ trait PlayWsDownloader {
     def processItems(client: AhcWSClient, progress: ProgressBar) = {
       // use minimal concurrency to avoid abuse rate limit error which is triggered
       // by making too many calls in a short period of time, see https://github.com/scalacenter/scaladex/issues/431
-      val parallelism = 1
+      val parallelism = 4
       Source(toDownload).mapAsyncUnordered(parallelism) { item =>
         processItem(client, item, progress)
       }

--- a/data/src/main/scala/ch.epfl.scala.index.data/github/GithubDownload.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/github/GithubDownload.scala
@@ -372,14 +372,14 @@ class GithubDownload(paths: DataPaths,
       log.info(s" $message, received 500 response from github")
     } else if (200 != response.status &&
                404 != response.status &&
-               500 != response.status &&
                204 != response.status) {
       // get 200 for valid response
       // get 404 for old repo that no longer exists
-      // get 500 with 1 repo with community profile api (error on github's side),
-      //   https://api.github.com/repos/spacelift/amqp-scala-client/community/profile
       // get 204 when getting contributors for empty repo,
       //   https:/api.github.com/repos/rockjam/cbt-sonatype/contributors?page=1
+      throw new Exception(
+          s" $message, Unknown response from Github API, ${response.status}, ${response.body}"
+        )
     }
   }
 


### PR DESCRIPTION
I tried increasing parallelism [earlier](https://github.com/scalacenter/scaladex/pull/470#discussion_r130227859) in #470 for code that hits the GraphQL API from 1 to 4 (so that it runs a bit faster but still avoids the rate limit errors), but the changes didn't go through for some reason so I added them in this PR.

Also fixed a line I forgot to change in #486 so that code that downloads poms from non-github APIs runs with max parallelism.