### PR TITLE
Use default artifact to get latest version

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -57,5 +57,5 @@ trait WebDatabase {
       now: Instant
   ): Future[Unit]
   def countVersions(ref: Project.Reference): Future[Long]
-  def getLastVersion(ref: Project.Reference): Future[SemanticVersion]
+  def getLastVersion(ref: Project.Reference, defaultArtifactName: Option[Artifact.Name]): Future[SemanticVersion]
 }

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -268,12 +268,25 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO]) exten
   override def countVersions(ref: Project.Reference): Future[Long] =
     run(ArtifactTable.countVersionsByProjct.unique(ref))
 
-  override def getLastVersion(ref: Project.Reference): Future[SemanticVersion] =
-    for {
-      versionOpt <- run(ArtifactTable.findLastSemanticVersionNotPrerelease.to[Seq](ref))
-      version <-
-        if (versionOpt.isEmpty) run(ArtifactTable.findLastVersion.unique(ref)) else Future.successful(versionOpt.head)
-    } yield version
+  override def getLastVersion(ref: Project.Reference, artifactNameOpt: Option[Artifact.Name]): Future[SemanticVersion] =
+    artifactNameOpt match {
+      case Some(artifactName) =>
+        for {
+          versionOpt <- run(ArtifactTable.selectLastReleaseVersionByArtifactName.option((ref, artifactName)))
+          version <- versionOpt match {
+            case Some(version) => Future.successful(version)
+            case None          => run(ArtifactTable.selectLastVersionByArtifactName.unique((ref, artifactName)))
+          }
+        } yield version
+      case None =>
+        for {
+          versionOpt <- run(ArtifactTable.selectLastReleaseVersion.option(ref))
+          version <- versionOpt match {
+            case Some(version) => Future.successful(version)
+            case None          => run(ArtifactTable.selectLastVersion.unique(ref))
+          }
+        } yield version
+    }
 
   def moveProject(
       ref: Project.Reference,

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
@@ -154,7 +154,7 @@ object ArtifactTable {
       groupBy = Seq("organization", "repository ", "platform ", "language_version", "version")
     )
 
-  val findLastSemanticVersionNotPrerelease: Query[Project.Reference, SemanticVersion] =
+  val selectLastReleaseVersion: Query[Project.Reference, SemanticVersion] =
     selectRequest1(
       table,
       "version",
@@ -163,11 +163,30 @@ object ArtifactTable {
       limit = Some(1L)
     )
 
-  val findLastVersion: Query[Project.Reference, SemanticVersion] =
+  val selectLastVersion: Query[Project.Reference, SemanticVersion] =
     selectRequest1(
       table,
       "version",
       where = Some("organization=? AND repository=?"),
+      orderBy = Some("release_date DESC"),
+      limit = Some(1L)
+    )
+
+  val selectLastReleaseVersionByArtifactName: Query[(Project.Reference, Artifact.Name), SemanticVersion] =
+    selectRequest1(
+      table,
+      "version",
+      where =
+        Some("organization=? AND repository=? AND artifact_name=? AND is_semantic='true' and is_prerelease='false'"),
+      orderBy = Some("release_date DESC"),
+      limit = Some(1L)
+    )
+
+  val selectLastVersionByArtifactName: Query[(Project.Reference, Artifact.Name), SemanticVersion] =
+    selectRequest1(
+      table,
+      "version",
+      where = Some("organization=? AND repository=? AND artifact_name=?"),
       orderBy = Some("release_date DESC"),
       limit = Some(1L)
     )

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
@@ -31,5 +31,8 @@ class ArtifactTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers
     check(ArtifactTable.selectArtifactByParams(Seq(`_sjs0.6_2.13`), false))
   }
   it("check selectMavenReferenceWithNoReleaseDate")(check(ArtifactTable.selectMavenReferenceWithNoReleaseDate))
-  it("check findLastVersion")(check(ArtifactTable.findLastSemanticVersionNotPrerelease))
+  it("check selectLastVersion")(check(ArtifactTable.selectLastVersion))
+  it("check selectLastReleaseVersion")(check(ArtifactTable.selectLastReleaseVersion))
+  it("check selectLastVersionByArtifactName")(check(ArtifactTable.selectLastVersionByArtifactName))
+  it("check selectLastReleaseVersionByArtifactName")(check(ArtifactTable.selectLastReleaseVersionByArtifactName))
 }


### PR DESCRIPTION
In some monorepos, like [endpoint4s/endpoint4s](https://index.scala-lang.org/endpoints4s/endpoints4s), some artifacts are released separately, with different version numbers. So to get the latest version of the project we should better rely on the configured default artifact in the project settings.