### PR TITLE
Add logs about unindexed artifacts

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/central/CentralMissing.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/central/CentralMissing.scala
@@ -188,13 +188,14 @@ class CentralMissing(paths: DataPaths)(implicit val system: ActorSystem) {
 
   // data/run central /home/gui/scaladex/scaladex-contrib /home/gui/scaladex/scaladex-index /home/gui/scaladex/scaladex-credentials
   def run(): Unit = {
-    val artifactMetaExtractor = new ArtifactMetaExtractor(paths)
+    val metaExtractor = new ArtifactMetaExtractor(paths)
     val allGroups: Set[String] =
       PomsReader(LocalPomRepository.MavenCentral, paths)
         .load()
         .flatMap {
           case Success((pom, _, _)) =>
-            artifactMetaExtractor(pom)
+            metaExtractor
+              .extractMeta(pom)
               .filter { meta =>
                 meta.scalaTarget.isDefined && !meta.isNonStandard
               }

--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ArtifactMetaExtractor.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ArtifactMetaExtractor.scala
@@ -32,7 +32,7 @@ class ArtifactMetaExtractor(paths: DataPaths) {
    *
    * @return The artifact name (without suffix), the Scala target, whether this project is a usual Scala library or not
    */
-  def apply(pom: ReleaseModel): Option[ArtifactMeta] = {
+  def extractMeta(pom: ReleaseModel): Option[ArtifactMeta] = {
     val nonStandardLookup =
       nonStandardLibs
         .find(lib =>

--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ProjectConvert.scala
@@ -20,7 +20,7 @@ class ProjectConvert(paths: DataPaths, githubDownload: GithubDownload)
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val artifactMetaExtractor = new ArtifactMetaExtractor(paths)
+  private val metaExtractor = new ArtifactMetaExtractor(paths)
 
   /**
    * @param pomsRepoSha poms and associated meta information reference
@@ -34,10 +34,10 @@ class ProjectConvert(paths: DataPaths, githubDownload: GithubDownload)
     val githubRepoExtractor = new GithubRepoExtractor(paths)
 
     log.info("Collecting Metadata")
-    val pomsAndMetaClean = PomMeta(pomsRepoSha, paths).flatMap {
+    val pomsAndMetaClean = PomMeta.all(pomsRepoSha, paths).flatMap {
       case PomMeta(pom, created, resolver) =>
         for {
-          artifactMeta <- artifactMetaExtractor(pom)
+          artifactMeta <- metaExtractor.extractMeta(pom)
           version <- SemanticVersion.tryParse(pom.version)
           github <- githubRepoExtractor(pom)
         } yield (


### PR DESCRIPTION
It often happens that an new artifact, pushed by Sonatype, is saved but not indexed, often because the binary version is not recognized or not valid anymore.

Previously a  `NoSuchElementException` was thrown and logged. In this PR we replace the exception by an info log explaining the reason the artifact is not indexed.