### PR TITLE
Adding Scala CLI dependency install instructions

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -156,6 +156,9 @@ case class Artifact(
     ).flatten.mkString("\n")
   }
 
+  def scalaCliInstall: String =
+    s"//> using lib $groupId::$artifactId:$version"
+
   def csLaunch: String =
     s"cs launch $groupId:$artifactId:$version"
 

--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -156,8 +156,10 @@ case class Artifact(
     ).flatten.mkString("\n")
   }
 
-  def scalaCliInstall: String =
-    s"//> using lib $groupId::$artifactId:$version"
+  def scalaCliInstall: String = {
+    val artifactOperator = if (isNonStandardLib) ":" else "::"
+    s"//> using lib $groupId$artifactOperator$artifactId:$version"
+  }
 
   def csLaunch: String =
     s"cs launch $groupId:$artifactId:$version"

--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -152,6 +152,7 @@
       @if(cliArtifacts.contains(artifact.artifactName)) {
         @tabLink("coursier", "Coursier")
       }
+      @tabLink("scalaCli", "Scala CLI")
       @tabLink("ammonite", "Ammonite")
       @tabLink("maven", "Maven")
       @tabLink("gradle", "Gradle")
@@ -165,6 +166,9 @@
         @tabPanel("coursier", artifact.csLaunch) {
           <a href="https://get-coursier.io/docs/cli-overview">Coursier</a>
         }
+      }
+      @tabPanel("scalaCli", artifact.scalaCliInstall) {
+        <a href="https://scala-cli.virtuslab.org/docs/overview">Scala CLI</a>
       }
       @tabPanel("ammonite", artifact.ammInstall) {
         <a href="https://ammonite.io/#Ammonite-REPL">Ammonite REPL</a>


### PR DESCRIPTION
The syntax for installing an artifact via Scala CLI now appears between
the Mill and Ammonite install instructions.

Resolves #1016.