### PR TITLE
Attempt to fix issue #664: parse artifacts for Scala 3 final

### DIFF
--- a/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
@@ -37,6 +37,7 @@ final case class ScalaVersion(version: BinaryVersion) extends LanguageVersion {
 final case class Scala3Version(version: BinaryVersion) extends LanguageVersion {
   def family = "scala3"
   def render: String = version match {
+    case MajorBinary(major) => s"scala $major"
     case MinorBinary(major, minor) if major == 0 && minor < 30 =>
       s"dotty $version"
     case PreReleaseBinary(major, _, _, _) if major == 3 => s"scala $toString"

--- a/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/LanguageVersion.scala
@@ -66,9 +66,12 @@ object ScalaVersion {
 }
 
 object Scala3Version {
+  val `3`: Scala3Version = Scala3Version(MajorBinary(3))
+
   def isValid(version: BinaryVersion): Boolean =
     version match {
-      case PreReleaseBinary(major, _, _, _) if major == 3 => true
+      case MajorBinary(3) => true
+      case PreReleaseBinary(3, _, _, _) => true
       case _ => false
     }
 

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/ScalaTargetTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/ScalaTargetTests.scala
@@ -45,6 +45,7 @@ class ScalaTargetTests
     val cases = Table(
       ("input", "target"),
       ("_2.12", ScalaJvm(ScalaVersion.`2.12`)),
+      ("_3", ScalaJvm(Scala3Version.`3`)),
       ("_sjs0.6_2.12", ScalaJs(ScalaVersion.`2.12`, MinorBinary(0, 6)))
     )
 


### PR DESCRIPTION
See https://github.com/scalacenter/scaladex/issues/664 - Scala 3 was officially released on Friday 14th May 2021, with the 3.0.0 final release arriving on Maven Central on the prior day. Scala libraries built with Scala 3.0.0 final now have just the Scala major version number (ie `_3`) as their Scala language-version binary family qualifier, rather than the fully qualified version that was used pre-release (eg `_3.0.0-RC3`), or the major-minor version that was used with Scala 2 (eg `_2.13`).

So the maven artifact name (eg for an artifact called `scala-collection-plus`, at version 0.9) will now look like this:

```
scala-collection-plus_3-0.9.jar
```

Scaladex didn't have code to parse this new 'major-only' version string, so new artifacts released for Scala 3 final were not showing up in the Scaladex.

The fix in this commit should hopefully fix the issue going forward, though as an outside developer, I'm really not sure how updates get into Scaladex's elasticsearch instance, and I think there might have to be some kind of backfill? I only have the old snapshot in https://github.com/scalacenter/scaladex-small-index to go on, which was pre-Scala 3, so this fix was, to an extent, developed in the dark!

cc @julienrf 