### PR TITLE
Improve usability of commit activity chart

### DIFF
--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -80,7 +80,7 @@
   @if(commitActivities.nonEmpty){
     <div class="box commit-activities">
       <h4>Commit Activity</h4>
-      <div class="commit-activity-container"><canvas id="commit-activity" data-commit-activity-count=@{commitActivities.flatMap(_.days).mkString(",")} data-commit-activity-starting-day=@{startingDay} /></div>
+      <div class="commit-activity-container"><canvas id="commit-activity" data-commit-activity-count=@{commitActivities.map(_.total).mkString(",")} data-commit-activity-starting-day=@{startingDay} /></div>
     </div>
   }
 }

--- a/modules/webclient/src/main/scala/scaladex/client/ChartJS.scala
+++ b/modules/webclient/src/main/scala/scaladex/client/ChartJS.scala
@@ -113,19 +113,10 @@ object LineOptions {
       .asInstanceOf[LineOptions]
 }
 
-@js.native
 trait PointOptions extends js.Object {
-  def radius: Int = js.native
-  def borderColor: String = js.native
-}
-object PointOptions {
-  def apply(radius: Int, borderColor: String = "black"): PointOptions =
-    js.Dynamic
-      .literal(
-        radius = radius,
-        borderColor = borderColor
-      )
-      .asInstanceOf[PointOptions]
+  var radius: js.UndefOr[Int] = js.undefined
+  var hitRadius: js.UndefOr[Int] = js.undefined
+  var borderColor: js.UndefOr[String] = js.undefined
 }
 
 @js.native

--- a/modules/webclient/src/main/scala/scaladex/client/Sparkline.scala
+++ b/modules/webclient/src/main/scala/scaladex/client/Sparkline.scala
@@ -17,7 +17,7 @@ object Sparkline {
     if (startingDay.nonEmpty) {
       val startDate = Instant.ofEpochSecond(startingDay.toLong)
       val data = commits.zipWithIndex.map {
-        case (commit, index) => DataPoint(startDate.plus(index, ChronoUnit.DAYS).toEpochMilli().toDouble, commit)
+        case (commit, index) => DataPoint(startDate.plus(index * 7, ChronoUnit.DAYS).toEpochMilli.toDouble, commit)
       }
       val ctx = canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
       val grad = ctx.createLinearGradient(0, 0, canvas.width, canvas.height)
@@ -39,9 +39,10 @@ object Sparkline {
             borderWidth = 1,
             fill = "origin"
           ),
-          point = PointOptions(
+          point = new PointOptions {
             radius = 0
-          )
+            hitRadius = 10
+          }
         ),
         scales = ScaleOptions(
           x = AxisTimeOptions(


### PR DESCRIPTION
- Group commits by week
- Use hit radius of 10 px

@joke1196, I allowed myself to tweak the activity chart a bit, is it okay?

## Before
![activity-before](https://user-images.githubusercontent.com/13123162/185389969-f0bd6962-31a5-48c0-a71c-7de4d8681e23.gif)

## After
![activity-after](https://user-images.githubusercontent.com/13123162/185389979-ab05bd5c-f301-4036-9ad9-5d01aa8158b9.gif)
