### PR TITLE
Optimize Github avatar loading

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/contributingInfo.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/contributingInfo.scala.html
@@ -6,10 +6,7 @@
 @if(!hideProjectInfo) {
 <div class="content-project-header">
   <a href="/@project.reference.organization/@project.reference.repository">
-    <img src="@{ project.github.flatMap(_.logo) match {
-        case Some(Url(v)) => v
-        case None => "/assets/img/avatar-list.png"
-      }}" alt="project logo">
+    @githubUserAvatar(project)
     <h4>@project.reference.organization/@project.reference.repository</h4>
   </a>
 </div>

--- a/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/frontpage.scala.html
@@ -110,10 +110,7 @@
                         <a href="/@project.reference.organization/@project.reference.repository">
                             <div class="content-project box">
                                 <div class="content-project-header">
-                                    <img src="@{ project.github.flatMap(_.logo) match {
-                                        case Some(Url(v)) => v
-                                        case None => "/assets/img/avatar-list.png"
-                                      }}" alt="project logo">
+                                    @githubUserAvatar(project)
                                     <h4>@project.reference.organization/@project.reference.repository</h4>
                                 </div>
                                 <div class="content-project-body">
@@ -143,10 +140,7 @@
                         <a href="/@project.reference.organization/@project.reference.repository">
                             <div class="content-project box">
                                 <div class="content-project-header">
-                                    <img src="@{ project.github.flatMap(_.logo) match {
-                                        case Some(Url(v)) => v
-                                        case None => "/assets/img/avatar-list.png"
-                                      }}" alt="project logo">
+                                    @githubUserAvatar(project)
                                     <h4>@project.reference.organization/@project.reference.repository</h4>
                                 </div>
                                 <div class="content-project-body">

--- a/template/src/main/twirl/ch.epfl.scala.index.views/githubUserAvatar.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/githubUserAvatar.scala.html
@@ -1,0 +1,8 @@
+@import ch.epfl.scala.index.model.Project
+@import ch.epfl.scala.index.model.misc.{Url, SearchParams, AvatarUrl}
+
+@(project: Project, size: Int=28)
+
+<img src="@{ project.github.flatMap(_.logo) match {
+    case Some(Url(v)) => (new AvatarUrl { val avatarUrl = v}).sizedAvatarUrl(size)
+    case None => " /assets/img/avatar-list.png" }}" alt="project logo" loading="lazy">

--- a/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/search/resultList.scala.html
@@ -16,7 +16,7 @@
             </div>
           } else {
             <div>
-              <img src="@{project.github.flatMap(_.logo.map(_.target)).getOrElse("/assets/img/avatar-list.png")}" alt="project logo">
+              @githubUserAvatar(project)
               <h4>@project.reference.organization/@project.reference.repository</h4>
 
               @for(github <- project.github) {


### PR DESCRIPTION
Closes #625 

The logic to display a github template was replicated in many templates. This PR addresses the problem by factoring it out in a dedicated component.
This PR also introduces lazy loading of images and requests avatars of the needed size to Github instead of downloading full size avatars and then resizing them.