### PR TITLE
Always use '\n' to split lines when parsing JSON files.

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/Meta.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/Meta.scala
@@ -62,7 +62,7 @@ object Meta {
     val metaRaw = new String(Files.readAllBytes(metaPath))
 
     metaRaw
-      .split(nl)
+      .split('\n')
       .toList
       .filter(_ != "")
       .map(json => Parser.parseUnsafe(json).extract[Meta])

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayMeta.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayMeta.scala
@@ -21,7 +21,7 @@ object BintrayMeta extends BintrayProtocol {
    */
   def load(paths: DataPaths): List[BintraySearch] = {
     val source = scala.io.Source.fromFile(path(paths).toFile)
-    val ret = source.mkString.split(nl).toList
+    val ret = source.mkString.split('\n').toList
     source.close()
     ret
       .filter(_ != "")


### PR DESCRIPTION
Previously, a platform-dependent line separator was used, which was incorrect on Windows and caused parsing to fail.

Credit for figuring this out goes to @adpi2 ;)

Together with #592, this allows the setup instructions to work on Windows and the server to run.