### PR TITLE
Fix binary version ordering

### DIFF
--- a/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/BinaryVersion.scala
@@ -1,6 +1,7 @@
 package ch.epfl.scala.index.model.release
 
 import ch.epfl.scala.index.model.{Parsers, PreRelease}
+import ch.epfl.scala.index.model.ReleaseCandidate
 
 sealed trait BinaryVersion extends Ordered[BinaryVersion] {
   override def compare(that: BinaryVersion): Int = {
@@ -38,12 +39,14 @@ object BinaryVersion extends Parsers {
   import fastparse._
 
   implicit val ordering: Ordering[BinaryVersion] = Ordering.by {
-    case MajorBinary(major) => (major, None, 0, None)
-    case MinorBinary(major, minor) => (major, Some(minor), 0, None)
+    case MajorBinary(major) =>
+      (major, Int.MaxValue, Int.MaxValue, None)
+    case MinorBinary(major, minor) =>
+      (major, minor, Int.MaxValue, None)
     case PatchBinary(major, minor, patch) =>
-      (major, Some(minor), patch, None)
+      (major, minor, patch, None)
     case PreReleaseBinary(major, minor, patch, preRelease) =>
-      (major, Some(minor), patch.getOrElse(0), Some(preRelease))
+      (major, minor, patch.getOrElse(Int.MaxValue), Some(preRelease))
   }
 
   def sortAndFilter(

--- a/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
+++ b/model/src/test/scala/ch.epfl.scala.index.model/release/BinaryVersionTests.scala
@@ -35,7 +35,7 @@ class BinaryVersionTests
     val inputs = Table[BinaryVersion, BinaryVersion](
       ("lower", "higher"),
       (MajorBinary(1), MajorBinary(2)),
-      (MajorBinary(1), MinorBinary(1, 1)), // 1.x < 1.1
+      (MinorBinary(1, 1), MajorBinary(1)),
       (MajorBinary(1), MinorBinary(2, 1)),
       (release.PreReleaseBinary(1, 2, None, Milestone(1)), MinorBinary(1, 2)),
       (


### PR DESCRIPTION
`Scala 3` should appear before `Scala 3.0.0-RC3`.
It entails that `MajorBinary(3) > PreReleaseBinary(3, 0, Some(0), ReleaseCandidate(3))`

More generally:
`MajorBinary(3) > MinorBinary(3, x) > PatchBinary(3, x, y) > PreReleaseBinary(3, x, y, z)`