### PR TITLE
Adding `/api/artifacts/<group_id>/<artifact_id>` endpoint

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactEndpointSchema.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactEndpointSchema.scala
@@ -10,4 +10,14 @@ trait ArtifactEndpointSchema extends PaginationSchema {
       .xmap[ArtifactResponse] { case (groupId, artifactId) => ArtifactResponse(groupId, artifactId) } {
         case ArtifactResponse(groupId, artifactId) => (groupId, artifactId)
       }
+
+  implicit val artifactMetadataResponseSchema: JsonSchema[ArtifactMetadataResponse] =
+    field[String]("version")
+      .zip(optField[String]("projectReference"))
+      .zip(field[String]("releaseDate"))
+      .zip(field[String]("language"))
+      .zip(field[String]("platform"))
+      .xmap[ArtifactMetadataResponse](ArtifactMetadataResponse.tupled)(
+        Function.unlift(ArtifactMetadataResponse.unapply)
+      )
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactEndpoints.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactEndpoints.scala
@@ -17,10 +17,29 @@ trait ArtifactEndpoints
     docs = Some("Filter the results matching the given platform only (e.g., 'jvm', 'sjs1', 'native0.4', 'sbt1.0')")
   )).xmap((ArtifactParams.apply _).tupled)(Function.unlift(ArtifactParams.unapply))
 
+  val artifactMetadataEndpointParams: Path[ArtifactMetadataParams] = (segment[String](
+    name = "group_id",
+    docs = Some(
+      "Filter the results matching the given group id only (e.g., 'org.typelevel', 'org.scala-lang', 'org.apache.spark')"
+    )
+  ) / segment[String](
+    name = "artifact_id",
+    docs = Some(
+      "Filter the results matching the given artifact id only (e.g., 'cats-core_3', 'cats-core_sjs0.6_2.13')"
+    )
+  )).xmap(ArtifactMetadataParams.tupled)(Function.unlift(ArtifactMetadataParams.unapply))
+
   // Artifact endpoint definition
   val artifact: Endpoint[ArtifactParams, Page[ArtifactResponse]] =
     endpoint(
       get(path / "api" / "artifacts" /? artifactEndpointParams),
       ok(jsonResponse[Page[ArtifactResponse]])
+    )
+
+  // Artifact metadata endpoint definition
+  val artifactMetadata: Endpoint[ArtifactMetadataParams, Page[ArtifactMetadataResponse]] =
+    endpoint(
+      get(path / "api" / "artifacts" / artifactMetadataEndpointParams),
+      ok(jsonResponse[Page[ArtifactMetadataResponse]])
     )
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactMetadataParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactMetadataParams.scala
@@ -1,0 +1,3 @@
+package scaladex.core.api.artifact
+
+final case class ArtifactMetadataParams(groupId: String, artifactId: String)

--- a/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactMetadataResponse.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/artifact/ArtifactMetadataResponse.scala
@@ -1,0 +1,9 @@
+package scaladex.core.api.artifact
+
+final case class ArtifactMetadataResponse(
+    version: String,
+    projectReference: Option[String],
+    releaseDate: String,
+    language: String,
+    platform: String
+)

--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import fastparse.P
 import fastparse.Start
 import fastparse._
+import scaladex.core.api.artifact.ArtifactMetadataResponse
 import scaladex.core.model.PatchVersion
 import scaladex.core.model.Project.DocumentationLink
 import scaladex.core.util.Parsers._
@@ -243,4 +244,12 @@ object Artifact {
       s"http://search.maven.org/#artifactdetails|$groupId|$artifactId|$version|jar"
   }
 
+  def toMetadataResponse(artifact: Artifact): ArtifactMetadataResponse =
+    ArtifactMetadataResponse(
+      version = artifact.version.toString,
+      projectReference = Some(artifact.projectRef.toString),
+      releaseDate = artifact.releaseDate.toString,
+      language = artifact.language.toString,
+      platform = artifact.platform.toString
+    )
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/model/search/Page.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/search/Page.scala
@@ -5,3 +5,12 @@ case class Page[A](pagination: Pagination, items: Seq[A]) {
 
   def flatMap[B](f: A => Iterable[B]): Page[B] = Page(pagination, items.flatMap(f))
 }
+
+object Page {
+
+  def empty[A]: Page[A] =
+    Page(
+      pagination = Pagination(current = 1, pageCount = 1, totalSize = 0),
+      items = Seq.empty
+    )
+}

