### PR TITLE
Fix project update when indexing new artifact

### DIFF
--- a/search/src/main/scala/ch.epfl.scala.index.search/DataRepository.scala
+++ b/search/src/main/scala/ch.epfl.scala.index.search/DataRepository.scala
@@ -494,12 +494,12 @@ object DataRepository extends LazyLogging with SearchProtocol with ElasticDsl {
     new BulkResponse(Array.empty, 0)
   )
 
-  private val config =
+  private lazy val config =
     ConfigFactory.load().getConfig("org.scala_lang.index.data")
-  private val elasticsearch = config.getString("elasticsearch")
-  private val indexName = config.getString("index")
+  private lazy val elasticsearch = config.getString("elasticsearch")
+  private lazy val indexName = config.getString("index")
 
-  private val local =
+  private lazy val local =
     if (elasticsearch == "remote") false
     else if (elasticsearch == "local" || elasticsearch == "local-prod") true
     else


### PR DESCRIPTION
Fixes #626 
Fixes #627

The bug is:
- Scaladex receives a publish request of a maven artifact
- it creates the release object corresponding to this artifact
- it looks into an in-memory cache for other releases of the same project
- it builds the project object based on the cached and new releases
- it inserts the new release and update the project in elasticsearch
- it caches the new release

The problem is that the cache is empty after start-up, so the project is updated with a lot of missing metadata (list of artifacts, supported versions...)

This PR fixes the bug by:
- loading the owner project and all its releases from elasticsearch
- building the updated project based on the loaded releases

There is no cache anymore.