### PR TITLE
Create Scaladex badge that supplies info on supported Scala versions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,6 +48,22 @@ read the [developer guide](/CONTRIBUTING.md)
 
 ## Badges API
 
+### Show the versions of Scala supported by your project!
+
+You can add this badge to the README.MD of your own GitHub projects to show
+the versions of Scala they support:
+
+[![Scala version Badge](https://index.scala-lang.org/typelevel/cats/cats-core/latest-by-scala-version.svg)
+
+...the badge above only summarises latest JVM artifacts, if you'd like a badge
+for  Scala JS or Scala Native, add a `targetType=...` query-string parameter:
+
+[![Scala version Badge](https://index.scala-lang.org/typelevel/cats/cats-core/latest-by-scala-version.svg?targetType=js)
+
+[![Scala version Badge](https://index.scala-lang.org/typelevel/cats/cats-core/latest-by-scala-version.svg?targetType=native)
+
+### Smaller, shorter badges
+
 [![Count Badge](https://index.scala-lang.org/count.svg?q=depends-on:typelevel/cats&subject=cats&color=orange&style=flat-square)](https://index.scala-lang.org/search?q=dependencies:typelevel/cats)
 
 [![Latest version](https://index.scala-lang.org/typelevel/cats/cats-core/latest.svg?color=orange&style=flat-square)](https://index.scala-lang.org/typelevel/cats/cats-core)

--- a/data/src/main/scala/ch.epfl.scala.index.data/central/CentralMissing.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/central/CentralMissing.scala
@@ -17,12 +17,15 @@ import ch.epfl.scala.index.data.maven.PomsReader
 import ch.epfl.scala.index.data.project.ArtifactMetaExtractor
 import ch.epfl.scala.index.model.misc.Sha1
 import ch.epfl.scala.index.model.release.{
+  Js,
   MinorBinary,
+  Native,
+  Sbt,
   SbtPlugin,
-  ScalaVersion,
   ScalaJs,
   ScalaJvm,
-  ScalaNative
+  ScalaNative,
+  ScalaVersion
 }
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport._
 import org.joda.time.DateTime
@@ -257,23 +260,18 @@ class CentralMissing(paths: DataPaths)(implicit val system: ActorSystem) {
         .flatten
         .toSet
 
-    val sbt013 = MinorBinary(0, 13)
-    val sbt10 = MinorBinary(1, 0)
-    val scalaJs06 = MinorBinary(0, 6)
-    val native03 = MinorBinary(0, 3)
-
     val allTargets = List(
       ScalaJvm(ScalaVersion.`2.13`),
       ScalaJvm(ScalaVersion.`2.12`),
       ScalaJvm(ScalaVersion.`2.11`),
       ScalaJvm(ScalaVersion.`2.10`),
-      SbtPlugin(ScalaVersion.`2.10`, sbt013),
-      SbtPlugin(ScalaVersion.`2.12`, sbt10),
-      ScalaJs(ScalaVersion.`2.13`, scalaJs06),
-      ScalaJs(ScalaVersion.`2.12`, scalaJs06),
-      ScalaJs(ScalaVersion.`2.11`, scalaJs06),
-      ScalaJs(ScalaVersion.`2.10`, scalaJs06),
-      ScalaNative(ScalaVersion.`2.11`, native03)
+      SbtPlugin(ScalaVersion.`2.10`, Sbt.`0.13`),
+      SbtPlugin(ScalaVersion.`2.12`, Sbt.`1.0`),
+      ScalaJs(ScalaVersion.`2.13`, Js.`0.6`),
+      ScalaJs(ScalaVersion.`2.12`, Js.`0.6`),
+      ScalaJs(ScalaVersion.`2.11`, Js.`0.6`),
+      ScalaJs(ScalaVersion.`2.10`, Js.`0.6`),
+      ScalaNative(ScalaVersion.`2.11`, Native.`0.3`)
     )
 
     val releasesDownloads =

--- a/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/Project.scala
@@ -1,14 +1,17 @@
 package ch.epfl.scala.index.model
 
 import ch.epfl.scala.index.model.release.{
+  BinaryVersion,
+  Js,
+  LanguageVersion,
+  Native,
+  Sbt,
   SbtPlugin,
   ScalaJs,
   ScalaJvm,
   ScalaNative
 }
 import misc.{GithubInfo, GithubRepo, Url}
-import ch.epfl.scala.index.model.release.LanguageVersion
-import ch.epfl.scala.index.model.release.BinaryVersion
 
 /**
  * Project representation which contains all necessary meta data to
@@ -76,12 +79,11 @@ case class Project(
       id = None,
       scalaVersion = LanguageVersion.sortFamilies(scalaVersion),
       scalaJsVersion =
-        BinaryVersion.sortAndFilter(scalaJsVersion, ScalaJs.isValid).toList,
+        BinaryVersion.sortAndFilter(scalaJsVersion, Js.isValid).toList,
       scalaNativeVersion = BinaryVersion
-        .sortAndFilter(scalaNativeVersion, ScalaNative.isValid)
+        .sortAndFilter(scalaNativeVersion, Native.isValid)
         .toList,
-      sbtVersion =
-        BinaryVersion.sortAndFilter(sbtVersion, SbtPlugin.isValid).toList
+      sbtVersion = BinaryVersion.sortAndFilter(sbtVersion, Sbt.isValid).toList
     )
   }
 

--- a/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
@@ -9,6 +9,7 @@ import fastparse._
  * It can be either a [[ScalaVersion]] or a [[Scala3Version]]
  */
 sealed trait LanguageVersion {
+  val version: BinaryVersion
 
   /**
    * When indexing, all dotty versions are regrouped under the 'dotty' keyword.

--- a/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
@@ -10,6 +10,8 @@ object ScalaTargetType {
 
   implicit val ordering: Ordering[ScalaTargetType] = Ordering.by(All.indexOf(_))
 
+  def ofName(name: String): Option[ScalaTargetType] =
+    All.find(_.getClass.getSimpleName.stripSuffix("$").equalsIgnoreCase(name))
 }
 
 sealed trait ScalaTargetType

--- a/model/src/test/scala/ch.epfl.scala.index.model/ArtifactTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/ArtifactTests.scala
@@ -9,10 +9,7 @@ class ArtifactTests extends FunSpec with Matchers {
       Artifact.parse("cats-core_sjs0.6_2.11") should contain(
         Artifact(
           "cats-core",
-          ScalaJs(
-            languageVersion = ScalaVersion.`2.11`,
-            scalaJsVersion = MinorBinary(0, 6)
-          )
+          ScalaJs(ScalaVersion.`2.11`, Js.`0.6`)
         )
       )
     }
@@ -21,10 +18,7 @@ class ArtifactTests extends FunSpec with Matchers {
       Artifact.parse("cats-core_native0.1_2.11") should contain(
         Artifact(
           "cats-core",
-          ScalaNative(
-            languageVersion = ScalaVersion.`2.11`,
-            scalaNativeVersion = MinorBinary(0, 1)
-          )
+          ScalaNative(ScalaVersion.`2.11`, MinorBinary(0, 1))
         )
       )
     }
@@ -51,15 +45,12 @@ class ArtifactTests extends FunSpec with Matchers {
       Artifact.parse("sbt-microsites_2.12_1.0") should contain(
         Artifact(
           "sbt-microsites",
-          SbtPlugin(
-            languageVersion = ScalaVersion.`2.12`,
-            sbtVersion = MinorBinary(1, 0)
-          )
+          SbtPlugin(ScalaVersion.`2.12`, Sbt.`1.0`)
         )
       )
     }
 
-    it("does not parse unconventionnal") {
+    it("does not parse unconventional") {
       Artifact.parse("sparrow") shouldBe empty
     }
 

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/SbtInstallTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/SbtInstallTests.scala
@@ -73,12 +73,7 @@ class SbtInstallTests extends FunSuite with TestHelpers {
         artifactId = "scalajs-dom_sjs0.6_2.12",
         version = "0.9.3",
         artifactName = "scalajs-dom",
-        target = Some(
-          ScalaJs(
-            languageVersion = ScalaVersion.`2.12`,
-            scalaJsVersion = MinorBinary(0, 6)
-          )
-        )
+        target = Some(ScalaJs(ScalaVersion.`2.12`, Js.`0.6`))
       ).sbtInstall
 
     val expected =
@@ -94,12 +89,7 @@ class SbtInstallTests extends FunSuite with TestHelpers {
         artifactId = "sbt-native-packager_2.10_0.13",
         version = "1.2.2",
         artifactName = "sbt-native-packager",
-        target = Some(
-          SbtPlugin(
-            languageVersion = ScalaVersion.`2.10`,
-            sbtVersion = MinorBinary(0, 13)
-          )
-        )
+        target = Some(SbtPlugin(ScalaVersion.`2.10`, Sbt.`0.13`))
       ).sbtInstall
 
     val expected =

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/ScalaTargetTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/ScalaTargetTests.scala
@@ -7,6 +7,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 class ScalaTargetTests
     extends FunSpec
     with Matchers
+    with OptionValues
     with TableDrivenPropertyChecks {
   it("should be ordered") {
     val js067 = PatchBinary(0, 6, 7)
@@ -50,5 +51,10 @@ class ScalaTargetTests
     forAll(cases) { (input, target) =>
       ScalaTarget.parse(input) should contain(target)
     }
+  }
+
+  it("should parse a string to yield a ScalaTargetType") {
+    ScalaTargetType.ofName("Js").value shouldBe Js
+    ScalaTargetType.ofName("Jvm").value shouldBe Jvm
   }
 }

--- a/search/src/main/scala/ch.epfl.scala.index.search/DataRepository.scala
+++ b/search/src/main/scala/ch.epfl.scala.index.search/DataRepository.scala
@@ -425,14 +425,14 @@ class DataRepository(
   }
 
   def getAllScalaJsVersions(): Future[List[(String, Long)]] = {
-    versionAggregations("scalaJsVersion", notDeprecatedQuery, ScalaJs.isValid)
+    versionAggregations("scalaJsVersion", notDeprecatedQuery, Js.isValid)
   }
 
   def getScalaJsVersions(params: SearchParams): Future[List[(String, Long)]] = {
     versionAggregations(
       "scalaJsVersion",
       filteredSearchQuery(params),
-      ScalaJs.isValid
+      Js.isValid
     )
       .map(addLabelsIfMissing(params.scalaJsVersions.toSet))
   }
@@ -441,7 +441,7 @@ class DataRepository(
     versionAggregations(
       "scalaNativeVersion",
       notDeprecatedQuery,
-      ScalaNative.isValid
+      Native.isValid
     )
   }
 
@@ -451,19 +451,19 @@ class DataRepository(
     versionAggregations(
       "scalaNativeVersion",
       filteredSearchQuery(params),
-      ScalaNative.isValid
+      Native.isValid
     ).map(addLabelsIfMissing(params.scalaNativeVersions.toSet))
   }
 
   def getAllSbtVersions(): Future[List[(String, Long)]] = {
-    versionAggregations("sbtVersion", notDeprecatedQuery, SbtPlugin.isValid)
+    versionAggregations("sbtVersion", notDeprecatedQuery, Sbt.isValid)
   }
 
   def getSbtVersions(params: SearchParams): Future[List[(String, Long)]] = {
     versionAggregations(
       "sbtVersion",
       filteredSearchQuery(params),
-      SbtPlugin.isValid
+      Sbt.isValid
     )
       .map(addLabelsIfMissing(params.sbtVersions.toSet))
   }

--- a/server/src/main/scala/ch.epfl.scala.index.server/ArtifactScalaVersionSupport.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/ArtifactScalaVersionSupport.scala
@@ -1,0 +1,113 @@
+package ch.epfl.scala.index.server
+
+import ch.epfl.scala.index.model.{Release, SemanticVersion}
+import ch.epfl.scala.index.model.release._
+import ch.epfl.scala.index.server.ArtifactScalaVersionSupport.ScalaSupport
+
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+case class ArtifactScalaVersionSupport(
+    scalaTargetsForAllArtifactVersions: Map[SemanticVersion, Seq[ScalaTarget]]
+) {
+
+  val allTargets: Set[ScalaTarget] =
+    scalaTargetsForAllArtifactVersions.values.flatten.toSet
+
+  val latestScalaVersionsOfAvailableBinaryVersions: Set[LanguageVersion] =
+    allTargets
+      .map(_.languageVersion)
+      .groupBy(_.family)
+      .view
+      .mapValues(_.max)
+      .values
+      .toSet
+
+  val latestArtifactVersionByLanguageVersion
+      : Map[LanguageVersion, SemanticVersion] = (for {
+    (artifactVersion, scalaTargets) <- scalaTargetsForAllArtifactVersions.toSeq
+    scalaTarget <- scalaTargets
+    if latestScalaVersionsOfAvailableBinaryVersions.contains(
+      scalaTarget.languageVersion
+    )
+  } yield scalaTarget.languageVersion -> artifactVersion)
+    .groupMap(_._1)(_._2)
+    .view
+    .mapValues(_.max)
+    .toMap
+
+  val scalaSupportByLatestSupportingArtifactVersion
+      : SortedMap[SemanticVersion, ScalaSupport] =
+    SortedMap.from(
+      latestArtifactVersionByLanguageVersion.groupMap(_._2)(_._1).view.map {
+        case (artifactVersion, notableLanguageVersions) =>
+          val notableLanguageVersionsSet = notableLanguageVersions.toSet
+          artifactVersion -> ScalaSupport(
+            scalaTargetsForAllArtifactVersions(artifactVersion)
+              .filter(st => notableLanguageVersionsSet(st.languageVersion))
+              .toSet
+          )
+      }
+    )(SemanticVersion.ordering.reverse)
+
+  val summaryOfLatestArtifactsSupportingScalaVersions: String = (for (
+    (artifactVersion, scalaSupport) <-
+      scalaSupportByLatestSupportingArtifactVersion
+  ) yield s"$artifactVersion (${scalaSupport.summary})").mkString(", ")
+}
+
+object ArtifactScalaVersionSupport {
+  def forSpecifiedArtifactAndTargetType(
+      allAvailableReleases: Seq[Release],
+      specificArtifact: String,
+      specificTargetType: ScalaTargetType
+  ): ArtifactScalaVersionSupport = {
+
+    val scalaTargetsByArtifactVersion = (for {
+      release <- allAvailableReleases if release.isValid
+      ref = release.reference if ref.artifact == specificArtifact
+      scalaTarget <- ref.target if scalaTarget.targetType == specificTargetType
+    } yield ref.version -> scalaTarget).groupMap(_._1)(_._2)
+
+    ArtifactScalaVersionSupport(scalaTargetsByArtifactVersion)
+  }
+
+  case class ScalaSupport(
+      scalaTargets: Set[ScalaTarget]
+  ) {
+    val scalaTargetsByLanguageVersion: Map[LanguageVersion, Set[ScalaTarget]] =
+      scalaTargets.groupBy(_.languageVersion)
+
+    val languageVersions: SortedSet[LanguageVersion] =
+      SortedSet.from(scalaTargetsByLanguageVersion.keySet)(
+        LanguageVersion.ordering.reverse
+      )
+
+    val platformEditionsSupportedForAllLanguageVersions: Set[PlatformEdition] =
+      scalaTargetsByLanguageVersion.values
+        .map(_.collect { case st: ScalaTargetWithPlatformBinaryVersion =>
+          st.platformEdition
+        })
+        .reduce(_ & _)
+
+    val platformBinaryVersionsByTargetType
+        : SortedMap[ScalaTargetType, SortedSet[BinaryVersion]] =
+      SortedMap.from(
+        platformEditionsSupportedForAllLanguageVersions
+          .groupMap(_.targetType)(_.version)
+          .view
+          .mapValues(SortedSet.from(_)(BinaryVersion.ordering.reverse))
+      )
+
+    val targetsSummary: Option[String] =
+      Option.when(platformBinaryVersionsByTargetType.nonEmpty)(
+        " - " + platformBinaryVersionsByTargetType
+          .map { case (targetType, platformBinaryVersions) =>
+            s"$targetType ${platformBinaryVersions.mkString("+")}"
+          }
+          .mkString(", ")
+      )
+
+    val summary: String =
+      s"Scala ${languageVersions.mkString(", ")}${targetsSummary.mkString}"
+  }
+}

--- a/server/src/test/scala/ch.epfl.scala.index.server/ArtifactScalaVersionSupportTest.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/ArtifactScalaVersionSupportTest.scala
@@ -1,0 +1,128 @@
+package ch.epfl.scala.index.server
+
+import ch.epfl.scala.index.model.release.ScalaVersion._
+import ch.epfl.scala.index.model.release.{
+  Js,
+  LanguageVersion,
+  Native,
+  PreReleaseBinary,
+  Scala3Version,
+  ScalaJs,
+  ScalaJvm,
+  ScalaNative
+}
+import ch.epfl.scala.index.model.{Milestone, ReleaseCandidate, SemanticVersion}
+import org.apache.commons.lang3.StringUtils.countMatches
+import org.scalatest.{FunSpec, Matchers}
+
+class ArtifactScalaVersionSupportTest extends FunSpec with Matchers {
+
+  val `3.0.0-M3`: LanguageVersion = Scala3Version(
+    PreReleaseBinary(3, 0, Some(0), Milestone(3))
+  )
+  val `3.0.0-RC2`: LanguageVersion = Scala3Version(
+    PreReleaseBinary(3, 0, Some(0), ReleaseCandidate(2))
+  )
+  val `3.0.0-RC3`: LanguageVersion = Scala3Version(
+    PreReleaseBinary(3, 0, Some(0), ReleaseCandidate(3))
+  )
+
+  val `7.0.0`: SemanticVersion = SemanticVersion(7, 0, 0)
+  val `7.1.0`: SemanticVersion = SemanticVersion(7, 1, 0)
+  val `7.2.0`: SemanticVersion = SemanticVersion(7, 2, 0)
+  val `7.3.0`: SemanticVersion = SemanticVersion(7, 3, 0)
+
+  it("should provide a concise summary of Scala support by the artifact") {
+    ArtifactScalaVersionSupport(
+      Map(
+        `7.0.0` -> Seq(ScalaJvm(`2.11`)),
+        `7.1.0` -> Seq(ScalaJvm(`2.11`), ScalaJvm(`2.12`)),
+        `7.2.0` -> Seq(ScalaJvm(`2.12`), ScalaJvm(`2.13`))
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions shouldBe "7.2.0 (Scala 2.13, 2.12), 7.1.0 (Scala 2.11)"
+  }
+
+  it(
+    "should concisely convey which versions of Scala are supported, most recent Scala version first"
+  ) {
+    ArtifactScalaVersionSupport(
+      Map(
+        `7.0.0` -> Seq(
+          ScalaJvm(`2.12`),
+          ScalaJvm(`2.13`),
+          ScalaJvm(`3.0.0-RC3`)
+        )
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions should include(
+      "Scala 3.0.0-RC3, 2.13, 2.12"
+    )
+  }
+
+  it(
+    "should convey the latest artifact version available for each Scala language version"
+  ) {
+    val summary = ArtifactScalaVersionSupport(
+      Map(
+        `7.0.0` -> Seq(ScalaJvm(`2.11`)),
+        `7.1.0` -> Seq(ScalaJvm(`2.11`)),
+        `7.2.0` -> Seq(ScalaJvm(`2.12`)),
+        `7.3.0` -> Seq(ScalaJvm(`2.12`))
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions
+
+    // these artifact versions are not the latest available support for any Scala language version, so uninteresting:
+    summary should not(include("7.0.0") or include("7.2.0"))
+
+    summary should include("7.1.0 (Scala 2.11)")
+    summary should include("7.3.0 (Scala 2.12)")
+  }
+
+  it(
+    "should, for brevity, not mention a Scala language version more than once, even if it occurs in multiple artifact versions being mentioned"
+  ) {
+    val summary = ArtifactScalaVersionSupport(
+      Map(
+        `7.1.0` -> Seq(ScalaJvm(`2.11`), ScalaJvm(`2.12`)),
+        `7.2.0` -> Seq(ScalaJvm(`2.12`))
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions
+
+    // it happens that two artifact versions that support Scala 2.12 will be mentioned...
+    assert(summary.contains("7.1.0") && summary.contains("7.2.0"))
+
+    // ...but for brevity no Scala language version (eg Scala 2.12 in this case) should be mentioned more than once...
+    countMatches(summary, "2.12") shouldBe 1
+
+    // ...specifically it should be listed  against the *latest* artifact that supports that Scala language version
+    summary should include("7.2.0 (Scala 2.12)")
+  }
+
+  it(
+    "should, for brevity, only mention the *latest* Scala language versions available for any given Scala binary version family"
+  ) {
+    ArtifactScalaVersionSupport(
+      Map(
+        `7.0.0` -> Seq(ScalaJvm(`2.13`), ScalaJvm(`3.0.0-M3`)),
+        `7.1.0` -> Seq(ScalaJvm(`2.13`), ScalaJvm(`3.0.0-RC2`)),
+        `7.2.0` -> Seq(ScalaJvm(`2.13`), ScalaJvm(`3.0.0-RC3`))
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions shouldBe "7.2.0 (Scala 3.0.0-RC3, 2.13)"
+  }
+
+  it(
+    "should list the Scala platform editions that support all cited versions of the Scala language"
+  ) {
+    ArtifactScalaVersionSupport(
+      Map(
+        `7.1.0` -> Seq(
+          ScalaNative(`3.0.0-M3`, Native.`0.3`),
+          ScalaNative(`2.13`, Native.`0.3`),
+          ScalaNative(`3.0.0-M3`, Native.`0.4`),
+          ScalaNative(`2.13`, Native.`0.4`)
+        )
+      )
+    ).summaryOfLatestArtifactsSupportingScalaVersions shouldBe "7.1.0 (Scala 3.0.0-M3, 2.13 - Native 0.4+0.3)"
+
+  }
+
+}

--- a/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/RelevanceTest.scala
@@ -6,11 +6,13 @@ import build.info.BuildInfo
 import model.{Project, SemanticVersion}
 import model.misc.SearchParams
 import model.release.{
+  Js,
   MinorBinary,
-  ScalaVersion,
+  Native,
   ScalaJs,
   ScalaNative,
-  ScalaTarget
+  ScalaTarget,
+  ScalaVersion
 }
 import data.elastic._
 import data.github.GithubDownload
@@ -110,11 +112,7 @@ class RelevanceTest
   }
 
   test("Scala.js targetFiltering") {
-    val scalaJs =
-      ScalaJs(
-        languageVersion = ScalaVersion.`2.12`,
-        scalaJsVersion = MinorBinary(0, 6)
-      )
+    val scalaJs = ScalaJs(ScalaVersion.`2.12`, Js.`0.6`)
 
     top(
       SearchParams(targetFiltering = Some(scalaJs)),
@@ -125,11 +123,7 @@ class RelevanceTest
   }
 
   test("Scala.js targetFiltering (2)") {
-    val scalaJs =
-      ScalaJs(
-        languageVersion = ScalaVersion.`2.12`,
-        scalaJsVersion = MinorBinary(0, 6)
-      )
+    val scalaJs = ScalaJs(ScalaVersion.`2.12`, Js.`0.6`)
 
     compare(
       SearchParams(targetFiltering = Some(scalaJs)),
@@ -151,11 +145,7 @@ class RelevanceTest
   }
 
   test("Scala Native targetFiltering") {
-    val scalaNative =
-      ScalaNative(
-        languageVersion = ScalaVersion.`2.11`,
-        scalaNativeVersion = MinorBinary(0, 3)
-      )
+    val scalaNative = ScalaNative(ScalaVersion.`2.11`, Native.`0.3`)
 
     top(
       SearchParams(targetFiltering = Some(scalaNative)),


### PR DESCRIPTION
Fixes #659 - adding support for a badge that summarises, for a given artifact, which versions of Scala it supports (and what the latest artifact version is for each of those Scala versions).

```
$ curl --silent -I http://localhost:8080/typelevel/cats/cats-core/latest-by-scala-version.svg | grep Location
Location: https://img.shields.io/badge/cats--core-0.9.0_(Scala_2.12,_2.11,_2.10)-green.svg?
```

...on my local box (with a minimal Scaladex elasticsearch index) this renders like this ![Badge](https://img.shields.io/badge/cats--core-0.9.0_(Scala_2.12,_2.11,_2.10)-green.svg)

### Scala JS & Scala Native

By default, the badge summarises just Scala JVM artifacts, but it's easy to create platform-specific badges by adding `targetType=js` or `targetType=native` as a query-string parameter to the url:

```
$ curl --silent -I http://localhost:8080/typelevel/cats/cats-core/latest-by-scala-version.svg?targetType=js | grep Location
Location: https://img.shields.io/badge/cats--core-0.9.0_(Scala_2.12,_2.11,_2.10_--_Js_0.6)-green.svg?
```

### Refactor & Implementation

This PR is split into 2 commits:

1. A refactor of `ScalaTargetType` & `ScalaTarget` to make grouping by 'platform edition' (eg 'Scala JS 1.x') easier (see commit message for more detail on that), which had the side benefit of reducing existing code duplication. The `ScalaTarget` classes are still successfully deserialised from Elasticsearch- I haven't modified them to the point of breaking that!
2. Implementation of the badge, introducing `ArtifactScalaVersionSupport` to do all the grouping operations to give a concise summary of Scala version support for a given artifact. The accompanying tests in `ArtifactScalaVersionSupportTest` detail & test some of the desired behaviour of the badge summary text.

cc @adpi2 