### PR TITLE
Add user doc on improving visibility

### DIFF
--- a/doc/user/improve-visibility.md
+++ b/doc/user/improve-visibility.md
@@ -1,0 +1,19 @@
+# How to improve the visibility of your project
+
+As a library author or maintainer, the visibility of your project on Scaladex is under your control.
+
+As soon as a release is pushed to Maven Central (Sonatype), Scaladex downloads the latest content and metadata from the Github repository. It then uses those metadata to index the project.
+
+You can make it easier for the search engine to index your project by paying attention to the below details:
+
+### Meaningful Github description
+
+A good description is short but meaningful. keep in mind that those words are the first a user will read about your project.
+
+### Precise Github topics
+
+Carefully choosing the topics of your project is the most efficient way to improve your discoverability. You should ask yourself what terms a developer is likely to type when looking for a solution that your library provides. Be precise. If your project is a collection of utilities the term `utils` is not much helpful but `time`, `duration`, `space`, `hashing` are.
+
+### Detailed readme
+
+A detailed readme is helpful but it is not required for good indexing.

--- a/doc/user/improve-visibility.md
+++ b/doc/user/improve-visibility.md
@@ -2,18 +2,28 @@
 
 As a library author or maintainer, the visibility of your project on Scaladex is under your control.
 
-As soon as a release is pushed to Maven Central (Sonatype), Scaladex downloads the latest content and metadata from the Github repository. It then uses those metadata to index the project.
+As soon as a release is pushed to Maven Central (Sonatype), Scaladex downloads the `pom.xml` from Maven Central and the repository metadata from Github. The following properties are taken into account by the search algorithm, with corresponding boost. The bigger is the boost, the more importance is attributed to the property.
+ 
 
-You can make it easier for the search engine to index your project by paying attention to the below details:
+| property                              | boost |
+| ------------------------------------- | --------- |
+| repository name on Github             | 6         |
+| repository organization on Github     | 5         |
+| repository description on Github      | 4         |
+| list of topics on Github              | 4         |
+| name of the artifacts in Maven Central| 2         |
+| project README on Github              | 0.5       |
+
+You can make it easier for a user to discover your project by paying attention to the below details:
 
 ### Meaningful Github description
 
-A good description is short but meaningful. keep in mind that those words are the first a user will read about your project.
+A good description is short but meaningful. keep in mind that those words are the first words a user will read about your project.
 
 ### Precise Github topics
 
-Carefully choosing the topics of your project is the most efficient way to improve your discoverability. You should ask yourself what terms a developer is likely to type when looking for a solution that your library provides. Be precise. If your project is a collection of utilities the term `utils` is not much helpful but `time`, `duration`, `space`, `hashing` are.
+Carefully choosing the topics of your project is the most efficient way to improve your discoverability. You should ask yourself what terms a developer is likely to type when looking for a solution that your library provides. Be precise. If your project is a collection of utilities the term `utils` is not much helpful but `time`, `duration`, `units`, `hashing` are.
 
-### Detailed readme
+### Detailed README
 
 A detailed readme is helpful but it is not required for good indexing.


### PR DESCRIPTION
This is just a markdown file in the `doc/user/` folder, for the moment. In the end, I think, this and all the user documentation should appear on the website under a help section. Something like https://pypi.org/help/