### PR TITLE
use sbt-sassify instead of sbt-sass (deprecated Ruby Sass)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val server = project
     javaOptions in reStart ++= Seq("-Xmx4g")
   )
   .dependsOn(template, data, sharedJVM)
-  .enablePlugins(SbtSass, JavaServerAppPackaging)
+  .enablePlugins(SbtSassify, JavaServerAppPackaging)
 
 lazy val model = project
   .settings(commonSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.2")
-addSbtPlugin("org.madoushi.sbt" % "sbt-sass" % "0.9.3")
+addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
Use the sbt-sassify plugin instead of sbt-sass plugin. The main goal is to get rid of the Ruby Sass dependency that is deprecated and that requires a manual installation.