### PR TITLE
Create index if not exists

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -54,42 +54,33 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(implicit ec: E
 
   private val maxLanguagesOrPlatforms = 20
 
-  def waitUntilReady(): Unit = {
-    def blockUntil(explain: String)(predicate: () => Boolean): Unit = {
-      var backoff = 0
-      var done = false
-      while (backoff <= 128 && !done) {
-        if (backoff > 0) Thread.sleep(200L * backoff)
-        backoff = backoff + 1
-        done = predicate()
-      }
-      require(done, s"Failed waiting on: $explain")
-    }
+  private def waitUntilReady(): Future[Unit] = Future {
+    var backoff = 0
+    var done = false
+    while (backoff <= 128 && !done) {
+      if (backoff > 0) Thread.sleep(200L * backoff)
+      backoff = backoff + 1
 
-    blockUntil("Expected cluster to have yellow status") { () =>
       val waitForYellowStatus =
         clusterHealth().waitForStatus(HealthStatus.Yellow)
+      // TODO: rewrite without await
       val response = esClient.execute(waitForYellowStatus).await
-      response.isSuccess
+      done = response.isSuccess
     }
+    require(done, s"Failed waiting on: Expected cluster to have yellow status")
   }
 
   def close(): Unit = esClient.close()
 
-  def reset(): Future[Unit] =
+  def init(reset: Boolean): Future[Unit] =
     for {
-      _ <- delete()
-      _ = logger.info(s"Creating index $index.")
-      _ <- create()
-    } yield logger.info(s"Index $index created")
-
-  private def delete(): Future[Unit] =
-    for {
-      response <- esClient.execute(indexExists(index))
-      exist = response.result.isExists
+      _ <- waitUntilReady()
+      indexExists <- esClient.execute(indexExists(index)).map(_.result.isExists)
       _ <-
-        if (exist) esClient.execute(deleteIndex(index))
-        else Future.successful(())
+        if (!indexExists) create()
+        else if (reset)
+          esClient.execute(deleteIndex(index)).flatMap(_ => create())
+        else Future.unit
     } yield ()
 
   private def create(): Future[Unit] = {
@@ -104,6 +95,7 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(implicit ec: E
       )
       .mapping(MappingDefinition(projectFields))
 
+    logger.info(s"Creating index $index.")
     esClient
       .execute(createProject)
       .map { resp =>

--- a/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
@@ -26,10 +26,8 @@ class ElasticsearchEngineTests extends AsyncFunSuite with Matchers with BeforeAn
   val searchEngine: ElasticsearchEngine = ElasticsearchEngine.open(config)
   val page: PageParams = PageParams(1, 20)
 
-  override protected def beforeAll(): Unit = {
-    searchEngine.waitUntilReady()
-    Await.result(searchEngine.reset(), Duration.Inf)
-  }
+  override protected def beforeAll(): Unit =
+    Await.result(searchEngine.init(true), Duration.Inf)
 
   override protected def afterAll(): Unit =
     searchEngine.close()

--- a/modules/server/src/it/scala/scaladex/RelevanceTest.scala
+++ b/modules/server/src/it/scala/scaladex/RelevanceTest.scala
@@ -30,8 +30,6 @@ class RelevanceTest extends TestKit(ActorSystem("SbtActorTest")) with AsyncFunSu
   private val searchEngine = ElasticsearchEngine.open(config.elasticsearch)
 
   override def beforeAll(): Unit = {
-    searchEngine.waitUntilReady()
-
     implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
     val transactor = DoobieUtils.transactor(config.database)
     transactor
@@ -44,7 +42,7 @@ class RelevanceTest extends TestKit(ActorSystem("SbtActorTest")) with AsyncFunSu
         IO.fromFuture(IO {
           for {
             _ <- Init.run(database, filesystem)
-            _ <- searchEngine.reset()
+            _ <- searchEngine.init(true)
             _ <- searchSync.syncAll()
             _ <- searchEngine.refresh()
           } yield ()

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -119,10 +119,7 @@ object Server extends LazyLogging {
     for {
       _ <- database.migrate
       _ = logger.info("Waiting for ElasticSearch to start")
-      _ <- IO(searchEngine.waitUntilReady())
-      _ <-
-        if (resetElastic) IO.fromFuture(IO(searchEngine.reset()))
-        else IO.unit
+      _ <- IO.fromFuture(IO(searchEngine.init(resetElastic)))
       _ = logger.info("Starting all schedulers")
       _ <- IO(scheduler.startAll())
     } yield ()


### PR DESCRIPTION
When running Scaladex for the first time, we must make sure that the Elasticsearch index exists even if `scaladex.elasticsearch.reset = false` in the config.