### PR TITLE
Hide artifacts of vigoo/zio-aws

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult
 import scaladex.core.model.Artifact
+import scaladex.core.model.ArtifactSelection
 import scaladex.core.model.Jvm
 import scaladex.core.model.Platform
 import scaladex.core.model.Project
@@ -90,7 +91,6 @@ class Badges(database: WebDatabase)(implicit executionContext: ExecutionContext)
     parameter("target".?) { binaryVersion =>
       shieldsOptionalSubject { (color, style, logo, logoWidth, subject) =>
         val res = getSelectedArtifact(
-          database,
           organization,
           repository,
           binaryVersion,
@@ -162,6 +162,29 @@ class Badges(database: WebDatabase)(implicit executionContext: ExecutionContext)
         }
       }
     }
+
+  private def getSelectedArtifact(
+      org: Project.Organization,
+      repo: Project.Repository,
+      binaryVersion: Option[String],
+      artifact: Option[Artifact.Name],
+      version: Option[String],
+      selected: Option[String]
+  ): Future[Option[Artifact]] = {
+    val artifactSelection = ArtifactSelection.parse(
+      binaryVersion = binaryVersion,
+      artifactName = artifact,
+      version = version,
+      selected = selected
+    )
+    val projectRef = Project.Reference(org, repo)
+    for {
+      project <- database.getProject(projectRef)
+      artifacts <- database.getArtifacts(projectRef)
+      defaultArtifact = project
+        .flatMap(p => artifactSelection.defaultArtifact(artifacts, p))
+    } yield defaultArtifact
+  }
 }
 
 object Badges {

--- a/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
@@ -6,7 +6,7 @@
 @import scala.collection.SortedSet
 
 @(project: Project, artifacts: SortedSet[Artifact.Name], versions: SortedSet[SemanticVersion],
-        binaryVersions: SortedSet[BinaryVersion], artifact: Artifact, canEdit: Boolean)
+        binaryVersions: SortedSet[BinaryVersion], artifactOpt: Option[Artifact], canEdit: Boolean)
 
 <div class="head-project">
   <div class="container">
@@ -72,71 +72,73 @@
           <a class="btn btn-primary" href="/artifacts/@project.reference" >
             Version Matrix
           </a>
