### PR TITLE
Upgrade Scala.js and Scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 os:
   - linux
 scala:
-  - 2.12.2
+  - 2.12.10
 jdk:
   - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val ammoniteSettings = Seq(
 
 lazy val commonSettings = Seq(
   resolvers += Resolver.typesafeIvyRepo("releases"),
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.12.10",
   scalacOptions := Seq(
     "-deprecation",
     "-encoding",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import ScalaJSHelper._
-import org.scalajs.sbtplugin.cross.CrossProject
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 import Deployment.githash
 
@@ -103,7 +103,7 @@ lazy val template = project
   .dependsOn(model)
   .enablePlugins(SbtTwirl)
 
-lazy val shared = crossProject
+lazy val shared = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(playJson)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val baseSettings = Seq(
 )
 
 lazy val ammoniteSettings = Seq(
-  libraryDependencies += "com.lihaoyi" % "ammonite" % "1.0.3-10-4311ac9" % Test cross CrossVersion.full,
+  libraryDependencies += "com.lihaoyi" % "ammonite" % "2.0.4" % Test cross CrossVersion.full,
   sourceGenerators in Test += Def.task {
     val file = (sourceManaged in Test).value / "amm.scala"
     IO.write(file, """object amm extends App { ammonite.Main.main(args) }""")
@@ -158,7 +158,7 @@ lazy val server = project
 lazy val model = project
   .settings(commonSettings)
   .settings(
-    libraryDependencies += "com.lihaoyi" %% "fastparse" % "1.0.0"
+    libraryDependencies += "com.lihaoyi" %% "fastparse" % "2.2.3"
   )
 
 lazy val data = project

--- a/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
+++ b/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
@@ -19,7 +19,8 @@ import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.concurrent.Future
 import scala.util.Try
-@JSExportTopLevel("ch.epfl.scala.index.client.Client")
+
+@JSExportTopLevel("ScaladexClient")
 object Client {
 
   private val searchId = "search"

--- a/data/src/main/scala/ch.epfl.scala.index.data/cleanup/ScmInfoParser.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/cleanup/ScmInfoParser.scala
@@ -5,20 +5,22 @@ package cleanup
 import model.misc.GithubRepo
 import model.Parsers
 
-import fastparse.all._
-import fastparse.core.Parsed
+import fastparse._
 
 object ScmInfoParser extends Parsers {
+  import fastparse.NoWhitespace._
+
   // More info in Rfc3986
-  private val Unreserved = P(Alpha | Digit | "-".! | ".".! | "_".! | "~".!).!
-  private val Segment = P(Unreserved | SubDelims | ":" | "@").!
-  private def SubDelims = CharIn("!$&'()*+,;=").!
+  private def Unreserved[_: P] =
+    P(Alpha | Digit | "-".! | ".".! | "_".! | "~".!).!
+  private def Segment[_: P] = P(Unreserved | SubDelims | ":" | "@").!
+  private def SubDelims[_: P] = CharIn("!$&'()*+,;=").!
 
   private def removeDotGit(v: String) =
     if (v.endsWith(".git")) v.dropRight(".git".length)
     else v
 
-  private val ScmUrl = P(
+  private def ScmUrl[_: P] = P(
     "scm:".? ~ "git:".? ~ ("git@" | "https://" | "git://" | "//") ~
       "github.com" ~ (":" | "/") ~ Segment
       .rep(1)
@@ -26,7 +28,7 @@ object ScmInfoParser extends Parsers {
   )
 
   def parse(scmInfo: String): Option[GithubRepo] = {
-    ScmUrl.parse(scmInfo) match {
+    fastparse.parse(scmInfo, x => ScmUrl(x)) match {
       case Parsed.Success((organization, repo), _) =>
         Some(GithubRepo(organization, repo))
       case _ => None

--- a/model/src/main/scala/ch.epfl.scala.index.model/Parsers.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Parsers.scala
@@ -1,8 +1,9 @@
 package ch.epfl.scala.index.model
 
 trait Parsers {
-  import fastparse.all._
+  import fastparse._
 
-  protected val Alpha = (CharIn('a' to 'z') | CharIn('A' to 'Z')).!
-  protected val Digit = CharIn('0' to '9').!
+  protected def Alpha[_: P] =
+    CharPred(c => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')).!
+  protected def Digit[_: P] = CharIn("0123456789").!
 }

--- a/project/ScalaJSHelper.scala
+++ b/project/ScalaJSHelper.scala
@@ -1,10 +1,9 @@
 import sbt._
 import Keys._
-import org.scalajs.sbtplugin.ScalaJSPlugin.AutoImport._
-import org.scalajs.sbtplugin.cross.CrossType
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 object ScalaJSHelper {
-  def packageScalaJS(client: Project) = Seq(
+  def packageScalaJS(client: Project): Seq[Setting[_]] = Seq(
     watchSources ++= (watchSources in client).value,
     // Pick fastOpt when developing and fullOpt when publishing
     resourceGenerators in Compile += Def.task {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.2")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 libraryDependencies += "com.typesafe" % "config" % "1.3.1"

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -146,9 +146,9 @@
 
         // Run client scalajs code (for instance, autocomplete)
         @if(user.isDefined) {
-          ch.epfl.scala.index.client.Client.main("@user.get.token");
+          ScaladexClient.main("@user.get.token");
         } else {
-          ch.epfl.scala.index.client.Client.main();
+          ScaladexClient.main();
         }
 
     </script>


### PR DESCRIPTION
This PR upgrades to Scala.js 0.6.32 (the latest 0.6.x version) and Scala 2.12.10. In the process, we need to upgrade to Ammonite 2.0.4 to support Scala 2.12.10, and fastparse 2.2.3 to avoid binary incompatibilities with Ammonite 2.0.4.