### PR TITLE
Adding percentage of Scala for a project

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/GithubInfo.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/GithubInfo.scala
@@ -16,13 +16,13 @@ import scaladex.core.model.search.GithubInfoDocument
  * @param watchers number of subscribers to this repo
  * @param issues number of open issues for this repo
  * @param contributors list of contributor profiles
- * @param contributorCount how many contributors there are, used to sort search results by number of contributors
  * @param commits number of commits, calculated by contributors
  * @param topics topics associated with the project
  * @param contributingGuide CONTRIBUTING.md
  * @param codeOfConduct link to code of conduct
  * @param chatroom link to chatroom (ex: https://gitter.im/scalacenter/scaladex)
  * @param openIssues list of all open issues for the project
+ * @param scalaPercentage the proportion of Scala code for this repo
  */
 case class GithubInfo(
     homepage: Option[Url],
@@ -40,7 +40,8 @@ case class GithubInfo(
     contributingGuide: Option[Url],
     codeOfConduct: Option[Url],
     chatroom: Option[Url],
-    openIssues: List[GithubIssue] // right now it's all issues, not only beginners issues
+    openIssues: List[GithubIssue], // right now it's all issues, not only beginners issues
+    scalaPercentage: Option[Int],
 ) {
   val contributorCount: Int = contributors.size
 
@@ -57,6 +58,7 @@ case class GithubInfo(
       stars = stars,
       forks = forks,
       contributorCount = contributorCount
+      // TODO: add a scalaPercentage field once I get data from GitHub.
     )
 }
 
@@ -77,6 +79,7 @@ object GithubInfo {
     contributingGuide = None,
     codeOfConduct = None,
     chatroom = None,
-    openIssues = List()
+    openIssues = List(),
+    scalaPercentage = None
   )
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/model/GithubInfo.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/GithubInfo.scala
@@ -41,7 +41,7 @@ case class GithubInfo(
     codeOfConduct: Option[Url],
     chatroom: Option[Url],
     openIssues: List[GithubIssue], // right now it's all issues, not only beginners issues
-    scalaPercentage: Option[Int],
+    scalaPercentage: Option[Int]
 ) {
   val contributorCount: Int = contributors.size
 
@@ -57,8 +57,8 @@ case class GithubInfo(
       codeOfConduct = codeOfConduct,
       stars = stars,
       forks = forks,
-      contributorCount = contributorCount
-      // TODO: add a scalaPercentage field once I get data from GitHub.
+      contributorCount = contributorCount,
+      scalaPercentage = scalaPercentage
     )
 }
 

--- a/modules/core/shared/src/main/scala/scaladex/core/model/search/GithubInfoDocument.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/search/GithubInfoDocument.scala
@@ -14,5 +14,6 @@ case class GithubInfoDocument(
     codeOfConduct: Option[Url],
     stars: Option[Int],
     forks: Option[Int],
-    contributorCount: Int
+    contributorCount: Int,
+    scalaPercentage: Option[Int]
 )

--- a/modules/infra/src/it/scala/scaladex/infra/GithubClientTests.scala
+++ b/modules/infra/src/it/scala/scaladex/infra/GithubClientTests.scala
@@ -65,8 +65,18 @@ class GithubClientTests extends AsyncFunSpec with Matchers {
   }
 
   it("getUserInfo") {
-    for (userInfo <- client.getUserInfo())
+    for (_ <- client.getUserInfo())
       yield succeed
+  }
+
+  it("getPercentageOfLanguage should return 0, given a repo with none of the target language") {
+    for (percentOfLanguage <- client.getPercentageOfLanguage(Scalafix.reference, "Racket"))
+      yield percentOfLanguage shouldBe 0
+  }
+
+  it("should return a non-zero value, given a repo which contains the target language") {
+    for (percentOfLanguage <- client.getPercentageOfLanguage(Scalafix.reference, "Scala"))
+      yield percentOfLanguage > 0 shouldBe true
   }
 
   if (!isCI) {

--- a/modules/infra/src/main/resources/migrations/V6__add_scala_percentage.sql
+++ b/modules/infra/src/main/resources/migrations/V6__add_scala_percentage.sql
@@ -1,0 +1,2 @@
+ALTER TABLE github_info
+  ADD scala_percentage INT

--- a/modules/infra/src/main/scala/scaladex/infra/sql/GithubInfoTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/GithubInfoTable.scala
@@ -25,7 +25,8 @@ object GithubInfoTable {
     "contributing_guide",
     "code_of_conduct",
     "chatroom",
-    "open_issues"
+    "open_issues",
+    "scala_percentage"
   )
 
   val insert: Update[(Project.Reference, GithubInfo)] =


### PR DESCRIPTION
This is a basic implementation of getting some information regarding how much of a codebase is Scala, i.e. `.scala` or`.sc`files.

I used this [endpoint](https://docs.github.com/en/rest/reference/repos#list-repository-languages), which produces a response like so:

```json
{
  "Scala": 40292600,
  "Python": 7343749,
  "Java": 4526889,
  "Jupyter Notebook": 4310516,
  "HiveQL": 1872438,
  "R": 1272682,
  "PLpgSQL": 352963,
  "Shell": 230745,
  "JavaScript": 222664,
  "q": 98156,
  "ANTLR": 56929,
  "HTML": 42080,
  "Roff": 31648,
  "Batchfile": 27405,
  "CSS": 26221,
  "Dockerfile": 9711,
  "PowerShell": 4221,
  "Makefile": 2374,
  "Thrift": 2016,
  "C": 1493,
  "ReScript": 240
}
```

Given a payload such as
```sh
curl -H "Accept: application/vnd.github.v3+json" \
  https://api.github.com/repos/apache/spark/languages
```

Which is basically a dictionary of languages to the number of bytes they occupy in the project. I understand that this isn't an ideal implementation (perhaps a count of files of a given language might be a better measure), so I'm open to suggestions.

Additionally, more work needs to be done on deciding how this percentage is used in calculating the scoring for Elasticsearch, but I think that can be discussed more in #928.

Should eventually close #928