### PR TITLE
Upgrade to Scala.js 1.1.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 import Deployment.githash
 
-val playJsonVersion = "2.6.2"
+val playJsonVersion = "2.9.0"
 val akkaVersion = "2.5.3"
 val akkaHttpVersion = "10.0.11"
 val elastic4sVersion = "5.4.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 libraryDependencies += "com.typesafe" % "config" % "1.3.1"


### PR DESCRIPTION
Together with play-json 2.9.0, which requires a lock step upgrade, and sbt-scalajs-crossproject 1.0.0, for good measure.