### PR TITLE
#523 Do not allow caching of badges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,6 @@ lazy val server = project
       "ch.megard" %% "akka-http-cors" % "0.2.1",
       "com.softwaremill.akka-http-session" %% "core" % "0.5.3",
       "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-caching" % akkaHttpVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
       "org.webjars.bower" % "bootstrap-sass" % "3.3.6",
       "org.webjars.bower" % "bootstrap-switch" % "3.3.2",

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/Badges.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/Badges.scala
@@ -7,7 +7,8 @@ import release._
 import akka.http.scaladsl._
 import server.Directives._
 import model.StatusCodes._
-import akka.http.scaladsl.server.directives.CachingDirectives.cachingProhibited
+import model.headers._
+import model.headers.CacheDirectives._
 
 class Badges(dataRepository: DataRepository) {
 
@@ -48,7 +49,7 @@ class Badges(dataRepository: DataRepository) {
       logoWidth.map(w => ("logoWidth", w.toString))
     ).flatten.map { case (k, v) => k + "=" + v }.mkString("?", "&", "")
 
-    cachingProhibited {
+    respondWithHeader(`Cache-Control`(`no-cache`)) {
       redirect(
         s"https://img.shields.io/badge/$subject-$status-$color.svg$query",
         TemporaryRedirect


### PR DESCRIPTION
`cachingProhibited` filters out requests and leaves only those that explicitly request for no caching. It was an incorrect solution for #515.

Instead we should add a `no-cache` header to the response and inform the client that badges should not be cached.

Fixes #523
