### PR TITLE
Use project_dependencies table in project dependency boxes

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
@@ -2,5 +2,8 @@ package scaladex.core.model
 
 case class ProjectDependency(
     source: Project.Reference,
-    target: Project.Reference
+    sourceVersion: SemanticVersion,
+    target: Project.Reference,
+    targetVersion: SemanticVersion,
+    scope: ArtifactDependency.Scope
 )

--- a/modules/core/shared/src/main/scala/scaladex/core/model/search/ProjectDocument.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/search/ProjectDocument.scala
@@ -22,7 +22,7 @@ final case class ProjectDocument(
     updateDate: Option[Instant],
     languages: Seq[Language],
     platforms: Seq[Platform],
-    inverseProjectDependencies: Int,
+    dependents: Long,
     category: Option[Category],
     formerReferences: Seq[Project.Reference],
     githubInfo: Option[GithubInfoDocument]
@@ -55,7 +55,7 @@ object ProjectDocument {
   def apply(
       project: Project,
       artifacts: Seq[Artifact],
-      inverseProjectDependencies: Int,
+      dependents: Long,
       formerReferences: Seq[Project.Reference]
   ): ProjectDocument = {
     import project._
@@ -68,7 +68,7 @@ object ProjectDocument {
       updateDate = None,
       artifacts.map(_.binaryVersion.language).distinct.sorted,
       artifacts.map(_.binaryVersion.platform).distinct.sorted,
-      inverseProjectDependencies,
+      dependents,
       settings.category,
       formerReferences,
       project.githubInfo.map(_.toDocument)

--- a/modules/core/shared/src/main/scala/scaladex/core/service/SchedulerDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/SchedulerDatabase.scala
@@ -12,23 +12,29 @@ import scaladex.core.model.GithubStatus
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
 import scaladex.core.model.ReleaseDependency
+import scaladex.core.model.SemanticVersion
 
 trait SchedulerDatabase extends WebDatabase {
+  // project and github
   def insertProject(project: Project): Future[Unit]
-  def insertArtifacts(artifacts: Seq[Artifact]): Future[Unit] // for init process
-  def insertDependencies(dependencies: Seq[ArtifactDependency]): Future[Unit]
-  def getAllProjectsStatuses(): Future[Map[Project.Reference, GithubStatus]]
-  def getDependencies(projectRef: Project.Reference): Future[Seq[ArtifactDependency]]
-  def updateArtifacts(artifacts: Seq[Artifact], newRef: Project.Reference): Future[Int]
-  def updateArtifactReleaseDate(reference: MavenReference, releaseDate: Instant): Future[Int]
-  def computeProjectDependencies(): Future[Seq[ProjectDependency]]
-  def computeReleaseDependencies(): Future[Seq[ReleaseDependency]]
   def updateGithubInfoAndStatus(ref: Project.Reference, githubInfo: GithubInfo, status: GithubStatus): Future[Unit]
-  def computeAllProjectsCreationDates(): Future[Seq[(Instant, Project.Reference)]]
   def updateProjectCreationDate(ref: Project.Reference, creationDate: Instant): Future[Unit]
+  def computeAllProjectsCreationDates(): Future[Seq[(Instant, Project.Reference)]]
+  def getAllProjectsStatuses(): Future[Map[Project.Reference, GithubStatus]]
+
+  // project dependencies (and release dependencies)
+  def computeProjectDependencies(reference: Project.Reference, version: SemanticVersion): Future[Seq[ProjectDependency]]
+  def computeReleaseDependencies(): Future[Seq[ReleaseDependency]]
   def insertProjectDependencies(projectDependencies: Seq[ProjectDependency]): Future[Int]
   def insertReleaseDependencies(projectDependencies: Seq[ReleaseDependency]): Future[Int]
-  def deleteDependenciesOfMovedProject(): Future[Unit]
+  def deleteProjectDependencies(ref: Project.Reference): Future[Int]
+
+  // artifacts and its dependencies
+  def insertArtifacts(artifacts: Seq[Artifact]): Future[Unit] // for init process
+  def insertDependencies(dependencies: Seq[ArtifactDependency]): Future[Unit]
+  def updateArtifacts(artifacts: Seq[Artifact], newRef: Project.Reference): Future[Int]
+  def updateArtifactReleaseDate(reference: MavenReference, releaseDate: Instant): Future[Int]
   def getAllGroupIds(): Future[Seq[Artifact.GroupId]]
   def getAllMavenReferences(): Future[Seq[Artifact.MavenReference]]
+  def getDependencies(projectRef: Project.Reference): Future[Seq[ArtifactDependency]]
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -12,19 +12,15 @@ import scaladex.core.model.GithubResponse
 import scaladex.core.model.Language
 import scaladex.core.model.Platform
 import scaladex.core.model.Project
-import scaladex.core.model.ReleaseDependency
+import scaladex.core.model.ProjectDependency
 import scaladex.core.model.SemanticVersion
 import scaladex.core.model.UserState
-import scaladex.core.model.web.ArtifactsPageParams
+import scaladex.core.web.ArtifactsPageParams
 
 trait WebDatabase {
-  // insertArtifact return a boolean. It's true if the a new project is inserted, false otherwise
+  // artifacts
+  // insertArtifact return a boolean. It's true if a new project is inserted, false otherwise
   def insertArtifact(artifact: Artifact, dependencies: Seq[ArtifactDependency], time: Instant): Future[Boolean]
-  def updateProjectSettings(ref: Project.Reference, settings: Project.Settings): Future[Unit]
-  def getAllProjects(): Future[Seq[Project]]
-  def getProject(projectRef: Project.Reference): Future[Option[Project]]
-  def getFormerReferences(projectRef: Project.Reference): Future[Seq[Project.Reference]]
-  def countInverseProjectDependencies(projectRef: Project.Reference): Future[Int]
   def getArtifacts(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Artifact]]
   def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]]
   def getArtifacts(
@@ -39,18 +35,17 @@ trait WebDatabase {
   def getAllArtifacts(maybeLanguage: Option[Language], maybePlatform: Option[Platform]): Future[Seq[Artifact]]
   def getArtifactNames(ref: Project.Reference): Future[Seq[Artifact.Name]]
   def getArtifactPlatforms(ref: Project.Reference, artifactName: Artifact.Name): Future[Seq[Platform]]
+  def countArtifacts(): Future[Long]
+
+  // artifact dependencies
   def getDirectDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Direct]]
   def getReverseDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Reverse]]
-  def getDirectReleaseDependencies(
-      ref: Project.Reference,
-      version: SemanticVersion
-  ): Future[Seq[ReleaseDependency.Direct]]
-  def getReverseReleaseDependencies(ref: Project.Reference): Future[Seq[ReleaseDependency.Reverse]]
-  def countArtifacts(): Future[Long]
-  def insertSession(userId: UUID, userState: UserState): Future[Unit]
-  def getSession(userId: UUID): Future[Option[UserState]]
-  def getAllSessions(): Future[Seq[(UUID, UserState)]]
-  def deleteSession(userId: UUID): Future[Unit]
+
+  // projects
+  def updateProjectSettings(ref: Project.Reference, settings: Project.Settings): Future[Unit]
+  def getAllProjects(): Future[Seq[Project]]
+  def getProject(projectRef: Project.Reference): Future[Option[Project]]
+  def getFormerReferences(projectRef: Project.Reference): Future[Seq[Project.Reference]]
   def updateGithubInfo(
       repo: Project.Reference,
       response: GithubResponse[(Project.Reference, GithubInfo)],
@@ -58,4 +53,15 @@ trait WebDatabase {
   ): Future[Unit]
   def countVersions(ref: Project.Reference): Future[Long]
   def getLastVersion(ref: Project.Reference, defaultArtifactName: Option[Artifact.Name]): Future[SemanticVersion]
+
+  // project dependencies
+  def countProjectDependents(projectRef: Project.Reference): Future[Long]
+  def getProjectDependencies(ref: Project.Reference, version: SemanticVersion): Future[Seq[ProjectDependency]]
+  def getProjectDependents(ref: Project.Reference): Future[Seq[ProjectDependency]]
+
+  // sessions
+  def insertSession(userId: UUID, userState: UserState): Future[Unit]
+  def getSession(userId: UUID): Future[Option[UserState]]
+  def getAllSessions(): Future[Seq[(UUID, UserState)]]
+  def deleteSession(userId: UUID): Future[Unit]
 }

--- a/modules/core/shared/src/main/scala/scaladex/core/web/ArtifactPageParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/web/ArtifactPageParams.scala
@@ -1,4 +1,4 @@
-package scaladex.core.model.web
+package scaladex.core.web
 
 import scaladex.core.model.BinaryVersion
 

--- a/modules/core/shared/src/main/scala/scaladex/core/web/ArtifactsPageParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/web/ArtifactsPageParams.scala
@@ -1,4 +1,4 @@
-package scaladex.core.model.web
+package scaladex.core.web
 
 import scaladex.core.model.BinaryVersion
 

--- a/modules/core/shared/src/test/scala/scaladex/core/test/Values.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/Values.scala
@@ -172,11 +172,14 @@ object Values {
     val `core_2.13:2.6.1`: Artifact = getArtifact("cats-core", `_2.13`, `2.6.1`, description = Some("Cats core"))
     val `core_3:4`: Artifact = getArtifact("cats-core", `_3`, `4`, description = Some("Cats core"))
     val `core_3:2.7.0`: Artifact = getArtifact("cats-core", `_3`, `2.7.0`, description = Some("Cats core"))
+
     val core_sjs1_3: Artifact = getArtifact("cats-core", `_sjs1_3`, `2.6.1`, description = Some("Cats core"))
     val core_sjs06_213: Artifact =
       getArtifact("cats-core", `_sjs0.6_2.13`, `2.6.1`, description = Some("Cats core"))
     val core_native04_213: Artifact =
       getArtifact("cats-core", `_native0.4_2.13`, `2.6.1`, description = Some("Cats core"))
+
+    val `kernel_2.13`: Artifact = getArtifact("cats-kernel", `_2.13`, `2.6.1`)
     val kernel_3: Artifact = getArtifact("cats-kernel", `_3`, `2.6.1`)
     val laws_3: Artifact = getArtifact("cats-laws", `_3`, `2.6.1`)
 

--- a/modules/infra/src/main/resources/migrations/V14__new_project_dependencies.sql
+++ b/modules/infra/src/main/resources/migrations/V14__new_project_dependencies.sql
@@ -1,0 +1,12 @@
+DROP TABLE project_dependencies;
+
+CREATE TABLE project_dependencies (
+  source_organization  VARCHAR(39)  NOT NULL,
+  source_repository   VARCHAR(100) NOT NULL,
+  source_version VARCHAR NOT NULL,
+  target_organization VARCHAR(39)  NOT NULL,
+  target_repository   VARCHAR(100) NOT NULL,
+  target_version VARCHAR NOT NULL,
+  scope VARCHAR,
+  PRIMARY KEY (source_organization, source_repository, source_version, target_organization, target_repository, target_version, scope)
+);

--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -196,7 +196,7 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(implicit ec: E
       case Sorting.Forks        => Some(combinedWithPercentage("githubInfo.forks"))
       case Sorting.Contributors => Some(combinedWithPercentage("githubInfo.contributorCount"))
       case Sorting.Dependent =>
-        Some(fieldFactorScore("inverseProjectDependencies").missing(0).modifier(FieldValueFactorFunctionModifier.LOG1P))
+        Some(fieldFactorScore("dependents").missing(0).modifier(FieldValueFactorFunctionModifier.LOG1P))
     }
 
     val scoringQuery = scorer match {

--- a/modules/infra/src/main/scala/scaladex/infra/elasticsearch/ElasticsearchMapping.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/elasticsearch/ElasticsearchMapping.scala
@@ -57,7 +57,7 @@ object ElasticsearchMapping {
     dateField("creationDate"),
     keywordField("languages"),
     keywordField("platforms"),
-    intField("inverseProjectDependencies"),
+    intField("dependents"),
     keywordField("category"),
     textField("githubInfo.description").analyzer("english"),
     textField("githubInfo.readme").analyzer("english_readme"),

--- a/modules/infra/src/main/scala/scaladex/infra/elasticsearch/RawProjectDocument.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/elasticsearch/RawProjectDocument.scala
@@ -25,7 +25,7 @@ case class RawProjectDocument(
     updateDate: Option[Instant],
     languages: Seq[String],
     platforms: Seq[String],
-    inverseProjectDependencies: Int,
+    dependents: Long,
     category: Option[String],
     formerReferences: Seq[Project.Reference],
     githubInfo: Option[GithubInfoDocument]
@@ -39,7 +39,7 @@ case class RawProjectDocument(
     updateDate,
     languages.flatMap(Language.fromLabel).sorted,
     platforms.flatMap(Platform.fromLabel).sorted,
-    inverseProjectDependencies,
+    dependents,
     category.flatMap(Category.byLabel.get),
     formerReferences,
     githubInfo
@@ -63,7 +63,7 @@ object RawProjectDocument {
       updateDate,
       languages.map(_.label),
       platforms.map(_.label),
-      inverseProjectDependencies,
+      dependents,
       category.map(_.label),
       formerReferences,
       githubInfo

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
@@ -7,6 +7,7 @@ import scaladex.core.model.ArtifactDependency
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
 import scaladex.core.model.ReleaseDependency
+import scaladex.core.model.SemanticVersion
 import scaladex.infra.sql.DoobieUtils.Mappings._
 import scaladex.infra.sql.DoobieUtils._
 
@@ -17,25 +18,25 @@ object ArtifactDependencyTable {
   val fields: Seq[String] = sourceFields ++ targetFields ++ Seq("scope")
 
   private val tableWithSourceArtifact =
-    s"$table d " +
+    s"($table d " +
       s"INNER JOIN ${ArtifactTable.table} a ON " +
       s"d.source_group_id = a.group_id AND " +
       s"d.source_artifact_id = a.artifact_id AND " +
-      s"d.source_version = a.version"
+      s"d.source_version = a.version)"
 
   private val tableWithTargetArtifact =
-    s"$table d " +
+    s"($table d " +
       s"LEFT JOIN ${ArtifactTable.table} a ON " +
       s"d.target_group_id = a.group_id AND " +
       s"d.target_artifact_id = a.artifact_id AND " +
-      s"d.target_version = a.version"
+      s"d.target_version = a.version)"
 
   private val fullJoin =
-    s"($tableWithSourceArtifact) d " +
+    s"($tableWithSourceArtifact d " +
       s"INNER JOIN ${ArtifactTable.table} t ON " +
       s"d.target_group_id = t.group_id AND " +
       s"d.target_artifact_id = t.artifact_id AND " +
-      s"d.target_version = t.version"
+      s"d.target_version = t.version)"
 
   private val dependencyAndArtifactFields =
     fields.map("d." + _) ++
@@ -64,12 +65,14 @@ object ArtifactDependencyTable {
       targetFields.map(f => s"d.$f")
     )
 
-  val computeProjectDependency: Query0[ProjectDependency] =
-    selectRequest(
+  val computeProjectDependencies: Query[(Project.Reference, SemanticVersion), ProjectDependency] =
+    selectRequest1[(Project.Reference, SemanticVersion, Project.Reference), ProjectDependency](
       fullJoin,
-      "d.organization, d.repository, t.organization, t.repository",
-      groupBy = Seq("d.organization", "d.repository", "t.organization", "t.repository")
-    )
+      "d.organization, d.repository, d.version, t.organization, t.repository, t.version, d.scope",
+      where = Some("d.organization=? AND d.repository=? AND d.version=? AND (t.organization<>? OR t.repository<>?)"),
+      groupBy =
+        Seq("d.organization", "d.repository", "d.version", "t.organization", "t.repository", "t.version", "d.scope")
+    ).contramap { case (ref, version) => (ref, version, ref) }
 
   val computeReleaseDependency: Query0[ReleaseDependency] = {
     val sourceReleaseFields = ReleaseTable.primaryKeys.map("d." + _)

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
@@ -3,32 +3,33 @@ package scaladex.infra.sql
 import doobie._
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
+import scaladex.core.model.SemanticVersion
 import scaladex.infra.sql.DoobieUtils.Mappings._
 import scaladex.infra.sql.DoobieUtils._
 
 object ProjectDependenciesTable {
   val table: String = "project_dependencies"
 
-  val sourceFields: Seq[String] = Seq("source_organization", "source_repository")
-  val targetFields: Seq[String] = Seq("target_organization", "target_repository")
-  val fields: Seq[String] = sourceFields ++ targetFields
+  val sourceFields: Seq[String] = Seq("source_organization", "source_repository", "source_version")
+  val targetFields: Seq[String] = Seq("target_organization", "target_repository", "target_version")
+  val allFields: Seq[String] = sourceFields ++ targetFields :+ "scope"
 
   val insertOrUpdate: Update[ProjectDependency] =
-    insertOrUpdateRequest(table, fields, fields)
+    insertOrUpdateRequest(table, allFields, allFields)
 
-  val countInverseDependencies: Query[Project.Reference, Int] =
-    selectRequest(table, Seq("COUNT(*)"), targetFields)
+  val countDependents: Query[Project.Reference, Long] =
+    selectRequest(
+      table,
+      Seq("COUNT(DISTINCT (source_organization, source_repository))"),
+      Seq("target_organization", "target_repository")
+    )
 
-  val getInverseDependencies: Query[Project.Reference, Project.Reference] =
-    selectRequest(table, sourceFields, targetFields)
+  val getDependents: Query[Project.Reference, ProjectDependency] =
+    selectRequest(table, allFields, Seq("target_organization", "target_repository"))
 
-  val getDirectDependencies: Query[Project.Reference, Project.Reference] =
-    selectRequest(table, targetFields, sourceFields)
+  val getDependencies: Query[(Project.Reference, SemanticVersion), ProjectDependency] =
+    selectRequest(table, allFields, sourceFields)
 
   val deleteBySource: Update[Project.Reference] =
-    deleteRequest(table, sourceFields)
-
-  val deleteByTarget: Update[Project.Reference] =
-    deleteRequest(table, targetFields)
-
+    deleteRequest(table, Seq("source_organization", "source_repository"))
 }

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ReleaseDependenciesTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ReleaseDependenciesTable.scala
@@ -1,12 +1,8 @@
 package scaladex.infra.sql
 
-import doobie._
 import doobie.util.update.Update
-import scaladex.core.model.Project
 import scaladex.core.model.ReleaseDependency
-import scaladex.core.model.SemanticVersion
 import scaladex.infra.sql.DoobieUtils.Mappings._
-import scaladex.infra.sql.DoobieUtils._
 import scaladex.infra.sql.DoobieUtils.insertOrUpdateRequest
 
 object ReleaseDependenciesTable {
@@ -37,34 +33,4 @@ object ReleaseDependenciesTable {
 
   val insertIfNotExists: Update[ReleaseDependency] =
     insertOrUpdateRequest(table, fields, primaryKeys)
-
-  val getDirectDependencies: Query[(Project.Reference, SemanticVersion), ReleaseDependency.Direct] =
-    selectRequest1[(Project.Reference, SemanticVersion, Project.Reference), ReleaseDependency.Direct](
-      table,
-      s"target_organization, target_repository, target_version, $scope",
-      where = Some(
-        "source_organization=? AND source_repository=? AND source_version=? AND NOT target_organization=? AND NOT target_repository=?"
-      ),
-      groupBy = Seq("target_organization", "target_repository", "target_version", scope)
-    ).contramap { case (ref, v) => (ref, v, ref) }
-
-  val getReverseDependencies: Query[Project.Reference, ReleaseDependency.Reverse] =
-    Query[(Project.Reference, Project.Reference), ReleaseDependency.Reverse](
-      """|SELECT DISTINCT organization, repository, target_version, scope
-         |FROM release_dependencies rd
-         |JOIN (
-         |	SELECT a1.organization, a1.repository, MAX(a1.version) AS version
-         |	FROM releases as a1
-         |	JOIN (
-         |		SELECT organization, repository, MAX(release_date) AS release_date
-         |		FROM releases
-         |		GROUP BY organization, repository
-         |	) AS a2
-         |	ON a1.organization=a2.organization AND a1.repository=a2.repository AND a1.release_date=a2.release_date
-         |	GROUP BY a1.organization, a1.repository
-         |) AS r
-         |ON source_organization=organization AND source_repository=repository AND source_version=version
-         |WHERE target_organization=? AND target_repository=? AND NOT source_organization=? AND NOT source_repository=?
-         |""".stripMargin
-    ).contramap(ref => (ref, ref))
 }

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactDependencyTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactDependencyTableTests.scala
@@ -10,6 +10,6 @@ class ArtifactDependencyTableTests extends AnyFunSpec with BaseDatabaseSuite wit
   it("check select")(check(ArtifactDependencyTable.select))
   it("check selectDirectDependency")(check(ArtifactDependencyTable.selectDirectDependency))
   it("check selectReverseDependency")(check(ArtifactDependencyTable.selectReverseDependency))
-  it("check selectProjectDependency")(check(ArtifactDependencyTable.computeProjectDependency))
+  it("check computeProjectDependencies")(check(ArtifactDependencyTable.computeProjectDependencies))
   it("check computeReleaseDependency")(check(ArtifactDependencyTable.computeReleaseDependency))
 }

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
@@ -8,7 +8,7 @@ import scaladex.infra.sql.ProjectDependenciesTable
 class ProjectDependenciesTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
   it("check insertOrUpdate")(check(ProjectDependenciesTable.insertOrUpdate))
   it("check deleteBySource")(check(ProjectDependenciesTable.deleteBySource))
-  it("check deleteByTarget")(check(ProjectDependenciesTable.deleteByTarget))
-  it("check getInverseDependencies")(check(ProjectDependenciesTable.getInverseDependencies))
-  it("check getDirectDependencies")(check(ProjectDependenciesTable.getDirectDependencies))
+  it("check getDependencies")(check(ProjectDependenciesTable.getDependencies))
+  it("check getDependents")(check(ProjectDependenciesTable.getDependents))
+  it("check countDependents")(check(ProjectDependenciesTable.countDependents))
 }

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ReleaseDependenciesTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ReleaseDependenciesTableTests.scala
@@ -6,6 +6,4 @@ import scaladex.infra.BaseDatabaseSuite
 
 class ReleaseDependenciesTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
   it("check insertIfNotExists")(check(ReleaseDependenciesTable.insertIfNotExists))
-  it("check getDirectDependencies")(check(ReleaseDependenciesTable.getDirectDependencies))
-  it("check getReverseDependencies")(check(ReleaseDependenciesTable.getReverseDependencies))
 }

--- a/modules/server/src/main/scala/scaladex/server/service/SearchSynchronizer.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/SearchSynchronizer.scala
@@ -61,8 +61,8 @@ class SearchSynchronizer(database: WebDatabase, searchEngine: SearchEngine)(impl
   private def insertDocument(project: Project, formerReferences: Seq[Project.Reference]): Future[Unit] =
     for {
       artifacts <- database.getArtifacts(project.reference)
-      inverseProjectDependencies <- database.countInverseProjectDependencies(project.reference)
-      document = ProjectDocument(project, artifacts, inverseProjectDependencies, formerReferences)
+      dependents <- database.countProjectDependents(project.reference)
+      document = ProjectDocument(project, artifacts, dependents, formerReferences)
       _ <- searchEngine.insert(document)
       _ <- formerReferences.mapSync(searchEngine.delete)
     } yield ()

--- a/modules/template/src/main/scala/scaladex/view/html/package.scala
+++ b/modules/template/src/main/scala/scaladex/view/html/package.scala
@@ -13,7 +13,7 @@ import scaladex.core.model.Category
 import scaladex.core.model.Project
 import scaladex.core.model.search.AwesomeParams
 import scaladex.core.model.search.SearchParams
-import scaladex.core.model.web.ArtifactsPageParams
+import scaladex.core.web.ArtifactsPageParams
 
 package object html {
 

--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -1,6 +1,6 @@
 @import scaladex.core.model._
 @import scaladex.view.html.main
-@import scaladex.core.model.web.ArtifactPageParams
+@import scaladex.core.web.ArtifactPageParams
 @import scaladex.view.Formats
 @import scaladex.view.html._
 

--- a/modules/template/src/main/twirl/scaladex/view/project/artifacts.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifacts.scala.html
@@ -1,7 +1,7 @@
 @import scaladex.core.model.{Artifact, BinaryVersion, Project, SemanticVersion, UserState, Env}
 @import scaladex.view.html.main
 @import scaladex.view.html._
-@import scaladex.core.model.web.ArtifactsPageParams
+@import scaladex.core.web.ArtifactsPageParams
 @import scaladex.core.model.Language
 @import scala.collection.SortedMap
 @import scaladex.core.util.ScalaExtensions._


### PR DESCRIPTION
Add `source_version`, `target_version` and `scope` in `project_dependencies` table. Adapt the synchronizer accordingly. Use this table to compute the project dependency boxes of the project page. This is more performant (no join). Also the project dependents count in elastic is more consistent with the new way of computing the project dependencies.