-          @if(binaryVersions.nonEmpty) {
+          @for(artifact <- artifactOpt) {
+            @if(binaryVersions.nonEmpty) {
+              <form action="/@project.reference" action="GET">
+                <input type="hidden" name="selected" value="binaryVersion">
+  
+                <input type="hidden" name="artifact" value="@artifact.artifactName">
+  
+                <select
+                  name="binaryVersion"
+                  onchange="this.form.submit()"
+                  data-live-search="true"
+                  class="selectpicker" data-style="btn-primary">
+  
+                @for(binaryVersion <- binaryVersions.iterator){
+                  <option value="@binaryVersion.label"
+                          @if(artifact.binaryVersion == binaryVersion){ selected }>
+                    @binaryVersion
+                  </option>
+                }
+                </select>
+  
+                <input type="hidden" name="version" value="@artifact.version">
+              </form>
+            }
+  
             <form action="/@project.reference" action="GET">
-              <input type="hidden" name="selected" value="binaryVersion">
-
-              <input type="hidden" name="artifact" value="@artifact.artifactName">
-
+  
+              <input type="hidden" name="binaryVersion" value="@artifact.binaryVersion.encode">
+  
+              <input type="hidden" name="selected" value="artifact">
+  
               <select
-                name="binaryVersion"
+                name="artifact"
                 onchange="this.form.submit()"
                 data-live-search="true"
-                class="selectpicker" data-style="btn-primary">
-
-              @for(binaryVersion <- binaryVersions.iterator){
-                <option value="@binaryVersion.label"
-                        @if(artifact.binaryVersion == binaryVersion){ selected }>
-                  @binaryVersion
+                class="selectpicker artifact-name" data-style="btn-primary">
+              @for(artifactName <- artifacts.diff(project.settings.artifactDeprecations).iterator) {
+                <option value="@artifactName" @if(artifactName == artifact.artifactName){ selected }>
+                  @artifactName
                 </option>
               }
               </select>
-
+  
               <input type="hidden" name="version" value="@artifact.version">
             </form>
+  
+            <form action="/@project.reference" action="GET">
+              <input type="hidden" name="selected" value="version">
+  
+              <input type="hidden" name="artifact" value="@artifact.artifactName">
+  
+              <input type="hidden" name="binaryVersion" value="@artifact.binaryVersion.encode">
+  
+              <select
+                name="version"
+                onchange="this.form.submit()"
+                data-live-search="true"
+                class="selectpicker" data-style="btn-primary">
+  
+              @for(version <- versions.iterator){
+                <option value="@version" @if(version == artifact.version){ selected }>
+                  @version
+                </option>
+              }
+              </select>
+            </form>
           }
-
-          <form action="/@project.reference" action="GET">
-
-            <input type="hidden" name="binaryVersion" value="@artifact.binaryVersion.encode">
-
-            <input type="hidden" name="selected" value="artifact">
-
-            <select
-              name="artifact"
-              onchange="this.form.submit()"
-              data-live-search="true"
-              class="selectpicker artifact-name" data-style="btn-primary">
-            @for(artifactName <- artifacts.diff(project.settings.artifactDeprecations).iterator) {
-              <option value="@artifactName" @if(artifactName == artifact.artifactName){ selected }>
-                @artifactName
-              </option>
-            }
-            </select>
-
-            <input type="hidden" name="version" value="@artifact.version">
-          </form>
-
-          <form action="/@project.reference" action="GET">
-            <input type="hidden" name="selected" value="version">
-
-            <input type="hidden" name="artifact" value="@artifact.artifactName">
-
-            <input type="hidden" name="binaryVersion" value="@artifact.binaryVersion.encode">
-
-            <select
-              name="version"
-              onchange="this.form.submit()"
-              data-live-search="true"
-              class="selectpicker" data-style="btn-primary">
-
-            @for(version <- versions.iterator){
-              <option value="@version" @if(version == artifact.version){ selected }>
-                @version
-              </option>
-            }
-            </select>
-          </form>
         </div>
       </div>
     </div>

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -1,7 +1,6 @@
 @import scaladex.view.html.contributingInfo
 @import scaladex.core.model.Project
 @import scaladex.core.model.Artifact
-@import akka.http.scaladsl.model.headers.LinkParams.title
 @import scaladex.core.model.Env
 @import scaladex.core.model.UserState
 @import scaladex.core.model.SemanticVersion
@@ -14,7 +13,7 @@
 @import scala.collection.SortedSet
 @(
   env: Env, project: Project, artifacts: SortedSet[Artifact.Name], versions: SortedSet[SemanticVersion],
-  binaryVersions: SortedSet[BinaryVersion], platforms: SortedSet[Platform], artifact: Artifact, user: Option[UserState],
+  binaryVersions: SortedSet[BinaryVersion], platforms: SortedSet[Platform], artifactOpt: Option[Artifact], user: Option[UserState],
   showEditButton: Boolean, twitterCard: Option[TwitterSummaryCard], artifactCount: Int,
   directDependencies: Seq[ArtifactDependency.Direct], reverseDependency: Seq[ArtifactDependency.Reverse]
 )
@@ -22,7 +21,7 @@
 @main(env, title = project.repository.value, user,
       extraMeta = twitterCard.map(_.toHeadMeta).getOrElse(Nil)) {
   <main id="container-project">
-    @headproject(project, artifacts, versions, binaryVersions, artifact, showEditButton)
+    @headproject(project, artifacts, versions, binaryVersions, artifactOpt, showEditButton)
     <div class="container">
       <div class="row">
         <div class="col-md-8">
@@ -35,15 +34,12 @@
         </div>
         <div class="col-md-4">
           <div class="sidebar-project">
-            @if(project.settings.artifactDeprecations.contains(artifact.artifactName)) {
-            <div class="box">
-              <h1>[DEPRECATED]</h1>
-            </div>
+            @for(artifact <- artifactOpt) {
+              @documentation(artifact, project)
+              @badges(artifact, platforms, env)
+              @install(artifact, project.settings.cliArtifacts)
+              @scastie(artifact.scastieURL)
             }
-            @documentation(artifact, project)
-            @badges(artifact, platforms, env)
-            @install(artifact, project.settings.cliArtifacts)
-            @scastie(artifact.scastieURL)
             @project.githubInfo.map(gh => statistic(gh, project.reference, artifactCount, reverseDependency.size))
             @project.githubInfo.map { github =>
               @if(github.openIssues.nonEmpty && github.chatroom.isDefined && github.contributingGuide.isDefined) {
@@ -57,9 +53,11 @@
               }
             }
             @project.githubInfo.map(gh => contributors(gh.contributors))
-            @license(artifact)
-            @dependencies(project.reference, directDependencies)
-            @dependents(artifact, reverseDependency)
+            @for(artifact <- artifactOpt) {
+              @license(artifact)
+              @dependencies(project.reference, directDependencies)
+              @dependents(artifact, reverseDependency)
+            }
           </div>
         </div>
       </div>


### PR DESCRIPTION
The `vigoo/zio-aws` project has more than 190 000 published artifacts. That's almost 1/5 of all artifacts in Scaladex.

As consequence it consumes a lot of CPU to load the page of that project.

This temporary fix is to not load any artifacts for this particular project.

After the redesign of the project page we should be able to remove this temporary fix.