### PR TITLE
[Awesome Scala] Add "See also"

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
@@ -21,6 +21,7 @@ sealed trait Category {
 }
 
 object Category {
+  implicit val ordering: Ordering[Category] = Ordering.by(_.label)
   val all: Seq[Category] = MetaCategory.all.flatMap(_.categories).distinct
   val byLabel: Map[String, Category] = all.map(category => category.label -> category).toMap
 

--- a/modules/core/shared/src/main/scala/scaladex/core/model/MetaCategory.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/MetaCategory.scala
@@ -12,11 +12,12 @@ sealed trait MetaCategory {
 
   val title: String
   val categories: Seq[Category]
+  val seeAlsoCategories: Seq[Category] = Seq.empty
 }
 
 object MetaCategory {
   def all: Seq[MetaCategory] = Seq(
-    AsynchronousConcurrentAndDistributedProgramming,
+    AsynchronousAndConcurrentProgramming,
     BigData,
     ComputerScience,
     ConfigurationLoggingTestingAndMonitoring,
@@ -34,14 +35,16 @@ object MetaCategory {
 
   val byLabel: Map[String, MetaCategory] = all.map(meta => meta.label -> meta).toMap
 
-  case object AsynchronousConcurrentAndDistributedProgramming extends MetaCategory {
+  case object AsynchronousAndConcurrentProgramming extends MetaCategory {
     override val title: String = "Asynchronous, Concurrent and Distributed Programming"
 
     override val categories: Seq[Category] = Seq(
       Category.AsynchronousAndReactiveProgramming,
-      Category.DistributedComputing,
       Category.DistributedMessagingSystemsAndMicroservices,
       Category.Schedulers
+    )
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.DistributedComputing
     )
   }
   case object BigData extends MetaCategory {
@@ -51,6 +54,12 @@ object MetaCategory {
       Category.DataVizualization,
       Category.DistributedComputing
     )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.Databases,
+      Category.IndexingAndSearching,
+      Category.ProbabilityStatisticsAndMachineLearning
+    )
   }
 
   case object ComputerScience extends MetaCategory {
@@ -58,15 +67,15 @@ object MetaCategory {
     override val categories: Seq[Category] = Seq(
       Category.AlgorithmsAndDataStructures,
       Category.Caching,
-      Category.Compilers,
       Category.CodeGeneration,
+      Category.Compilers,
       Category.DependencyInjection,
       Category.FunctionnalProgrammingAndCategoryTheory,
       Category.LogicProgrammingAndTypeConstraints,
       Category.MiscellaneousUtils,
       Category.Parsing,
-      Category.ScalaLanguageExtensions,
-      Category.ProgrammingLanguageInterfaces
+      Category.ProgrammingLanguageInterfaces,
+      Category.ScalaLanguageExtensions
     )
   }
 
@@ -91,11 +100,15 @@ object MetaCategory {
     override val title: String = "Deployment, Virtualization and Cloud"
     override val categories: Seq[Category] = Seq(
       Category.DeploymentAndCloud,
-      Category.PackagingAndPublishing,
-      Category.LibraryDependencyManagement,
       Category.Serverless,
       Category.VersionManagement,
       Category.VirtualizationAndContainerization
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.ConfigurationAndEnvironment,
+      Category.PackagingAndPublishing,
+      Category.Yaml
     )
   }
   case object DevelopmentTooling extends MetaCategory {
@@ -103,13 +116,19 @@ object MetaCategory {
     override val categories: Seq[Category] = Seq(
       Category.BuildTools,
       Category.CodeAnalysis,
-      Category.LintingAndRefactoring,
-      Category.PrintingAndDebugging,
       Category.CodeEditorsAndNotebooks,
       Category.CodeFormatting,
+      Category.LibraryDependencyManagement,
+      Category.LintingAndRefactoring,
+      Category.MiscellaneousTools,
+      Category.PackagingAndPublishing,
+      Category.PrintingAndDebugging,
       Category.ScriptingAndRepls,
-      Category.StaticSitesAndDocumentation,
-      Category.MiscellaneousTools
+      Category.StaticSitesAndDocumentation
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.Testing
     )
   }
   case object ImagesAudioAndVideo extends MetaCategory {
@@ -117,6 +136,9 @@ object MetaCategory {
     override val categories: Seq[Category] = Seq(
       Category.AudioAndMusic,
       Category.VideoAndImageProcessing
+    )
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.GraphicalInterfacesAndGameDevelopment
     )
   }
 
@@ -126,24 +148,33 @@ object MetaCategory {
       Category.Bioinformatics,
       Category.CryptographyAndHashing,
       Category.EconomyFinanceAndCryptocurrencies,
-      Category.ProbabilityStatisticsAndMachineLearning,
       Category.NaturalLanguageProcessing,
-      Category.NumericalAndSymbolicComputing
+      Category.NumericalAndSymbolicComputing,
+      Category.ProbabilityStatisticsAndMachineLearning
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.GeometryAndGeopositionning,
+      Category.UnitsOfMeasurement
     )
   }
   case object MobileDesktopAndGameDevelopment extends MetaCategory {
     override val title: String = "Mobile, Desktop and Game Development"
     override val categories: Seq[Category] = Seq(
-      Category.Mobile,
-      Category.GraphicalInterfacesAndGameDevelopment
+      Category.GraphicalInterfacesAndGameDevelopment,
+      Category.Mobile
     )
   }
   case object OperatingSystemsAndHardware extends MetaCategory {
     override val title: String = "Operating System, Hardware and Robotics"
     override val categories: Seq[Category] = Seq(
-      Category.HardwareAndEmulators,
       Category.FileSystemsAndProcesses,
+      Category.HardwareAndEmulators,
       Category.Network
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.Mobile
     )
   }
   case object TextFormatAndCompression extends MetaCategory {
@@ -153,11 +184,15 @@ object MetaCategory {
       Category.Csv,
       Category.Json,
       Category.Markdown,
+      Category.OtherDocumentFormats,
       Category.Pdf,
       Category.Serialization,
       Category.TextManipulation,
-      Category.OtherDocumentFormats,
       Category.Yaml
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.XmlHtmlAndDom
     )
   }
   case object TimePositionsAndUnitsOfMeasurement extends MetaCategory {
@@ -183,6 +218,10 @@ object MetaCategory {
       Category.UrlsAndRouting,
       Category.WebFrontend,
       Category.XmlHtmlAndDom
+    )
+
+    override val seeAlsoCategories: Seq[Category] = Seq(
+      Category.Json
     )
   }
 }

--- a/modules/core/shared/src/test/scala/scaladex/core/model/CategoryTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/CategoryTests.scala
@@ -4,12 +4,26 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class CategoryTests extends AnyFunSpec with Matchers {
-  it("should compute category label and title") {
-    Category.AlgorithmsAndDataStructures.label shouldBe "algorithms-and-data-structures"
-    Category.AlgorithmsAndDataStructures.title shouldBe "Algorithms and Data Structures"
+  describe("category") {
+    it("should compute category label and title") {
+      Category.AlgorithmsAndDataStructures.label shouldBe "algorithms-and-data-structures"
+      Category.AlgorithmsAndDataStructures.title shouldBe "Algorithms and Data Structures"
+    }
+
+    it("should all be owned by a single meta-category") {
+      for (category <- Category.all)
+        MetaCategory.all.filter(meta => meta.categories.contains(category)).size shouldBe 1
+    }
   }
 
-  it("should compute meta-category label") {
-    MetaCategory.AsynchronousConcurrentAndDistributedProgramming.label shouldBe "asynchronous-concurrent-and-distributed-programming"
+  describe("MetaCategory") {
+    it("should compute meta-category label") {
+      MetaCategory.AsynchronousAndConcurrentProgramming.label shouldBe "asynchronous-and-concurrent-programming"
+    }
+
+    it("categories should be sorted alphabetically") {
+      for (meta <- MetaCategory.all) meta.categories shouldBe sorted
+      for (meta <- MetaCategory.all) meta.seeAlsoCategories shouldBe sorted
+    }
   }
 }

--- a/modules/server/src/main/assets/css/partials/_explore.scss
+++ b/modules/server/src/main/assets/css/partials/_explore.scss
@@ -95,22 +95,15 @@
     &>.row {
       font-size: 0;
     }
-    .category {
+    .category, .see-also {
       float: none;
       display: inline-block;
       vertical-align: top;
       padding: 0 30px;
       font-size: 16px;
       h3 {
-        a {
-          font-size: 22px;
-          color: $brand-secondary;
-        }
+        color: $brand-secondary;
         margin-top: 40px;
-      }
-      ol {
-        padding: 0;
-        list-style-type: none;
       }
       a {
         color: inherit;
@@ -122,9 +115,28 @@
           }
         }
       }
+    }
+    .category {
+      h3 {
+        a {
+          font-size: 22px;
+          color: $brand-secondary;
+        }
+      }
+      ol {
+        padding: 0;
+        list-style-type: none;
+      }
       .see-more {
         float: right;
         padding-right: 20px;
+      }
+    }
+    .see-also {
+      li {
+        font-size: 18px;
+        font-family: "Roboto Slab", serif;
+        color: $brand-secondary;
       }
     }
     .project {

--- a/modules/server/src/main/scala/scaladex/server/route/ExplorePages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ExplorePages.scala
@@ -65,13 +65,13 @@ class ExplorePages(env: Env, searchEngine: SearchEngine)(implicit ec: ExecutionC
       languagesCount <- languagesCountF
       platformsCount <- platformsCountF
     } yield {
-      val byCategories = allByCategories.filter { case (_, projects) => projects.nonEmpty }.toMap
-      val byMetaCategories = MetaCategory.all
-        .map(m => m -> m.categories.flatMap(c => byCategories.get(c).map(c -> _)))
+      val projectsByCategory = allByCategories.filter { case (_, projects) => projects.nonEmpty }.toMap
+      val categoriesByMetaCategory = MetaCategory.all
+        .map(m => m -> m.categories.filter(projectsByCategory.contains))
         .filter { case (_, categories) => categories.nonEmpty }
       val scalaVersions = languagesCount.collect { case (v: Scala, _) => v }
       val platforms = platformsCount.map { case (p, _) => p }
-      html.exploreAll(env, user, byMetaCategories, scalaVersions, platforms, params)
+      html.exploreAll(env, user, categoriesByMetaCategory, projectsByCategory, scalaVersions, platforms, params)
     }
   }
 

--- a/modules/template/src/main/twirl/scaladex/view/explore/exploreAll.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/explore/exploreAll.scala.html
@@ -11,7 +11,8 @@
 @(
   env: Env,
   user: Option[UserState],
-  metaCategories: Seq[(MetaCategory, Seq[(Category, Seq[ProjectDocument])])],
+  categoriesByMetaCategory: Seq[(MetaCategory, Seq[Category])],
+  projectsByCategory: Map[Category, Seq[ProjectDocument]],
   languages: Seq[Scala],
   platforms: Seq[Platform],
   params: ExploreParams
@@ -52,26 +53,26 @@
         <nav>
           <h3>Categories:</h3>
           <ul>
-            @for((metaCategory, _) <- metaCategories) { 
+            @for((meta, _) <- categoriesByMetaCategory) { 
               <li>
-                <a href="#@metaCategory.label"> @metaCategory.title </a>
+                <a href="#@meta.label"> @meta.title </a>
               </li>
             }
           </ul>
         </div>
       </nav>
       <div class="col-lg-9 col-md-8 col-sm-12">
-        @for((metaCategory, categories) <- metaCategories) {
-          <section class="meta-category" id="@metaCategory.label">
-            <h2>@metaCategory.title</h2>
+        @for((meta, categories) <- categoriesByMetaCategory) {
+          <section class="meta-category" id="@meta.label">
+            <h2>@meta.title</h2>
             <div class="row">
-              @for((category, projects) <- categories) {
-                <section class="category col-lg-6 col-md-12">
+              @for(category <- categories) {
+                <section class="category col-lg-6 col-md-12" id="@category.label">
                   <h3>
                     <a href="@exploreCategoryUri(category, params)">@category.title</a>
                   </h3>
                   <ol>
-                    @for(project <- projects) {
+                    @for(project <- projectsByCategory(category)) {
                       <li>
                         <a href="/@project.reference">
                           <div class="project">
@@ -97,6 +98,18 @@
                     <a href="@exploreCategoryUri(category, params)">See More</a>
                   </div>
                 </section>
+              }
+              @defining(meta.seeAlsoCategories.filter(projectsByCategory.contains(_))) { seeAlsoCategories =>
+                @if(seeAlsoCategories.nonEmpty) {
+                  <div class="see-also col-lg-6 col-md-12">
+                    <h3>See also:</h3>
+                    <ul>
+                      @for(category <- seeAlsoCategories) {
+                        <li><a href="#@category.label">@category.title</a></li>
+                      }
+                    </ul>
+                  </div>
+                }
               }
             </div>
           </section>


### PR DESCRIPTION
Comes after #905 

Added "See also" list of categories in each meta-category to avoid duplication of content in the "Awesome Scala" page.

For example, in the "Big Data" meta-category we can have:
![image](https://user-images.githubusercontent.com/13123162/155324263-28976547-a38b-4642-be67-4efcb75adf5f.png)

Result visible here: https://index-dev.scala-lang.org/awesome 