### PR TITLE
GithubClient: paginate organizations and projects of organizations

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/GithubService.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/GithubService.scala
@@ -10,7 +10,11 @@ import scaladex.core.model.UserInfo
 trait GithubService {
   def getProjectInfo(ref: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]]
   def getUserInfo(): Future[UserInfo]
-  def getUserOrganizations(login: String): Future[Set[Project.Organization]]
-  def getUserOrganizationRepositories(login: String, filterPermissions: Seq[String]): Future[Seq[Project.Reference]]
+  def getUserOrganizations(login: String): Future[Seq[Project.Organization]]
   def getUserRepositories(login: String, filterPermissions: Seq[String]): Future[Seq[Project.Reference]]
+  def getOrganizationRepositories(
+      user: String,
+      organization: Project.Organization,
+      filterPermissions: Seq[String]
+  ): Future[Seq[Project.Reference]]
 }

--- a/modules/infra/src/it/scala/scaladex/infra/GithubClientTests.scala
+++ b/modules/infra/src/it/scala/scaladex/infra/GithubClientTests.scala
@@ -70,8 +70,8 @@ class GithubClientTests extends AsyncFunSpec with Matchers {
   }
 
   if (!isCI) {
-    it("getUserOrganizationRepositories") {
-      for (repos <- client.getUserOrganizationRepositories("atry", Nil))
+    it("getOrganizationRepositories") {
+      for (repos <- client.getOrganizationRepositories("atry", Project.Organization("scala"), Nil))
         yield repos should not be empty
     }
     it("getUserRepositories") {


### PR DESCRIPTION
This should deal with user having more than 100 organizations or organizations having more than 100 projects.

Deployed on [index-dev.scala-lang.org](https://index-dev.scala-lang.org/).