### PR TITLE
Ensure web assets are available when running Scaladex locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,9 @@ lazy val server = project
       .dependsOn(Assets / WebKeys.assets)
       .value,
     Test / test := (Test / test).dependsOn(startElasticsearch).value,
-    reStart := reStart.dependsOn(startElasticsearch).evaluated,
+    reStart := reStart
+      .dependsOn(startElasticsearch, Assets / WebKeys.assets)
+      .evaluated,
     Compile / run := (Compile / run).dependsOn(startElasticsearch).evaluated,
     Compile / unmanagedResourceDirectories += (Assets / WebKeys.public).value,
     reStart / javaOptions ++= Seq("-Xmx4g")


### PR DESCRIPTION
Fixes a small problem introduced with PR #663 -  see https://github.com/scalacenter/scaladex/pull/663#pullrequestreview-660215509 for more details!
