### PR TITLE
Add test on storing user session in database

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/GithubAuth.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/GithubAuth.scala
@@ -6,11 +6,5 @@ import scaladex.core.model.UserState
 
 trait GithubAuth {
   def getUserStateWithToken(token: String): Future[UserState]
-
-  def getUserStateWithOauth2(
-      clientId: String,
-      clientSecret: String,
-      code: String,
-      redirectUri: String
-  ): Future[UserState]
+  def getUserStateWithOauth2(code: String): Future[UserState]
 }

--- a/modules/core/shared/src/test/scala/scaladex/core/test/MockGithubAuth.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/MockGithubAuth.scala
@@ -40,11 +40,6 @@ object MockGithubAuth extends GithubAuth {
   override def getUserStateWithToken(token: String): Future[UserState] =
     Future.successful(users(token))
 
-  override def getUserStateWithOauth2(
-      clientId: String,
-      clientSecret: String,
-      code: String,
-      redirectUri: String
-  ): Future[UserState] =
+  override def getUserStateWithOauth2(code: String): Future[UserState] =
     ???
 }

--- a/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/UserSessionsTable.scala
@@ -18,7 +18,7 @@ object UserSessionsTable {
   private val allFields = userId +: (userStateFields ++ userInfoFields)
 
   val insertOrUpdate: Update[(UUID, UserState)] =
-    insertOrUpdateRequest(table, allFields, allFields)
+    insertOrUpdateRequest(table, allFields, Seq(userId))
 
   val selectUserSessionById: Query[UUID, UserState] =
     selectRequest(table, userStateFields ++ userInfoFields, Seq("user_id"))

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -1,5 +1,6 @@
 package scaladex.infra
 
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -11,8 +12,12 @@ import scaladex.core.model.Artifact
 import scaladex.core.model.ArtifactDependency
 import scaladex.core.model.GithubStatus
 import scaladex.core.model.Project
+import scaladex.core.model.Project.Organization
 import scaladex.core.model.ProjectDependency
+import scaladex.core.model.UserInfo
+import scaladex.core.model.UserState
 import scaladex.core.util.ScalaExtensions._
+import scaladex.core.util.Secret
 
 class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers {
 
@@ -218,5 +223,15 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       scalafixInverseDeps shouldBe 0
       catsInverseDeps shouldBe 0
     }
+  }
+
+  it("should insert and get user session from id") {
+    val userId = UUID.randomUUID()
+    val userInfo = UserInfo("login", Some("name"), "", new Secret("token"))
+    val userState = new UserState(Set(Scalafix.reference), Set(Organization("scalacenter")), userInfo)
+    for {
+      _ <- database.insertSession(userId, userState)
+      obtained <- database.getSession(userId)
+    } yield obtained shouldBe Some(userState)
   }
 }

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -146,7 +146,7 @@ object Server extends LazyLogging {
   ): Route = {
     import actor.dispatcher
 
-    val githubAuth = new GithubAuthImpl()
+    val githubAuth = new GithubAuthImpl(config.oAuth2.clientId, config.oAuth2.clientSecret, config.oAuth2.redirectUri)
     val session = new GithubUserSession(config.session, webDatabase)
 
     val searchPages = new SearchPages(config.env, searchEngine)

--- a/modules/server/src/main/scala/scaladex/server/route/Oauth2.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Oauth2.scala
@@ -1,7 +1,6 @@
 package scaladex.server.route
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 import akka.http.scaladsl.model.StatusCodes.TemporaryRedirect
 import akka.http.scaladsl.model.Uri.Query
@@ -13,7 +12,6 @@ import com.softwaremill.session.CsrfDirectives._
 import com.softwaremill.session.CsrfOptions._
 import com.softwaremill.session.SessionDirectives._
 import com.softwaremill.session.SessionOptions._
-import scaladex.core.model.UserState
 import scaladex.core.service
 import scaladex.server.GithubUserSession
 import scaladex.server.config.OAuth2Config
@@ -62,7 +60,7 @@ class Oauth2(config: OAuth2Config, githubAuth: service.GithubAuth, session: Gith
             ),
             pathEnd(
               parameters("code", "state".?) { (code, state) =>
-                val futureUserState = queryUserState(code)
+                val futureUserState = githubAuth.getUserStateWithOauth2(code)
                 val futureUserId = futureUserState.flatMap(session.addUser)
 
                 onSuccess(futureUserId) { userId =>
@@ -89,13 +87,4 @@ class Oauth2(config: OAuth2Config, githubAuth: service.GithubAuth, session: Gith
         )
       )
     )
-
-  def queryUserState(code: String): Future[UserState] =
-    githubAuth
-      .getUserStateWithOauth2(
-        config.clientId,
-        config.clientSecret,
-        code,
-        config.redirectUri
-      )
 }


### PR DESCRIPTION
There was a small bug when inserting a new `userSession` to the databse:
```
org.postgresql.util.PSQLException: ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2553)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2285)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:323)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:481)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:401)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:164)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:130)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at doobie.free.KleisliInterpreter$PreparedStatementInterpreter.$anonfun$executeUpdate$5(kleisliinterpreter.scala:955)
	at doobie.free.KleisliInterpreter$PreparedStatementInterpreter.$anonfun$executeUpdate$5$adapted(kleisliinterpreter.scala:955)
	at doobie.free.KleisliInterpreter.$anonfun$primitive$2(kleisliinterpreter.scala:109)
	at unsafeRunSync @ scaladex.server.Server$.main(Server.scala:64)
	at evalOn @ doobie.util.transactor$Transactor$fromDataSource$FromDataSourceUnapplied.$anonfun$apply$13(transactor.scala:294)
	at $anonfun$tailRecM$1 @ doobie.util.transactor$Transactor$$anon$4.$anonfun$apply$4(transactor.scala:167)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.util.transactor$Transactor$$anon$4.$anonfun$apply$4(transactor.scala:167)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.util.transactor$Transactor$$anon$4.$anonfun$apply$4(transactor.scala:167)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at $anonfun$tailRecM$1 @ doobie.free.KleisliInterpreter$ConnectionInterpreter.$anonfun$bracketCase$28(kleisliinterpreter.scala:750)
	at run @ akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
	at unsafeRunSync @ scaladex.server.Server$.main(Server.scala:64)
```

This PR contains a fix and a test.

Also there is some minor refactoring around `GithubAuth`.