### PR TITLE
Limit the number of loaded artifacts on a project page

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
@@ -40,8 +40,10 @@ object ArtifactTable {
   val updateReleaseDate: Update[(Instant, Artifact.MavenReference)] =
     updateRequest(table, Seq("release_date"), mavenReferenceFields)
 
-  val selectArtifactByProject: Query[Project.Reference, Artifact] =
-    selectRequest(table, Seq("*"), projectReferenceFields)
+  val selectArtifactByProject: Query[Project.Reference, Artifact] = {
+    val where = projectReferenceFields.map(f => s"$f=?").mkString(" AND ")
+    selectRequest1(table, "*", where = Some(where), orderBy = Some("release_date DESC"), limit = Some(10000))
+  }
 
   val selectArtifactByProjectAndName: Query[(Project.Reference, Artifact.Name), Artifact] =
     selectRequest(table, Seq("*"), projectReferenceFields :+ "artifact_name")

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
@@ -116,6 +116,22 @@ object DoobieUtils {
     Query0(sql)
   }
 
+  def selectRequest1[A: Write, B: Read](
+      table: String,
+      fields: String,
+      where: Option[String] = None,
+      groupBy: Seq[String] = Seq.empty,
+      orderBy: Option[String] = None,
+      limit: Option[Long] = None
+  ): Query[A, B] = {
+    val sql = s"SELECT $fields FROM $table" +
+      where.map(p => s" WHERE $p").getOrElse("") +
+      (if (groupBy.nonEmpty) groupBy.mkString(" GROUP BY ", ", ", "") else "") +
+      orderBy.map(o => s" ORDER BY $o").getOrElse("") +
+      limit.map(l => s" LIMIT $l").getOrElse("")
+    Query(sql)
+  }
+
   def deleteRequest[T: Write](table: String, where: Seq[String]): Update[T] = {
     val whereK = where.map(k => s"$k=?").mkString(" AND ")
     Update(s"DELETE FROM $table WHERE $whereK")

--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.server.RequestContext
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult
 import scaladex.core.model.Artifact
+import scaladex.core.model.ArtifactSelection
 import scaladex.core.model.Jvm
 import scaladex.core.model.Platform
 import scaladex.core.model.Project
@@ -90,7 +91,6 @@ class Badges(database: WebDatabase)(implicit executionContext: ExecutionContext)
     parameter("target".?) { binaryVersion =>
       shieldsOptionalSubject { (color, style, logo, logoWidth, subject) =>
         val res = getSelectedArtifact(
-          database,
           organization,
           repository,
           binaryVersion,
@@ -162,6 +162,29 @@ class Badges(database: WebDatabase)(implicit executionContext: ExecutionContext)
         }
       }
     }
+
+  private def getSelectedArtifact(
+      org: Project.Organization,
+      repo: Project.Repository,
+      binaryVersion: Option[String],
+      artifact: Option[Artifact.Name],
+      version: Option[String],
+      selected: Option[String]
+  ): Future[Option[Artifact]] = {
+    val artifactSelection = ArtifactSelection.parse(
+      binaryVersion = binaryVersion,
+      artifactName = artifact,
+      version = version,
+      selected = selected
+    )
+    val projectRef = Project.Reference(org, repo)
+    for {
+      project <- database.getProject(projectRef)
+      artifacts <- database.getArtifacts(projectRef)
+      defaultArtifact = project
+        .flatMap(p => artifactSelection.defaultArtifact(artifacts, p))
+    } yield defaultArtifact
+  }
 }
 
 object Badges {

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -312,4 +312,24 @@ class ProjectPages(env: Env, database: WebDatabase, searchEngine: SearchEngine)(
           Tuple1(settings)
       }
     )
+
+  private def getSelectedArtifact(
+      database: WebDatabase,
+      project: Project,
+      binaryVersion: Option[String],
+      artifact: Option[Artifact.Name],
+      version: Option[String],
+      selected: Option[String]
+  ): Future[Option[Artifact]] = {
+    val artifactSelection = ArtifactSelection.parse(
+      binaryVersion = binaryVersion,
+      artifactName = artifact,
+      version = version,
+      selected = selected
+    )
+    for {
+      artifacts <- database.getArtifacts(project.reference)
+      defaultArtifact = artifactSelection.defaultArtifact(artifacts, project)
+    } yield defaultArtifact
+  }
 }


### PR DESCRIPTION
This is an alternative solution to #984.

We only load the latest 10K artifact.

That currently affects 14 projects listed below:

organization | repository | count
-- | -- | --
vigoo | zio-aws | 193380
zio | zio-aws | 57033
thoughtworksinc | dsl.scala | 38936
trace4cats | trace4cats | 32169
digital-asset | daml | 28735
com-lihaoyi | mill | 23907
http4s | http4s | 17993
precog | quasar | 15613
lightbend | cloudflow | 14904
7mind | izumi | 13649
etorreborre | specs2 | 11957
tmtsoftware | csw | 11672
wvlet | airframe | 11255
softwaremill | tapir | 10278


</body>

</html>
