### PR TITLE
Fix 'Create Badge' markdown closing-bracket typos

### DIFF
--- a/template/src/main/twirl/ch.epfl.scala.index.views/project/badges.scala.html
+++ b/template/src/main/twirl/ch.epfl.scala.index.views/project/badges.scala.html
@@ -22,7 +22,7 @@
           aria-label="Badge markdown"
           id="copy-badge-markdown"
           class="copyable-incantation"
-          >[![@artifact.artifactName Scala version support](@artifact.badgeUrl(env)](@artifact.artifactFullHttpUrl(env)</pre>
+          >[![@artifact.artifactName Scala version support](@artifact.badgeUrl(env))](@artifact.artifactFullHttpUrl(env))</pre>
           <button class="btn-copy btn btn-primary pull-right" data-clipboard-target="copy-badge-markdown">Copy Markdown</button>
         </div>
       </div>


### PR DESCRIPTION
The 'Create Badge' function was introduced with https://github.com/scalacenter/scaladex/pull/670, but unfortunately a small typo was introduced with https://github.com/scalacenter/scaladex/pull/705, removing two closing brackets on the markdown the user will copy - so instead of this:

[![play-v28 Scala version support](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28)

...there's this broken markdown [on the current production site](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28/0.31?target=_2.13#badge-markdown):

[![play-v28 Scala version support](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28/latest-by-scala-version.svg](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28
