### PR TITLE
Adding user_sessions table + tests

### DIFF
--- a/modules/infra/src/main/resources/migrations/V8__add_user_sessions.sql
+++ b/modules/infra/src/main/resources/migrations/V8__add_user_sessions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE user_sessions(
+    user_id       VARCHAR NOT NULL,
+    repos         VARCHAR NOT NULL,
+    orgs          VARCHAR NOT NULL,
+    login         VARCHAR(39) NOT NULL,
+    name          VARCHAR,
+    avatar_url    VARCHAR NOT NULL,
+    secret        VARCHAR NOT NULL,
+    PRIMARY KEY (user_id)
+);

--- a/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
@@ -21,5 +21,5 @@ object UserSessionsTable {
     insertOrUpdateRequest(table, allFields, allFields)
 
   val selectUserSessionById: Query[UUID, UserState] =
-    selectRequest(table, allFields, Seq("user_id"))
+    selectRequest(table, userStateFields ++ userInfoFields, Seq("user_id"))
 }

--- a/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
@@ -1,0 +1,25 @@
+package scaladex.infra.sql
+
+import java.util.UUID
+
+import doobie.util.query.Query
+import doobie.util.update.Update
+import scaladex.core.model.UserState
+import scaladex.infra.sql.DoobieUtils.Mappings._
+import scaladex.infra.sql.DoobieUtils.insertOrUpdateRequest
+import scaladex.infra.sql.DoobieUtils.selectRequest
+
+object UserSessionsTable {
+
+  private[sql] val table = "user_sessions"
+  private val userId = "user_id"
+  private val userStateFields = Seq("repos", "orgs")
+  private val userInfoFields = Seq("login", "name", "avatar_url", "secret")
+  private val allFields = userId +: (userStateFields ++ userInfoFields)
+
+  val insertOrUpdate: Update[(UUID, UserState)] =
+    insertOrUpdateRequest(table, allFields, allFields)
+
+  val selectUserSessionById: Query[UUID, UserState] =
+    selectRequest(table, allFields, Seq("user_id"))
+}

--- a/modules/infra/src/test/scala/scaladex/infra/sql/UserSessionsTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/UserSessionsTableTests.scala
@@ -1,0 +1,10 @@
+package scaladex.infra.sql
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scaladex.infra.BaseDatabaseSuite
+
+class UserSessionsTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
+  it("check insertOrUpdate")(check(UserSessionsTable.insertOrUpdate))
+  it("check selectUserSessionById")(check(UserSessionsTable.selectUserSessionById))
+}


### PR DESCRIPTION
Sorry about the lack of progress on this, been busy with school.

  * Created `Meta[_]` instances, and implicit readers and writers for `UserInfo`
    and `UserState`
  * Test behaviour seems a bit off... `login` is being reported as an
    `Option[String]` when the SQL schema is `NOT NULL`.
  * Also seems to want me to filter out the "secret" key from the `select`,
    which doesn't make any sense.

Part of work for #947 