### PR TITLE
Better support for sbt artifacts in the Scaladex badge

### DIFF
--- a/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
@@ -33,6 +33,8 @@ case class PlatformAndLanguageVersions(
 sealed trait PlatformVersionedTargetType extends ScalaTargetType {
   def encode(platformAndLanguageVersions: PlatformAndLanguageVersions): String
   val platformId: String
+  val shortName: String
+  val platformVersionDeterminesScalaVersion: Boolean = false
   val stableBinaryVersions: Set[BinaryVersion]
   def isValid(version: BinaryVersion): Boolean =
     stableBinaryVersions.contains(version)
@@ -40,6 +42,7 @@ sealed trait PlatformVersionedTargetType extends ScalaTargetType {
 }
 case object Js extends PlatformVersionedTargetType {
   val platformId = "scala-js"
+  val shortName = "JS"
   def encode(versions: PlatformAndLanguageVersions) =
     s"_sjs${versions.platform}_${versions.language}"
 
@@ -56,6 +59,7 @@ case object Js extends PlatformVersionedTargetType {
 }
 case object Native extends PlatformVersionedTargetType {
   val platformId = "scala-native"
+  val shortName = "Native"
   def encode(versions: PlatformAndLanguageVersions) =
     s"_native${versions.platform}_${versions.language}"
   val `0.3`: BinaryVersion = MinorBinary(0, 3)
@@ -72,6 +76,8 @@ case object Native extends PlatformVersionedTargetType {
 case object Java extends ScalaTargetType
 case object Sbt extends PlatformVersionedTargetType {
   val platformId = "sbt"
+  val shortName = "sbt"
+  override val platformVersionDeterminesScalaVersion = true
   def encode(versions: PlatformAndLanguageVersions) =
     s"_${versions.language}_${versions.platform}"
 

--- a/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
@@ -10,93 +10,203 @@ object BadgesSupport {
       allAvailableReleases: Seq[Release],
       specificArtifact: String,
       specificTargetType: ScalaTargetType
-  ): String = summaryOfLatestVersions((for {
-    release <- allAvailableReleases if release.isValid
-    ref = release.reference if ref.artifact == specificArtifact
-    scalaTarget <- ref.target if scalaTarget.targetType == specificTargetType
-  } yield ref.version -> scalaTarget).groupMap(_._1)(_._2))
-
-  def summaryOfLatestVersions(
-      scalaTargetsByArtifactVersion: Map[SemanticVersion, Seq[ScalaTarget]]
-  ): String = {
-    val allTargets = scalaTargetsByArtifactVersion.values.flatten.toSet
-
-    val latestScalaVersionsOfAvailableBinaryVersions =
-      allTargets
-        .map(_.languageVersion)
-        .groupBy(_.family)
-        .view
-        .mapValues(_.max)
-        .values
-        .toSet
-
-    val latestArtifactVersionByLanguageVersion = (for {
-      (artifactVersion, scalaTargets) <- scalaTargetsByArtifactVersion.toSeq
-      scalaTarget <- scalaTargets
-      if latestScalaVersionsOfAvailableBinaryVersions.contains(
-        scalaTarget.languageVersion
-      )
-    } yield scalaTarget.languageVersion -> artifactVersion)
+  ): String = summaryOfLatestVersions(
+    (for {
+      release <- allAvailableReleases if release.isValid
+      ref = release.reference if ref.artifact == specificArtifact
+      scalaTarget <- ref.target if scalaTarget.targetType == specificTargetType
+    } yield ref.version -> scalaTarget)
       .groupMap(_._1)(_._2)
       .view
-      .mapValues(_.max)
+      .mapValues(_.toSet)
       .toMap
+  )
 
-    val scalaSupportByLatestSupportingArtifactVersion = SortedMap.from(
-      latestArtifactVersionByLanguageVersion.groupMap(_._2)(_._1).view.map {
-        case (artifactVersion, notableLanguageVersions) =>
-          val notableLanguageVersionsSet = notableLanguageVersions.toSet
-          artifactVersion -> ScalaSupport(
-            scalaTargetsByArtifactVersion(artifactVersion)
-              .filter(st => notableLanguageVersionsSet(st.languageVersion))
-              .toSet
-          )
+  def summaryOfLatestVersions(
+      scalaTargetsByArtifactVersion: Map[SemanticVersion, Set[ScalaTarget]]
+  ): String = {
+    // Are ALL `ScalaTarget`s instances of ScalaTargetWithPlatformBinaryVersion withe targetTypes for platforms that
+    // *fully dictate the Scala version used*?  If so, we want to summarise by `PlatformEdition`, rather than `LanguageVersion`
+    val platformTargetsByArtifactVersion: Option[
+      Map[SemanticVersion, Set[ScalaTargetWithPlatformBinaryVersion]]
+    ] = (for {
+      (artifactVersion, scalaTargets) <- scalaTargetsByArtifactVersion.toSeq
+      scalaTarget <- scalaTargets
+    } yield artifactVersion -> scalaTarget)
+      .foldLeft(
+        Option(
+          Set.empty[(SemanticVersion, ScalaTargetWithPlatformBinaryVersion)]
+        )
+      ) {
+        case (
+              Some(platformTargets),
+              (
+                artifactVersion,
+                platformTarget: ScalaTargetWithPlatformBinaryVersion
+              )
+            ) if platformTarget.targetType.platformVersionDeterminesScalaVersion =>
+          Some(platformTargets + (artifactVersion -> platformTarget))
+        case _ => None
       }
-    )(SemanticVersion.ordering.reverse)
+      .map(_.groupMap(_._1)(_._2))
 
-    (for (
-      (artifactVersion, scalaSupport) <-
-        scalaSupportByLatestSupportingArtifactVersion
-    ) yield s"$artifactVersion (${scalaSupport.summary})").mkString(", ")
+    platformTargetsByArtifactVersion.fold(
+      SummariseLanguageVersions.summarise(scalaTargetsByArtifactVersion)
+    )(
+      SummarisePlatformEditions.summarise
+    )
   }
 
-  case class ScalaSupport(
-      scalaTargets: Set[ScalaTarget]
-  ) {
-    val scalaTargetsByLanguageVersion: Map[LanguageVersion, Set[ScalaTarget]] =
-      scalaTargets.groupBy(_.languageVersion)
+  def summarisePlatformTargets(
+      platformEditions: Set[PlatformEdition],
+      sep: String
+  ): String = {
+    val platformBinaryVersionsByTargetType = SortedMap.from(
+      platformEditions
+        .groupMap(_.targetType.shortName)(_.version)
+        .view
+        .mapValues(
+          SortedSet.from(_)(BinaryVersion.ordering.reverse)
+        )
+    )
 
-    val languageVersions: SortedSet[LanguageVersion] =
-      SortedSet.from(scalaTargetsByLanguageVersion.keySet)(
-        LanguageVersion.ordering.reverse
-      )
+    platformBinaryVersionsByTargetType
+      .map { case (shortName, platformBinaryVersions) =>
+        s"$shortName ${platformBinaryVersions.mkString(sep)}"
+      }
+      .mkString(", ")
+  }
 
-    val platformEditionsSupportedForAllLanguageVersions: Set[PlatformEdition] =
-      scalaTargetsByLanguageVersion.values
-        .map(_.collect { case st: ScalaTargetWithPlatformBinaryVersion =>
-          st.platformEdition
-        })
-        .reduce(_ & _)
+  /**
+   * Implementations of this strategy will summarise different
+   * properties of ScalaTargets - eg, the Scala LanguageVersion, or
+   * the PlatformEdition.
+   *
+   * @tparam V the version type to be summarised by this SummaryStrategy
+   */
+  trait SummaryStrategy[T <: ScalaTarget, V] {
 
-    val platformBinaryVersionsByTargetType
-        : SortedMap[ScalaTargetType, SortedSet[BinaryVersion]] =
-      SortedMap.from(
-        platformEditionsSupportedForAllLanguageVersions
-          .groupMap(_.targetType)(_.version)
+    /**
+     * @return the pertinent (for this summary strategy) version of the supplied ScalaTarget
+     */
+    def versionFor(t: T): V
+    def removeSuperfluousVersionsFrom(versions: Set[V]): Set[V]
+
+    def notableSupportByArtifactVersion(
+        scalaTargetsByArtifactVersion: Map[SemanticVersion, Set[T]]
+    ): Map[SemanticVersion, Set[V]] = {
+      val keyVersionsByArtifactVersion: Map[SemanticVersion, Set[V]] =
+        scalaTargetsByArtifactVersion.view.mapValues(_.map(versionFor)).toMap
+      val interestingVersions: Set[V] = {
+        val allVersions = keyVersionsByArtifactVersion.values.flatten.toSet
+        removeSuperfluousVersionsFrom(allVersions)
+      }
+
+      val latestArtifactForKeyVersion: Map[V, SemanticVersion] = (for {
+        (artifactVersion, keyVersions) <- keyVersionsByArtifactVersion.toSeq
+        interestingKeyVersion <- keyVersions.filter(interestingVersions)
+      } yield interestingKeyVersion -> artifactVersion)
+        .groupMap(_._1)(_._2)
+        .view
+        .mapValues(_.max)
+        .toMap
+
+      latestArtifactForKeyVersion
+        .groupMap(_._2)(_._1)
+        .view
+        .mapValues(_.toSet)
+        .toMap
+    }
+
+    def summarise(
+        scalaTargetsByArtifactVersion: Map[SemanticVersion, Set[T]]
+    ): String = (for {
+      (artifactVersion, keyVersions) <-
+        SortedMap.from(
+          notableSupportByArtifactVersion(scalaTargetsByArtifactVersion)
+        )(SemanticVersion.ordering.reverse)
+    } yield s"$artifactVersion (${summarise(scalaTargetsByArtifactVersion(artifactVersion), keyVersions)})")
+      .mkString(", ")
+
+    def summarise(scalaTargets: Set[T], interestingKeyVersions: Set[V]): String
+  }
+
+  /**
+   * Summarises primarily the available Scala LanguageVersions - but
+   * will secondarily summarise the PlatformEditions that are supported
+   * for all those Scala LanguageVersions.
+   */
+  object SummariseLanguageVersions
+      extends SummaryStrategy[ScalaTarget, LanguageVersion] {
+    override def versionFor(t: ScalaTarget): LanguageVersion = t.languageVersion
+    override def removeSuperfluousVersionsFrom(
+        versions: Set[LanguageVersion]
+    ): Set[
+      LanguageVersion
+    ] = // we're only interested in the latest version of a binary family
+      versions.groupBy(_.family).values.map(_.max).toSet
+
+    override def summarise(
+        scalaTargets: Set[ScalaTarget],
+        interestingKeyVersions: Set[LanguageVersion]
+    ): String = {
+      val scalaTargetsByLanguageVersion
+          : Map[LanguageVersion, Set[ScalaTarget]] =
+        scalaTargets
+          .groupBy(_.languageVersion)
           .view
-          .mapValues(SortedSet.from(_)(BinaryVersion.ordering.reverse))
-      )
+          .filterKeys(interestingKeyVersions)
+          .toMap
 
-    val targetsSummary: Option[String] =
-      Option.when(platformBinaryVersionsByTargetType.nonEmpty)(
-        " - " + platformBinaryVersionsByTargetType
-          .map { case (targetType, platformBinaryVersions) =>
-            s"$targetType ${platformBinaryVersions.mkString("+")}"
-          }
-          .mkString(", ")
-      )
+      val languageVersions: SortedSet[LanguageVersion] =
+        SortedSet.from(scalaTargetsByLanguageVersion.keySet)(
+          LanguageVersion.ordering.reverse
+        )
 
-    val summary: String =
+      val platformEditionsSupportedForAllLanguageVersions
+          : Set[PlatformEdition] =
+        scalaTargetsByLanguageVersion.values
+          .map(_.collect { case st: ScalaTargetWithPlatformBinaryVersion =>
+            st.platformEdition
+          })
+          .reduce(_ & _)
+
+      val targetsSummary: Option[String] =
+        Option.when(platformEditionsSupportedForAllLanguageVersions.nonEmpty)(
+          " - " + summarisePlatformTargets(
+            platformEditionsSupportedForAllLanguageVersions,
+            "+"
+          )
+        )
+
       s"Scala ${languageVersions.mkString(", ")}${targetsSummary.mkString}"
+    }
+  }
+
+  /**
+   * Summarises *just* PlatformEdition versions - it's only appropriate
+   * if *all* the ScalaTargets are targets with PlatformEdition types
+   * where the platform version *fully dictates* the Scala version -
+   * like sbt.
+   */
+  object SummarisePlatformEditions
+      extends SummaryStrategy[
+        ScalaTargetWithPlatformBinaryVersion,
+        PlatformEdition
+      ] {
+    override def versionFor(
+        t: ScalaTargetWithPlatformBinaryVersion
+    ): PlatformEdition = t.platformEdition
+    override def removeSuperfluousVersionsFrom(
+        versions: Set[PlatformEdition]
+    ): Set[PlatformEdition] = versions
+    override def summarise(
+        scalaTargets: Set[ScalaTargetWithPlatformBinaryVersion],
+        interestingKeyVersions: Set[PlatformEdition]
+    ): String =
+      summarisePlatformTargets(
+        scalaTargets.map(_.platformEdition).filter(interestingKeyVersions),
+        ", "
+      )
   }
 }

--- a/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
@@ -58,8 +58,7 @@ object BadgesSupport {
   }
 
   def summarisePlatformTargets(
-      platformEditions: Set[PlatformEdition],
-      sep: String
+      platformEditions: Set[PlatformEdition]
   ): String = {
     val platformBinaryVersionsByTargetType = SortedMap.from(
       platformEditions
@@ -72,7 +71,7 @@ object BadgesSupport {
 
     platformBinaryVersionsByTargetType
       .map { case (shortName, platformBinaryVersions) =>
-        s"$shortName ${platformBinaryVersions.mkString(sep)}"
+        s"$shortName ${platformBinaryVersions.mkString(", ")}"
       }
       .mkString(", ")
   }
@@ -174,8 +173,7 @@ object BadgesSupport {
       val targetsSummary: Option[String] =
         Option.when(platformEditionsSupportedForAllLanguageVersions.nonEmpty)(
           " - " + summarisePlatformTargets(
-            platformEditionsSupportedForAllLanguageVersions,
-            "+"
+            platformEditionsSupportedForAllLanguageVersions
           )
         )
 
@@ -205,8 +203,7 @@ object BadgesSupport {
         interestingKeyVersions: Set[PlatformEdition]
     ): String =
       summarisePlatformTargets(
-        scalaTargets.map(_.platformEdition).filter(interestingKeyVersions),
-        ", "
+        scalaTargets.map(_.platformEdition).filter(interestingKeyVersions)
       )
   }
 }

--- a/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/BadgesSupport.scala
@@ -25,7 +25,7 @@ object BadgesSupport {
   def summaryOfLatestVersions(
       scalaTargetsByArtifactVersion: Map[SemanticVersion, Set[ScalaTarget]]
   ): String = {
-    // Are ALL `ScalaTarget`s instances of ScalaTargetWithPlatformBinaryVersion withe targetTypes for platforms that
+    // Are ALL `ScalaTarget`s instances of ScalaTargetWithPlatformBinaryVersion with targetTypes for platforms that
     // *fully dictate the Scala version used*?  If so, we want to summarise by `PlatformEdition`, rather than `LanguageVersion`
     val platformTargetsByArtifactVersion: Option[
       Map[SemanticVersion, Set[ScalaTargetWithPlatformBinaryVersion]]

--- a/server/src/test/scala/ch.epfl.scala.index.server/BadgesSupportTest.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/BadgesSupportTest.scala
@@ -38,7 +38,7 @@ class BadgesSupportTest extends FunSpec with Matchers {
           ScalaNative(`2.13`, Native.`0.4`)
         )
       )
-    ) shouldBe "7.0.0 (Scala 2.13 - Native 0.4+0.3)"
+    ) shouldBe "7.0.0 (Scala 2.13 - Native 0.4, 0.3)"
   }
 
   it(
@@ -143,7 +143,7 @@ class BadgesSupportTest extends FunSpec with Matchers {
           ScalaNative(`2.13`, Native.`0.4`)
         )
       )
-    ) shouldBe "7.1.0 (Scala 3.0.0-M3, 2.13 - Native 0.4+0.3)"
+    ) shouldBe "7.1.0 (Scala 3.0.0-M3, 2.13 - Native 0.4, 0.3)"
 
   }
 


### PR DESCRIPTION
Each release of sbt uses a specific version of Scala (1.0 uses Scala 2.12, 0.13 uses Scala 2.10), so the sbt version of a plugin fully determines the Scala language binary version it uses - this means, for a user, it's only really interesting to know the sbt version of the plugin, not the Scala language version.

At the moment, the Scaladex badge for, eg, the `sbt-assembly` plugin reads:

[![sbt-assembly Scala version support](https://img.shields.io/badge/sbt--assembly-1.0.0_(Scala_2.12,_2.10)-green.svg)](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly) (`1.0.0 (Scala 2.12, 2.10)`)

...for the user, it would be more helpful if it read:

[![sbt-assembly Scala version support](https://img.shields.io/badge/sbt--assembly-1.0.0_(sbt_1.0,_0.13)-green.svg)](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly) (`1.0.0 (sbt 1.0, 0.13)`)

...listing the versions of sbt you can actually use it with! Although the Scaladex badge did have some logic to display the platform versions supported by _all_ listed Scala language versions, that doesn't help in this situation, as the Scala language version differs for each platform version of sbt. See also [this comment](https://github.com/scalacenter/scaladex/pull/670#issuecomment-853426504) from a prior PR.

This PR refactors the Scaladex badge logic to have two version-summary strategies:

* `SummariseLanguageVersion` - which was the existing strategy, listing notable Scala version support, secondarily adding in a summary of platform editions (eg 'Scala 2.13 - Native 0.4+0.3')
* `SummarisePlatformEdition` - the new strategy, which is used if *all* fetched `ScalaTarget`s for an artifact have a `targetType` for which the platform version fully determines the Scala version (as is the case for sbt). It omits the Scala version from the summary, and just relates the platform versions (eg `sbt 1.0, 0.13`)

The refactor is quite a substantial rearrangement of the code in `BadgesSupport.scala` unfortunately, and so the diff is quite hard to read - might be better to just read the updated final version. Tests in `BadgesSupportTest.scala` have been added/updated to check for the new sbt case.

cc @adpi2 