### PR TITLE
Reduce `infra / test` logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,15 @@ inThisBuild(
   )
 )
 
-lazy val loggingSettings =
+lazy val loggingSettings = Seq(
   libraryDependencies ++= Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.10",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
-  )
+  ),
+  // Drop and replace commons-logging with slf4j
+  libraryDependencies += "org.slf4j" % "jcl-over-slf4j" % "1.7.33",
+  excludeDependencies += ExclusionRule("commons-logging", "commons-logging")
+)
 
 val amm = inputKey[Unit]("Start Ammonite REPL")
 lazy val ammoniteSettings = Def.settings(

--- a/data/src/main/resources/logback.xml
+++ b/data/src/main/resources/logback.xml
@@ -1,14 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <!-- encoders are assigned the type
-         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
-  </appender>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%X{akkaTimestamp} %-5level[%thread] %logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
 
-  <root level="info">
-    <appender-ref ref="STDOUT" />
-  </root>
+    <logger name="akka" level="INFO" />
+    <logger name="com.sksamuel" level="INFO" />
+    <logger name="org.elasticsearch" level="INFO" />
+    <logger name="org.flywaydb" level="INFO"/>
+<!--   TODO: implement authentication instead of silencing the log https://github.com/scalacenter/scaladex/issues/755-->
+    <logger name="org.elasticsearch.client.RestClient" level="ERROR"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
 </configuration>

--- a/infra/src/it/resources/logback.xml
+++ b/infra/src/it/resources/logback.xml
@@ -8,25 +8,16 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>scaladex.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%date{yyyy-MM-dd} %X{akkaTimestamp} %-5level[%thread] %logger{1} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="akka" level="INFO" />
-
     <logger name="com.sksamuel" level="INFO" />
     <logger name="org.elasticsearch" level="INFO" />
-    <logger name="org.flywaydb.*" level="INFO"/>
+    <logger name="org.flywaydb" level="WARN"/>
+
     <!--   TODO: implement authentication instead of silencing the log https://github.com/scalacenter/scaladex/issues/755-->
     <logger name="org.elasticsearch.client.RestClient" level="ERROR"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
     </root>
 
 </configuration>

--- a/infra/src/test/resources/logback.xml
+++ b/infra/src/test/resources/logback.xml
@@ -8,25 +8,16 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>scaladex.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%date{yyyy-MM-dd} %X{akkaTimestamp} %-5level[%thread] %logger{1} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="akka" level="INFO" />
-
     <logger name="com.sksamuel" level="INFO" />
     <logger name="org.elasticsearch" level="INFO" />
-    <logger name="org.flywaydb.*" level="INFO"/>
+    <logger name="org.flywaydb" level="WARN"/>
+
     <!--   TODO: implement authentication instead of silencing the log https://github.com/scalacenter/scaladex/issues/755-->
     <logger name="org.elasticsearch.client.RestClient" level="ERROR"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
     </root>
 
 </configuration>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -8,24 +8,15 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>scaladex.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%date{yyyy-MM-dd} %X{akkaTimestamp} %-5level[%thread] %logger{1} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="akka" level="INFO" />
     <logger name="com.sksamuel" level="INFO" />
     <logger name="org.elasticsearch" level="INFO" />
-    <logger name="org.flywaydb.*" level="INFO"/>
+    <logger name="org.flywaydb" level="INFO"/>
 <!--   TODO: implement authentication instead of silencing the log https://github.com/scalacenter/scaladex/issues/755-->
     <logger name="org.elasticsearch.client.RestClient" level="ERROR"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
Hide scaladex warnings about authentication and flyway migrate logs.

This makes the logs of running `infra / test` less verbose and more readable.

```
sbt:scaladex> infra / test
[info] Trying to connect to elasticsearch on port 49155
[info] Postgres has already started on port 49156
[info] Elasticsearch has already started on port 49155
 INFO [pool-1-thread-1] ElasticsearchEngine$ - Using elasticsearch index: scaladex-test
 INFO [pool-1-thread-1] JavaClient$ - Creating HTTP client on http://localhost:49155
[info] ElasticsearchEngineTests:ts 0s
 INFO [scala-execution-context-global-28] ElasticsearchEngine - Creating index scaladex-test.
 INFO [scala-execution-context-global-28] ElasticsearchEngine - Index scaladex-test created
[info] - match for cats with scala3
[info] - search for cats_3
[info] - sort by dependent, created, stars, forks, and contributors
[info] - contributing search
[info] - count by topics
[info] - count by platform types
[info] - count by Scala versions
[info] - count by Scala.js versions
[info] - count by Scala Native versions
[info] - remove missing document should not fail
[info] - should find project by former reference
[info] SqlDatabaseTests:
 INFO [pool-1-thread-1-ScalaTest-running-SqlDatabaseTests] HikariDataSource - HikariPool-1 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-SqlDatabaseTests] HikariDataSource - HikariPool-1 - Start completed.
[info] - insert artifact and its dependencies
[info] - should get all project statuses
[info] - should get all projects statuses
[info] - should update artifacts
[info] - should update github status
[info] - should find artifacts by name
[info] - should count projects, artifacts, dependencies, github infos and data forms
[info] - should find directDependencies
[info] - should find reverseDependencies
[info] - should compute project dependencies
[info] - should update creation date
[info] - should createMovedProject
[info] - should delete moved projects from project-dependency-table
 INFO [pool-1-thread-1-ScalaTest-running-ArtifactTableTests] HikariDataSource - HikariPool-2 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-ArtifactTableTests] HikariDataSource - HikariPool-2 - Start completed.
[info] LocalStorageRepoTests:
[info] encode/decode json
[info] ArtifactTableTests:
[info] - check insert
[info] - check selectArtifactByProject
[info] - check selectArtifactByProjectAndName
[info] - check findOldestArtifactsPerProjectReference
[info] - check updateProjectRef
[info] GithubModelTests:
[info] GithubModelt / executeTests 4s
[info] - should parse creationDate
[info] GithubInfoTableTests:
 INFO [pool-1-thread-1-ScalaTest-running-GithubInfoTableTests] HikariDataSource - HikariPool-3 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-GithubInfoTableTests] HikariDataSource - HikariPool-3 - Start completed.
[info] - check insert
[info] - check insertOrUpdate
[info] ProjectTableTests:
 INFO [pool-1-thread-1-ScalaTest-running-ProjectTableTests] HikariDataSource - HikariPool-4 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-ProjectTableTests] HikariDataSource - HikariPool-4 - Start completed.
[info] - check insertIfNotExists
[info] - check updateGithubStatus
[info] - check selectProjects
[info] - check selectReferenceAndStatus
[info] - check updateCreated
[info] - check selectProjectByGithubStatus
[info] ArtifactDependencyTableTests:
 INFO [pool-1-thread-1-ScalaTest-running-ArtifactDependencyTableTests] HikariDataSource - HikariPool-5 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-ArtifactDependencyTableTests] HikariDataSource - HikariPool-5 - Start completed.
[info] - check insert
[info] - check select
[info] - check selectDirectDependency
[info] - check selectReverseDependency
[info] - check selectProjectDependency
[info] ProjectSettingsTableTests:
 INFO [pool-1-thread-1-ScalaTest-running-ProjectSettingsTableTests] HikariDataSource - HikariPool-6 - Starting...
[info] should generate query for
 INFO [pool-1-thread-1-ScalaTest-running-ProjectSettingsTableTests] HikariDataSource - HikariPool-6 - Start completed.
[info] - check insertOrUpdate
[info] ProjectDependenciesTableTests:
 INFO [pool-1-thread-1-ScalaTest-running-ProjectDependenciesTableTests] HikariDataSource - HikariPool-7 - Starting...
 INFO [pool-1-thread-1-ScalaTest-running-ProjectDependenciesTableTests] HikariDataSource - HikariPool-7 - Start completed.
[info] - check insertOrUpdate
[info] - check deleteBySource
[info] - check deleteByTargetTests 5s
[info] CoursierResolverTests:
[info] - should resolve parent pom
[info] - should resolve same pom 10 times concurrently
[info] Run completed in 6 seconds, 508 milliseconds.
[info] Total number of tests run: 49
[info] Suites: completed 11, aborted 0
[info] Tests: succeeded 49, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 7 s, completed Jan 24, 2022 8:39:46 AM
```