### PR TITLE
Opensearch

### DIFF
--- a/server/src/main/assets/opensearch.xml
+++ b/server/src/main/assets/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Scaladex</ShortName>
+    <Description>Search Scaladex</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://index.scala-lang.org/assets/img/favicon.ico</Image>
+    <Url type="text/html" method="GET" template="https://index.scala-lang.org/search?q={searchTerms}"/>
+    <moz:SearchForm>https://index.scala-lang.org</moz:SearchForm>
+</OpenSearchDescription>

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/Assets.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/Assets.scala
@@ -34,6 +34,9 @@ object Assets {
         ),
         path("assets" / "client-jsdeps.js")(
           getFromResource("client-jsdeps.js")
+        ),
+        path("assets" / "opensearch.xml")(
+          getFromResource("opensearch.xml")
         )
       )
     )

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!--meta name="description" content="Description...">
     <meta name="author" content="Author..."-->
+    <link rel="search" type="application/opensearchdescription+xml" href="/assets/opensearch.xml" title="@title">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/apple-touch-icon.png">
     <link rel="icon" type="image/png" href="/assets/img/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="/assets/img/favicon-16x16.png" sizes="16x16">


### PR DESCRIPTION
This will add "Scaladex search" to the browser, which then can be used either with TAB key (like in chrome) or just in search box (like in FF)
![image](https://user-images.githubusercontent.com/25635548/37370282-f8691710-270b-11e8-901a-d0a931d3ebdb.png)
 

Chrome is using that search with TAB key already  somehow
![image](https://user-images.githubusercontent.com/25635548/37370211-c2ed8ce2-270b-11e8-99d7-274af87adaa1.png)


