### PR TITLE
Fixes the copy/pastable line for libraries with crossSuffix.

### DIFF
--- a/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
@@ -62,7 +62,7 @@ case class Release(
 
       List(
         Some(
-          s"""libraryDependencies += "${maven.groupId}" $artifactOperator "${reference.artifact}" % "${reference.version}$crossSuffix""""
+          s"""libraryDependencies += "${maven.groupId}" $artifactOperator "${reference.artifact}" % "${reference.version}"$crossSuffix"""
         ),
         resolver.map("resolvers += " + _.sbt)
       ).flatten.mkString(System.lineSeparator)


### PR DESCRIPTION
See e.g. ammonite (https://index.scala-lang.org/lihaoyi/ammonite/ammonite/1.0.2?target=_2.12.3):
Is currently:     `libraryDependencies += "com.lihaoyi" % "ammonite" % "1.0.2 cross CrossVersion.full"`
Correct would be: `libraryDependencies += "com.lihaoyi" % "ammonite" % "1.0.2" cross CrossVersion.full`

N.b. I wasn't able to compile the project (before or after this change) because I don't have `sass` installed.