### PR TITLE
Remove the `gem install` of `sass` in the Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ before_script:
   - git clone git://github.com/scalacenter/scaladex-small-index.git
   - git clone git://github.com/scalacenter/scaladex-contrib.git
   - popd
-  - 'gem install sass --version "=3.2.12"'


### PR DESCRIPTION
This was forgotten in 93317577c27914ecaec7d69dee9c0a421898c91f.