### PR TITLE
Fix BinaryVersion ordering when patch version is empty

### DIFF
--- a/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
@@ -38,12 +38,12 @@ object BinaryVersion extends Parsers {
   import fastparse._
 
   implicit val ordering: Ordering[BinaryVersion] = Ordering.by {
-    case MajorBinary(major) => (major, None, None, None)
-    case MinorBinary(major, minor) => (major, Some(minor), None, None)
+    case MajorBinary(major)        => (major, None, 0, None)
+    case MinorBinary(major, minor) => (major, Some(minor), 0, None)
     case PatchBinary(major, minor, patch) =>
-      (major, Some(minor), Some(patch), None)
+      (major, Some(minor), patch, None)
     case PreReleaseBinary(major, minor, patch, preRelease) =>
-      (major, Some(minor), patch, Some(preRelease))
+      (major, Some(minor), patch.getOrElse(0), Some(preRelease))
   }
 
   def sortAndFilter(

--- a/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
@@ -38,7 +38,7 @@ object BinaryVersion extends Parsers {
   import fastparse._
 
   implicit val ordering: Ordering[BinaryVersion] = Ordering.by {
-    case MajorBinary(major)        => (major, None, 0, None)
+    case MajorBinary(major) => (major, None, 0, None)
     case MinorBinary(major, minor) => (major, Some(minor), 0, None)
     case PatchBinary(major, minor, patch) =>
       (major, Some(minor), patch, None)

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
@@ -38,6 +38,8 @@ class BinaryVersionTests
       (MajorBinary(1), MinorBinary(1, 1)), // 1.x < 1.1
       (MajorBinary(1), MinorBinary(2, 1)),
       (release.PreReleaseBinary(1, 2, None, Milestone(1)), MinorBinary(1, 2)),
+      (release.PreReleaseBinary(1, 2, Some(0), Milestone(1)),
+       MinorBinary(1, 2)),
       (MajorBinary(1), release.PreReleaseBinary(2, 0, None, Milestone(1)))
     )
 

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
@@ -38,8 +38,10 @@ class BinaryVersionTests
       (MajorBinary(1), MinorBinary(1, 1)), // 1.x < 1.1
       (MajorBinary(1), MinorBinary(2, 1)),
       (release.PreReleaseBinary(1, 2, None, Milestone(1)), MinorBinary(1, 2)),
-      (release.PreReleaseBinary(1, 2, Some(0), Milestone(1)),
-       MinorBinary(1, 2)),
+      (
+        release.PreReleaseBinary(1, 2, Some(0), Milestone(1)),
+        MinorBinary(1, 2)
+      ),
       (MajorBinary(1), release.PreReleaseBinary(2, 0, None, Milestone(1)))
     )
 


### PR DESCRIPTION
This PR fixes BinaryVersion ordering occurring when `PreReleaseBinaryVersion` containing patch version was compared with `BinaryVersion` not containing patch, eg.: 
```
assert(MinorBinary(0, 4) > PreReleaseBinary(0, 4, None, Milestone(2))) // success
assert(MinorBinary(0, 4) > PreReleaseBinary(0, 4, Some(0), Milestone(2))) // failure
```