### PR TITLE
Always use '\n' when building multiline strings in the codebase.

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/Meta.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/Meta.scala
@@ -83,7 +83,7 @@ object Meta {
     val jsonPerLine =
       sorted
         .map(s => swrite(s))
-        .mkString("", System.lineSeparator, System.lineSeparator)
+        .mkString("", "\n", "\n")
 
     val metaPath = paths.meta(repository)
 

--- a/data/src/main/scala/ch.epfl.scala.index.data/SubIndex.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/SubIndex.scala
@@ -27,7 +27,7 @@ object SubIndex extends BintrayProtocol {
 
     val repos =
       slurp(Paths.get("subindex.txt"))
-        .split(nl)
+        .split('\n')
         .map(splitRepo)
         .toSet
 
@@ -107,7 +107,7 @@ object SubIndex extends BintrayProtocol {
         .load(source)
         .filter(meta => bintrayShas.contains(meta.sha1))
         .map(bintray => write[BintraySearch](bintray))
-        .mkString(nl)
+        .mkString("\n")
 
     writeFile(destination.meta(LocalPomRepository.Bintray), filteredBintrayMeta)
 

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayClient.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayClient.scala
@@ -25,13 +25,12 @@ class BintrayClient(paths: DataPaths) {
     val credentials = paths.credentials
 
     if (Files.exists(credentials) && Files.isDirectory(credentials)) {
-      val nl = System.lineSeparator
       val source = scala.io.Source.fromFile(
         credentials.resolve("search-credentials").toFile
       )
 
       val info = source.mkString
-        .split(nl)
+        .split('\n')
         .map { v =>
           val (l, r) = v.span(_ != '=')
           (l.trim, r.drop(2).trim)

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayDownloadPoms.scala
@@ -14,8 +14,6 @@ import akka.stream.ActorMaterializer
 
 import org.slf4j.LoggerFactory
 
-import System.{lineSeparator => nl}
-
 class BintrayDownloadPoms(paths: DataPaths)(
     implicit val system: ActorSystem,
     implicit val materializer: ActorMaterializer
@@ -138,8 +136,8 @@ class BintrayDownloadPoms(paths: DataPaths)(
     } else {
 
       log.warn(
-        "Pom download failed" + nl +
-          search.toString + nl +
+        "Pom download failed\n" +
+          search.toString + "\n" +
           response.body.toString
       )
     }

--- a/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/bintray/BintrayListPoms.scala
@@ -2,7 +2,6 @@ package ch.epfl.scala.index
 package data
 package bintray
 
-import java.lang.System.{lineSeparator => nl}
 import java.nio.file.Files
 
 import akka.actor.ActorSystem
@@ -113,7 +112,7 @@ class BintrayListPoms(paths: DataPaths)(
     val flow = Flow[BintraySearch]
       .filterNot(search => mavenShas.contains(search.sha1))
       .map(bintray => write[BintraySearch](bintray))
-      .map(s => ByteString(s + nl))
+      .map(s => ByteString(s + "\n"))
       .toMat(FileIO.toPath(BintrayMeta.path(paths)))(Keep.right)
 
     Await.result(Source(merged).runWith(flow), Duration.Inf)

--- a/data/src/main/scala/ch.epfl.scala.index.data/package.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/package.scala
@@ -4,8 +4,6 @@ import java.nio.file.{Files, Path}
 
 package object data {
 
-  val nl = System.lineSeparator
-
   def innerJoin[K, A, B, Z](m1: Map[K, A],
                             m2: Map[K, B])(f: (A, B) => Z): Map[K, Z] = {
     m1.flatMap {
@@ -40,6 +38,6 @@ package object data {
   }
 
   def slurp(path: Path): String = {
-    Files.readAllLines(path).toArray.mkString(System.lineSeparator)
+    Files.readAllLines(path).toArray.mkString("\n")
   }
 }

--- a/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Release.scala
@@ -80,7 +80,7 @@ case class Release(
     List(
       Some(install),
       resolver.flatMap(_.sbt.map("resolvers += " + _))
-    ).flatten.mkString(System.lineSeparator)
+    ).flatten.mkString("\n")
   }
 
   /**
@@ -105,7 +105,7 @@ case class Release(
         s"import $$ivy.`${maven.groupId}$artifactOperator${reference.artifact}:${reference.version}`"
       ),
       resolver.map(addResolver)
-    ).flatten.mkString(System.lineSeparator)
+    ).flatten.mkString("\n")
   }
 
   /**
@@ -143,7 +143,7 @@ case class Release(
         s"""ivy"${maven.groupId}$artifactOperator${reference.artifact}:${reference.version}""""
       ),
       resolver flatMap addResolver
-    ).flatten.mkString(System.lineSeparator)
+    ).flatten.mkString("\n")
   }
 
   /**

--- a/project/Deployment.scala
+++ b/project/Deployment.scala
@@ -7,8 +7,6 @@ import com.typesafe.config.ConfigFactory
 import java.nio.file._
 import java.nio.file.attribute._
 
-import System.{lineSeparator => nl}
-
 object Deployment {
   def apply(data: Project, server: Project): Seq[Def.Setting[_]] = Seq(
     deployServer := deployTask(server, prodUserName, prodPort).value,
@@ -143,7 +141,7 @@ class Deployment(rootFolder: File,
         "credentials",
         "contrib",
         "index"
-      ).map(cloneIfAbsent).mkString(nl)
+      ).map(cloneIfAbsent).mkString("\n")
 
     val sentryDsn = getSentryDsn
 


### PR DESCRIPTION
This allows `test` to pass on Windows.