### PR TITLE
Fix #638: Add filters in the compatibility grid page.

### DIFF
--- a/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
+++ b/client/src/main/scala/ch.epfl.scala.index.client/Client.scala
@@ -226,4 +226,49 @@ object Client {
 
     CopyToClipboard.addCopyListenersOnClass("btn-copy")
   }
+
+  @JSExport
+  def updateVisibleArtifactsInGrid(): Unit = {
+    def valuesOfCheckedInputsWithName(name: String): Set[String] = {
+      jQuery(s"input[name='$name']")
+        .toArray()
+        .asInstanceOf[js.Array[HTMLInputElement]]
+        .filter(_.checked)
+        .map(_.value)
+        .toSet
+    }
+
+    val selectedTargetTypes = valuesOfCheckedInputsWithName("targetType")
+    val selectedTargets = valuesOfCheckedInputsWithName("target")
+    val allRequiredClasses = selectedTargetTypes ++ selectedTargets
+
+    jQuery(".artifact-line").each { (_, elem) =>
+      val supported = allRequiredClasses.forall(elem.classList.contains(_))
+
+      if (supported) {
+        elem.classList.remove("artifact-line-hidden")
+        elem.classList.add("artifact-line-visible")
+      } else {
+        elem.classList.remove("artifact-line-visible")
+        elem.classList.add("artifact-line-hidden")
+      }
+    }
+
+    jQuery(".version-line").each { (_, elem) =>
+      val supportedCount =
+        elem.querySelectorAll("tr.artifact-line-visible").length
+
+      val versionCell =
+        elem.querySelector("td.version").asInstanceOf[HTMLTableCellElement]
+      versionCell.rowSpan = supportedCount + 1
+
+      if (supportedCount != 0) {
+        elem.classList.remove("version-line-hidden")
+        elem.classList.add("version-line-visible")
+      } else {
+        elem.classList.remove("version-line-visible")
+        elem.classList.add("version-line-hidden")
+      }
+    }
+  }
 }

--- a/server/src/main/assets/css/main.scss
+++ b/server/src/main/assets/css/main.scss
@@ -15,7 +15,7 @@
     'vendors-extensions/bootstrap',
     'vendors-extensions/bootstrap-select';
 
-// 4. Base 
+// 4. Base
 @import
     'base/base';
 
@@ -24,4 +24,5 @@
     'partials/header',
     'partials/main',
     'partials/footer',
-    'partials/github';
+    'partials/github',
+    'partials/artifacts';

--- a/server/src/main/assets/css/partials/_artifacts.scss
+++ b/server/src/main/assets/css/partials/_artifacts.scss
@@ -1,0 +1,11 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles related to the 'artifacts' page.
+// -----------------------------------------------------------------------------
+
+.artifact-line-hidden {
+  display: none;
+}
+
+.version-line-hidden {
+  display: none;
+}

--- a/template/src/main/twirl/ch.epfl.scala.index.views/artifacts.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/artifacts.scala.html
@@ -10,9 +10,16 @@
 
 @main(title = project.repository, showSearch = true, user) {
   <main class="artifacts">
-    <a href="/@project.reference.organization/@project.reference.repository" class="btn btn-primary">
-      Back
-    </a>
+    <div class="row">
+      <div class="col-md-12">
+        <a href="/@project.reference.organization/@project.reference.repository" class="btn btn-primary">
+          Back
+        </a>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
 
     <table>
       <thead>
@@ -21,34 +28,59 @@
           <th rowspan="2" class="artifact">Artifacts</th>
 
           @for((targetType, count) <- targetTypes) {
-            <th colspan="@count">@targetType</th>
+            <th colspan="@count">
+              <label>
+                <input type="checkbox" name="targetType" value="supported-target-type_@targetType"
+                    onclick="ScaladexClient.updateVisibleArtifactsInGrid()">
+                @targetType
+              </label>
+            </th>
           }
         </tr>
 
         <tr>
-        @for((_, label) <- targets) {
-            <th class="target">@label</th>
+          @for((optTarget, name) <- targets) {
+            <th class="target">
+              <label>
+                <input type="checkbox" name="target" value="supported-target@(optTarget.fold("_none")(_.encode))"
+                    onclick="ScaladexClient.updateVisibleArtifactsInGrid()">
+                @name
+              </label>
+            </th>
           }
         </tr>
       </thead>
 
-      <tbody>
       @for((version, releasesByVersion) <- releases){
-        <tr>
+        <tbody class="version-line version-line-visible">
           @defining(releasesByVersion.groupBy(_.reference.artifact).toList.sortBy(_._1)) { artifacts =>
-            <td rowspan="@{artifacts.size + 1}" class="version">
-              @version
-            </td>
+            <tr>
+              <td rowspan="@{artifacts.size + 1}" class="version">
+                @version
+              </td>
+            </tr>
             @for((artifact, releasesByArtifact) <- artifacts) {
-              <tr>
-                <td class="artifact">
-                  @artifact
-                </td>
-                @defining(releasesByArtifact.groupBy(_.reference.target)) { suportedTargets =>
-
+              @defining(releasesByArtifact.groupBy(_.reference.target)) { supportedTargets =>
+                <tr class="@({
+                  val scalaTargets = supportedTargets.collect {
+                    case (Some(scalaTarget), _) => scalaTarget
+                  }.toList
+                  if (scalaTargets.isEmpty) {
+                    ""
+                  } else {
+                    "artifact-line artifact-line-visible" + (
+                      scalaTargets.map(_.targetType).distinct.map(" supported-target-type_" + _).mkString(" ")
+                    ) + (
+                      scalaTargets.map(_.encode).map(" supported-target" + _).mkString(" ")
+                    )
+                  }
+                })">
+                  <td class="artifact">
+                    @artifact
+                  </td>
                   @for((target, _) <- targets) {
                     <td class="target" title="@target.map(_.render).getOrElse("Java")">
-                    @for(release <- suportedTargets.get(target)) {
+                    @for(release <- supportedTargets.get(target)) {
                       @for(r0 <- release.headOption) {
                         <a href="@r0.reference.httpUrl" class="supported-target">
                         </a>
@@ -56,14 +88,21 @@
                     }
                     </td>
                   }
-                } 
-              </tr>
+                </tr>
+              }
             }
           }
-
-        </tr>
+        </tbody>
       }
-      </tbody>
     </table>
+
+      </div>
+    </div>
   </main>
+
+  <script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+    ScaladexClient.updateVisibleArtifactsInGrid();
+  })
+  </script>
 }


### PR DESCRIPTION
We add checkboxes in the header cells of the table. Only lines
that match all selected checkboxes will be displayed.

The filtering is done entirely on the client-side.

![image](https://user-images.githubusercontent.com/535934/98707525-6d366700-2380-11eb-82a4-c3ed7990a50a.png)