--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -22,7 +22,7 @@ trait WebDatabase {
   def getProject(projectRef: Project.Reference): Future[Option[Project]]
   def getFormerReferences(projectRef: Project.Reference): Future[Seq[Project.Reference]]
   def countInverseProjectDependencies(projectRef: Project.Reference): Future[Int]
-  def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]]
+  def getArtifacts(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Artifact]]
   def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]]
   def getArtifactsByName(projectRef: Project.Reference, artifactName: Artifact.Name): Future[Seq[Artifact]]
   def getArtifactByMavenReference(mavenRef: Artifact.MavenReference): Future[Option[Artifact]]

--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -22,6 +22,7 @@ trait WebDatabase {
   def getProject(projectRef: Project.Reference): Future[Option[Project]]
   def getFormerReferences(projectRef: Project.Reference): Future[Seq[Project.Reference]]
   def countInverseProjectDependencies(projectRef: Project.Reference): Future[Int]
+  def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]]
   def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]]
   def getArtifactsByName(projectRef: Project.Reference, artifactName: Artifact.Name): Future[Seq[Artifact]]
   def getArtifactByMavenReference(mavenRef: Artifact.MavenReference): Future[Option[Artifact]]

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -57,6 +57,13 @@ class InMemoryDatabase extends SchedulerDatabase {
   override def getProject(projectRef: Project.Reference): Future[Option[Project]] =
     Future.successful(projects.get(projectRef))
 
+  override def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]] =
+    Future.successful {
+      artifacts.values.flatten.find { artifact: Artifact =>
+        artifact.groupId == groupId && artifact.artifactId == artifactId.value
+      }
+    }
+
   override def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]] =
     Future.successful(artifacts.getOrElse(projectRef, Nil))
 

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -57,11 +57,11 @@ class InMemoryDatabase extends SchedulerDatabase {
   override def getProject(projectRef: Project.Reference): Future[Option[Project]] =
     Future.successful(projects.get(projectRef))
 
-  override def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]] =
+  override def getArtifacts(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Artifact]] =
     Future.successful {
-      artifacts.values.flatten.find { artifact: Artifact =>
+      artifacts.values.flatten.filter { artifact: Artifact =>
         artifact.groupId == groupId && artifact.artifactId == artifactId.value
-      }
+      }.toSeq
     }
 
   override def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]] =

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -129,8 +129,8 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO]) exten
   override def getProject(projectRef: Project.Reference): Future[Option[Project]] =
     run(ProjectTable.selectByReference.option(projectRef))
 
-  override def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]] =
-    run(ArtifactTable.selectArtifactByGroupIdAndArtifactId.option(groupId, artifactId))
+  override def getArtifacts(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Artifact]] =
+    run(ArtifactTable.selectArtifactByGroupIdAndArtifactId.to[Seq](groupId, artifactId))
 
   override def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]] =
     run(ArtifactTable.selectArtifactByProject.to[Seq](projectRef))

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -129,6 +129,9 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO]) exten
   override def getProject(projectRef: Project.Reference): Future[Option[Project]] =
     run(ProjectTable.selectByReference.option(projectRef))
 
