### PR TITLE
Make system shutdown captured by scaladex server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,6 +174,7 @@ lazy val server = project
     reStart := reStart
       .dependsOn(startESandPostgreSQL, Assets / WebKeys.assets)
       .evaluated,
+    Compile / run / fork := true,
     Compile / run := (Compile / run).dependsOn(startESandPostgreSQL).evaluated,
     Compile / unmanagedResourceDirectories += (Assets / WebKeys.public).value,
     reStart / javaOptions ++= Seq("-Xmx4g")

--- a/project/Deployment.scala
+++ b/project/Deployment.scala
@@ -128,7 +128,7 @@ class Deployment(
           |  -Dconfig.file=/home/$userName/scaladex-credentials/application.conf \\
           |  -Dsentry.dsn=$sentryDsn \\
           |  -Dsentry.release=$version \\
-          |  $port \\
+          |  -Dapi.port=$port \\
           |  /home/$userName/scaladex-contrib \\
           |  /home/$userName/scaladex-index \\
           |  /home/$userName/scaladex-credentials \\

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -10,6 +10,11 @@ org.scala_lang.index.server {
   tempDirPath = "/tmp"
 }
 
+api {
+   endpoint = "localhost"
+   port = 8082
+}
+
 database {
   user = "user"
   user = ${?POSTGRESQL_USERNAME}

--- a/server/src/main/scala/ch.epfl.scala.index.server/config/ServerConfig.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/config/ServerConfig.scala
@@ -10,18 +10,22 @@ case class ServerConfig(
     production: Boolean,
     oAuth2: OAuth2Config,
     session: SessionConfig,
+    api: ApiConfig,
     dbConf: DbConf
 )
+case class ApiConfig(endpoint: String, port: Int)
 
 object ServerConfig {
   def load(): ServerConfig = {
     val config = ConfigFactory.load().getConfig("org.scala_lang.index.server")
     val dbConfig = ConfigFactory.load().getConfig("database")
+    val apiConfig = ConfigFactory.load().getConfig("api")
     ServerConfig(
       tempDirPath = config.getString("tempDirPath"),
       production = config.getBoolean("production"),
       oAuth2(config.getConfig("oauth2")),
       SessionConfig.default(config.getString("sesssion-secret")),
+      ApiConfig(apiConfig.getString("endpoint"), apiConfig.getInt("port")),
       DbConf.from(dbConfig.getString("database-url")).get // can be refactored
     )
   }

--- a/server/src/test/scala/ch.epfl.scala.index.server/ServerConfigTests.scala
+++ b/server/src/test/scala/ch.epfl.scala.index.server/ServerConfigTests.scala
@@ -1,0 +1,16 @@
+package ch.epfl.scala.index.server
+
+import scala.util.Success
+import scala.util.Try
+
+import ch.epfl.scala.index.server.config.ServerConfig
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ServerConfigTests extends AnyFunSpec with Matchers {
+  describe("AppConf") {
+    it("should load the conf") {
+      Try(ServerConfig.load()) shouldBe a[Success[_]]
+    }
+  }
+}


### PR DESCRIPTION
 - when running server/run, previously, the system shutdown didn't stop the server.
It's now fixed.
- Also added in this PR configuration to configure the endpoint and the port