### PR TITLE
Load and set user sessions in Server

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -1,12 +1,14 @@
 package scaladex.core.service
 
 import java.time.Instant
+import java.util.UUID
 
 import scala.concurrent.Future
 
 import scaladex.core.model.Artifact
 import scaladex.core.model.ArtifactDependency
 import scaladex.core.model.Project
+import scaladex.core.model.UserState
 
 trait WebDatabase {
   def insertArtifact(artifact: Artifact, dependencies: Seq[ArtifactDependency], time: Instant): Future[Unit]
@@ -20,4 +22,6 @@ trait WebDatabase {
   def getDirectDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Direct]]
   def getReverseDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Reverse]]
   def countArtifacts(): Future[Long]
+  def insertSession(userId: UUID, userState: UserState): Future[Unit]
+  def getSession(userId: UUID): Future[Option[UserState]]
 }

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -1,6 +1,7 @@
 package scaladex.core.test
 
 import java.time.Instant
+import java.util.UUID
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -11,6 +12,7 @@ import scaladex.core.model.GithubInfo
 import scaladex.core.model.GithubStatus
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
+import scaladex.core.model.UserState
 import scaladex.core.service.SchedulerDatabase
 
 class InMemoryDatabase extends SchedulerDatabase {
@@ -117,4 +119,6 @@ class InMemoryDatabase extends SchedulerDatabase {
   override def deleteDependenciesOfMovedProject(): scala.concurrent.Future[Unit] = ???
   override def getAllGroupIds(): Future[Seq[Artifact.GroupId]] = ???
   override def getAllMavenReferences(): Future[Seq[Artifact.MavenReference]] = ???
+  override def insertSession(userId: UUID, userState: UserState): Future[Unit] = ???
+  override def getSession(userId: UUID): Future[Option[UserState]] = ???
 }

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -1,6 +1,7 @@
 package scaladex.infra
 
 import java.time.Instant
+import java.util.UUID
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -14,6 +15,7 @@ import scaladex.core.model.GithubInfo
 import scaladex.core.model.GithubStatus
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
+import scaladex.core.model.UserState
 import scaladex.core.service.SchedulerDatabase
 import scaladex.infra.config.PostgreSQLConfig
 import scaladex.infra.sql.ArtifactDependencyTable
@@ -23,6 +25,7 @@ import scaladex.infra.sql.GithubInfoTable
 import scaladex.infra.sql.ProjectDependenciesTable
 import scaladex.infra.sql.ProjectSettingsTable
 import scaladex.infra.sql.ProjectTable
+import scaladex.infra.sql.UserSessionsTable
 
 class SqlDatabase(conf: PostgreSQLConfig, xa: doobie.Transactor[IO]) extends SchedulerDatabase with LazyLogging {
 
@@ -173,6 +176,12 @@ class SqlDatabase(conf: PostgreSQLConfig, xa: doobie.Transactor[IO]) extends Sch
 
   override def getAllMavenReferences(): Future[Seq[Artifact.MavenReference]] =
     run(ArtifactTable.selectMavenReference.to[Seq])
+
+  override def insertSession(userId: UUID, userState: UserState): Future[Unit] =
+    run(UserSessionsTable.insertOrUpdate.run((userId, userState)).map(_ => ()))
+
+  override def getSession(userId: UUID): Future[Option[UserState]] =
+    run(UserSessionsTable.selectUserSessionById.to[Seq](userId)).map(_.headOption)
 
   private def run[A](v: doobie.ConnectionIO[A]): Future[A] =
     v.transact(xa).unsafeToFuture()

--- a/modules/server/src/main/scala/scaladex/server/GithubUserSession.scala
+++ b/modules/server/src/main/scala/scaladex/server/GithubUserSession.scala
@@ -2,7 +2,6 @@ package scaladex.server
 
 import java.util.UUID
 
-import scala.collection.parallel.mutable.ParTrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Try
@@ -29,12 +28,11 @@ class GithubUserSession(sessionConfig: SessionConfig, database: WebDatabase)(imp
         else logger.info(msg)
   }
 
-  private val users = ParTrieMap[UUID, UserState]()
-
   def addUser(userState: UserState): Future[UUID] = {
     val userId = UUID.randomUUID
     database.insertSession(userId, userState).map(_ => userId)
   }
 
-  def getUser(id: UUID): Option[UserState] = users.get(id)
+  def getUser(id: UUID): Future[Option[UserState]] =
+    database.getSession(id)
 }

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -146,7 +146,7 @@ object Server extends LazyLogging {
     import actor.dispatcher
 
     val githubAuth = new GithubAuthImpl()
-    val session = new GithubUserSession(config.session)
+    val session = new GithubUserSession(config.session, webDatabase)
 
     val searchPages = new SearchPages(config.env, searchEngine)
     val frontPage = new FrontPage(config.env, webDatabase, searchEngine)

--- a/modules/server/src/main/scala/scaladex/server/route/api/SearchApi.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/SearchApi.scala
@@ -1,8 +1,5 @@
 package scaladex.server.route.api
-
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Directive
@@ -51,7 +48,7 @@ class SearchApi(searchEngine: SearchEngine, session: GithubUserSession)(
           val futureRoute = futureMaybeUser.map { maybeUser =>
             request.directive(request => f(Tuple1(request.withUser(maybeUser))))
           }
-          Await.result(futureRoute, Duration.Inf)
+          context => futureRoute.flatMap(_.apply(context))
         }
       }
       def uri(params: SearchParams): Uri = request.uri(params.toAutocomplete)


### PR DESCRIPTION
This work removes the locally-stored user sessions in `GithubSession.scala` and replaces it with a call to the SQL database to read and write user sessions.

This also involves having to make calls in `Server.scala` and `SearchApi.scala` to load the user sessions. Unfortunately, this currently involves the use of `Await`, which I don't think is a good idea, but could not find an alternative. Maybe someone more experienced could take a look?

Eventually closes #947 