### PR TITLE
Insert artifact and dependencies if not exists

### DIFF
--- a/infra/src/main/scala/scaladex/infra/storage/sql/tables/ArtifactDependencyTable.scala
+++ b/infra/src/main/scala/scaladex/infra/storage/sql/tables/ArtifactDependencyTable.scala
@@ -39,7 +39,8 @@ object ArtifactDependencyTable {
     fields.map("d." + _) ++
       ArtifactTable.fields.map("a." + _)
 
-  val insert: Update[ArtifactDependency] = insertRequest(table, fields)
+  val insertIfNotExist: Update[ArtifactDependency] =
+    insertOrUpdateRequest(table, fields, fields)
 
   val count: doobie.Query0[Long] =
     selectRequest(table, Seq("COUNT(*)"))

--- a/infra/src/main/scala/scaladex/infra/storage/sql/tables/ArtifactTable.scala
+++ b/infra/src/main/scala/scaladex/infra/storage/sql/tables/ArtifactTable.scala
@@ -26,7 +26,8 @@ object ArtifactTable {
       "is_non_standard_Lib"
     )
 
-  val insert: Update[Artifact] = insertRequest(table, fields)
+  val insertIfNotExist: Update[Artifact] =
+    insertOrUpdateRequest(table, fields, mavenReferenceFields)
 
   val count: Query0[Long] =
     selectRequest(table, "COUNT(*)")

--- a/infra/src/test/scala/scaladex/infra/storage/sql/tables/ArtifactDependencyTableTests.scala
+++ b/infra/src/test/scala/scaladex/infra/storage/sql/tables/ArtifactDependencyTableTests.scala
@@ -6,7 +6,7 @@ import scaladex.infra.storage.sql.BaseDatabaseSuite
 import scaladex.infra.storage.sql.tables.ArtifactDependencyTable
 
 class ArtifactDependencyTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
-  it("check insert")(check(ArtifactDependencyTable.insert))
+  it("check insertIfNotExist")(check(ArtifactDependencyTable.insertIfNotExist))
   it("check select")(check(ArtifactDependencyTable.select))
   it("check selectDirectDependency")(check(ArtifactDependencyTable.selectDirectDependency))
   it("check selectReverseDependency")(check(ArtifactDependencyTable.selectReverseDependency))

--- a/infra/src/test/scala/scaladex/infra/storage/sql/tables/ArtifactTableTests.scala
+++ b/infra/src/test/scala/scaladex/infra/storage/sql/tables/ArtifactTableTests.scala
@@ -6,7 +6,7 @@ import scaladex.infra.storage.sql.BaseDatabaseSuite
 import scaladex.infra.storage.sql.tables.ArtifactTable
 
 class ArtifactTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
-  it("check insert")(check(ArtifactTable.insert))
+  it("check insertIfNotExist")(check(ArtifactTable.insertIfNotExist))
   it("check selectArtifactByProject")(check(ArtifactTable.selectArtifactByProject))
   it("check selectArtifactByProjectAndName")(check(ArtifactTable.selectArtifactByProjectAndName))
   it("check findOldestArtifactsPerProjectReference")(check(ArtifactTable.selectOldestByProject))


### PR DESCRIPTION
We often try to insert an artifact that already exists:
- in `data / run init` some poms are duplicated under several repositories
- Sonatype often pushes the same artifact twice or more

As a consequence, I think it is better not to log if an artifact already exists, and to throw if insertion fails for some other reason.