### PR TITLE
Fix indexing non-standard scala 3 libs

### DIFF
--- a/data/src/main/scala/ch.epfl.scala.index.data/project/ArtifactMetaExtractor.scala
+++ b/data/src/main/scala/ch.epfl.scala.index.data/project/ArtifactMetaExtractor.scala
@@ -86,7 +86,7 @@ class ArtifactMetaExtractor(paths: DataPaths) {
         for {
           dep <- pom.dependencies.find { dep =>
             dep.groupId == "org.scala-lang" &&
-            dep.artifactId == "scala-library"
+            (dep.artifactId == "scala-library" || dep.artifactId == "scala3-library_3")
           }
           version <- SemanticVersion.tryParse(dep.version)
           target <- ScalaJvm.fromFullVersion(version)

--- a/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
+++ b/model/src/main/scala/ch.epfl.scala.index.model/release/ScalaTarget.scala
@@ -159,8 +159,11 @@ case class SbtPlugin(
 object ScalaJvm {
   def fromFullVersion(fullVersion: SemanticVersion): Option[ScalaJvm] = {
     val binaryVersion = fullVersion match {
-      case SemanticVersion(major, Some(minor), _, None, None, None) =>
+      case SemanticVersion(major, Some(minor), _, None, None, None)
+          if major == 2 =>
         Some(MinorBinary(major, minor))
+      case SemanticVersion(major, _, _, None, None, None) if major == 3 =>
+        Some(MajorBinary(major))
       case _ => None
     }
 

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/IndexingActor.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/api/impl/IndexingActor.scala
@@ -153,7 +153,7 @@ class IndexingActor(
               s"Failed adding the ${dependencies.size} dependencies of ${release.maven}"
             )
           } else {
-            log.error(
+            log.info(
               s"Added ${dependencies.size} dependencies of ${release.maven}"
             )
           }


### PR DESCRIPTION
This fix indexing non-standard libraries which depend on the scala3-library.

Some artifacts don't have the binary suffix. We call them "non-standard"
libraries. To index a non-standard libray, one must add it manually into
the scaladex-contrib/non-standard.json file. Scaladex finds its Scala
version from the dependency toward the Scala library.