+  override def getArtifact(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Option[Artifact]] =
+    run(ArtifactTable.selectArtifactByGroupIdAndArtifactId.option(groupId, artifactId))
+
   override def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]] =
     run(ArtifactTable.selectArtifactByProject.to[Seq](projectRef))
 

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
@@ -65,6 +65,9 @@ object ArtifactTable {
   val selectArtifactByLanguageAndPlatform: Query[(Language, Platform), Artifact] =
     selectRequest(table, fields, keys = Seq("language_version", "platform"))
 
+  val selectArtifactByGroupIdAndArtifactId: Query[(Artifact.GroupId, Artifact.ArtifactId), Artifact] =
+    selectRequest(table, fields, Seq("group_id", "artifact_id"))
+
   val selectArtifactByProject: Query[Project.Reference, Artifact] = {
     val where = projectReferenceFields.map(f => s"$f=?").mkString(" AND ")
     selectRequest1(

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
@@ -153,6 +153,8 @@ object DoobieUtils {
       Meta[String].timap(_.split(",").filter(_.nonEmpty).map(Artifact.Name.apply).toSet)(_.mkString(","))
     implicit val semanticVersionMeta: Meta[SemanticVersion] =
       Meta[String].timap(SemanticVersion.parse(_).get)(_.encode)
+    implicit val artifactIdMeta: Meta[Artifact.ArtifactId] =
+      Meta[String].timap(Artifact.ArtifactId.parse(_).get)(_.value)
     implicit val binaryVersionMeta: Meta[BinaryVersion] =
       Meta[String].timap { x =>
         BinaryVersion

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -334,4 +334,32 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       )
     } yield storedArtifacts.size shouldBe 0
   }
+
+  it("should not return any artifacts when the database is empty, given a group id and artifact id") {
+    val testArtifact = Cats.`core_3:4`
+    val testArtifactId = Artifact.ArtifactId
+      .parse(testArtifact.artifactId)
+      .getOrElse(fail("Parsing an artifact id should not have failed"))
+    for {
+      maybeRetrievedArtifact <- database.getArtifact(testArtifact.groupId, testArtifactId)
+      storedArtifacts <- database.getAllArtifacts(None, None)
+    } yield {
+      maybeRetrievedArtifact shouldBe None
+      storedArtifacts.size shouldBe 0
+    }
+  }
+
+  it("should return an artifact, given a group id an artifact id of a stored artifact") {
+    val testArtifact = Cats.`core_3:4`
+    val testArtifactId = Artifact.ArtifactId
+      .parse(testArtifact.artifactId)
+      .getOrElse(fail("Parsing an artifact id should not have failed"))
+    for {
+      isStoredSuccessfully <- database.insertArtifact(testArtifact, dependencies = Cats.dependencies, now)
+      maybeRetrievedArtifact <- database.getArtifact(testArtifact.groupId, testArtifactId)
+    } yield {
+      isStoredSuccessfully shouldBe true
+      maybeRetrievedArtifact shouldBe Some(testArtifact)
+    }
+  }
 }

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
@@ -10,6 +10,7 @@ class ArtifactTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers
   it("check selectArtifactByLanguage")(check(ArtifactTable.selectArtifactByLanguage))
   it("check selectArtifactByPlatform")(check(ArtifactTable.selectArtifactByPlatform))
   it("check selectArtifactByLanguageAndPlatform")(check(ArtifactTable.selectArtifactByLanguageAndPlatform))
+  it("check selectArtifactByGroupIdAndArtifactId")(check(ArtifactTable.selectArtifactByGroupIdAndArtifactId))
   it("check selectArtifactByProject")(check(ArtifactTable.selectArtifactByProject))
   it("check selectArtifactByProjectAndName")(check(ArtifactTable.selectArtifactByProjectAndName))
   it("check findOldestArtifactsPerProjectReference")(check(ArtifactTable.selectOldestByProject))

--- a/modules/server/src/main/scala/scaladex/server/route/api/ApiDocumentation.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/ApiDocumentation.scala
@@ -20,5 +20,5 @@ object ApiDocumentation
       title = "Scaladex API",
       version = "0.1.0"
     )
-  )(autocomplete, artifact)
+  )(autocomplete, artifact, artifactMetadata)
 }

--- a/modules/server/src/test/scala/scaladex/server/route/api/ArtifactApiTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/api/ArtifactApiTests.scala
@@ -126,6 +126,23 @@ class ArtifactApiTests extends ControllerBaseSuite with BeforeAndAfterEach with 
       }
     }
 
+    it("should not return any artifacts given a valid group id and an artifact id that does not parse") {
+      val malformedArtifactId = "badArtifactId"
+      Get(s"/api/artifacts/org.apache.spark/$malformedArtifactId") ~> artifactRoute ~> check {
+        status shouldBe StatusCodes.OK
+        val response = responseAs[Page[ArtifactMetadataResponse]]
+        response shouldBe Page.empty[ArtifactMetadataResponse]
+      }
+    }
+
+    it("should not return any artifacts given an invalid group id and a valid artifact id") {
+      Get("/api/artifacts/ca.ubc.cs/cats-core_3") ~> artifactRoute ~> check {
+        status shouldBe StatusCodes.OK
+        val response = responseAs[Page[ArtifactMetadataResponse]]
+        response shouldBe Page.empty[ArtifactMetadataResponse]
+      }
+    }
+
     it("should return artifacts with the given group id and artifact id") {
       Get("/api/artifacts/org.typelevel/cats-core_3") ~> artifactRoute ~> check {
         status shouldBe StatusCodes.OK


### PR DESCRIPTION
## Summary of Work

  * [`WebDatabase#getArtifacts(groupId, artifactId): Future[Seq[Artifact]]`](https://github.com/scalacenter/scaladex/compare/yoo/add-artifact-data-endpoint?expand=1#diff-2ce2689f5215078761c39afa95acdd451e9be2261b8c1da5d532a75ded5936ceR25), with associated tests in `ArtifactTestTable.scala` and `SqlDatabaseTests.scala`.
  * Defined the `/api/artifacts/<group_id>/<artifact_id>` endpoint in `ArtifactEndpoints`, added them to `ArtifactApi.scala`, with associated tests.

Closes #998