### PR TITLE
#518 changed checking of the source of the key events.

### DIFF
--- a/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
+++ b/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
@@ -144,7 +144,7 @@ object Client {
     if (event.keyCode == KeyCode.S) {
       getSearchBox.foreach { searchBox =>
         val input = searchBox.getInput
-        if (event.srcElement != input) {
+        if (event.target != input) {
           input.focus()
           event.preventDefault()
         }


### PR DESCRIPTION
Typing the 's' in searchbox didn't work only on my FF.

I think I've got it.  I checked the solution on FF, IE, and Chrome on windows.