### PR TITLE
Add pathPrefix for Assets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,9 @@ lazy val server = project
       .dependsOn(startESandPostgreSQL, Assets / WebKeys.assets)
       .evaluated,
     Compile / run / fork := true,
-    Compile / run := (Compile / run).dependsOn(startESandPostgreSQL).evaluated,
+    Compile / run := (Compile / run)
+      .dependsOn(startESandPostgreSQL, Assets / WebKeys.assets)
+      .evaluated,
     Compile / unmanagedResourceDirectories += (Assets / WebKeys.public).value,
     reStart / javaOptions ++= Seq("-Xmx4g")
   )

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ org.scala_lang.index.server {
 app {
    env = "local"
    endpoint = "localhost"
-   port = 8082
+   port = 8080
 }
 
 data-paths {

--- a/server/src/main/scala/ch.epfl.scala.index.server/routes/Assets.scala
+++ b/server/src/main/scala/ch.epfl.scala.index.server/routes/Assets.scala
@@ -7,35 +7,37 @@ import akka.http.scaladsl.server.Route
 
 object Assets {
   val routes: Route =
-    get(
-      concat(
-        path("assets" / "lib" / Remaining)(path =>
-          getFromResource("lib/" + path)
-        ),
-        path("assets" / "img" / Remaining)(path =>
-          getFromResource("img/" + path)
-        ),
-        path("assets" / "css" / Remaining)(path =>
-          getFromResource("css/" + path)
-        ),
-        path("assets" / "js" / Remaining)(path =>
-          getFromResource("js/" + path)
-        ),
-        path("assets" / "client-opt.js")(
-          getFromResource("client-opt.js")
-        ),
-        path("assets" / "client-fastopt.js")(
-          getFromResource("client-fastopt.js")
-        ),
-        path("assets" / "client-opt.js.map")(
-          getFromResource("client-opt.js.map")
-        ),
-        path("assets" / "client-fastopt.js.map")(
-          getFromResource("client-fastopt.js.map")
-        ),
-        path("assets" / "opensearch.xml")(
-          getFromResource("opensearch.xml")
+    pathPrefix("assets") {
+      get(
+        concat(
+          path("lib" / Remaining) { path =>
+            getFromResource("lib/" + path)
+          },
+          path("img" / Remaining) { path =>
+            getFromResource("img/" + path)
+          },
+          path("css" / Remaining) { path =>
+            getFromResource("css/" + path)
+          },
+          path("js" / Remaining) { path =>
+            getFromResource("js/" + path)
+          },
+          path("client-opt.js")(
+            getFromResource("client-opt.js")
+          ),
+          path("client-fastopt.js")(
+            getFromResource("client-fastopt.js")
+          ),
+          path("client-opt.js.map")(
+            getFromResource("client-opt.js.map")
+          ),
+          path("client-fastopt.js.map")(
+            getFromResource("client-fastopt.js.map")
+          ),
+          path("opensearch.xml")(
+            getFromResource("opensearch.xml")
+          )
         )
       )
-    )
+    }
 }

--- a/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/main.scala.html
@@ -1,4 +1,3 @@
-@import ch.epfl.scala.index.model._
 @import ch.epfl.scala.index.model.misc.{UserInfo, SearchParams, HeadMeta}
 
 @(title: String, showSearch: Boolean, user: Option[UserInfo],
@@ -126,7 +125,7 @@
     }
 
     <script src="/assets/lib/raven-js/dist/raven.min.js"></script>
-    <script src="/assets/lib/jQuery/dist/jquery.min.js"></script>
+    <script src="/assets/lib/jquery/dist/jquery.min.js"></script>
     <script src="/assets/lib/bootstrap-sass/assets/javascripts/bootstrap.min.js"></script>
     <script src="/assets/lib/bootstrap-select/dist/js/bootstrap-select.min.js"></script>
     <script src="/assets/lib/select2/dist/js/select2.min.js"></script>


### PR DESCRIPTION
- change the path for jQuery from
/assets/lib/jQuery/dist/jquery.min.js to /assets/lib/jquery/dist/jquery.min.js

the reason is that locally on macos (at least), the path is case sensitive. It was tested on the prod
server and the new path is found.