### PR TITLE
Include ETag header in badge response

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -75,7 +75,7 @@ class Badges(database: WebDatabase)(implicit executionContext: ExecutionContext)
       logoWidth.map(w => ("logoWidth", w.toString))
     ).flatten.map { case (k, v) => k + "=" + v }.mkString("?", "&", "")
 
-    respondWithHeader(`Cache-Control`(`no-cache`)) {
+    respondWithHeaders(`Cache-Control`(`no-cache`), ETag(status)) {
       redirect(
         s"https://img.shields.io/badge/$subject-$status-$color.svg$query",
         TemporaryRedirect


### PR DESCRIPTION
According to https://github.com/github/markup/issues/224#issuecomment-33454537 this is required to prevent badge caching.
> Assets must include `Cache-Control: no-cache` and `ETag` headers. If a badge is not updating, then it means they are not properly setting these headers.

I believe we can use the `status` as the `ETag`, since this is the dynamic part of the reponse (i.e. the result of the version lookup). Everything else should be determined by the URL itself.