### PR TITLE
Fix badges page

### DIFF
--- a/modules/template/src/main/twirl/scaladex/view/project/badges.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/badges.scala.html
@@ -24,15 +24,15 @@
         <section class="badge-section" id="latest">
           <h2>Latest version</h2>
           <img src="@artifact.latestBadgeUrl(env)" />
-          <pre aria-label="Badge markdown" id="badge-markdown">[![@artifact.artifactName Scala version support](@artifact.latestBadgeUrl(env)](@artifact.fullHttpUrl(env))</pre>
+          <pre aria-label="Badge markdown" id="badge-markdown">[![@artifact.artifactName Scala version support](@artifact.latestBadgeUrl(env))](@artifact.fullHttpUrl(env))</pre>
           <button class="btn btn-primary btn-copy pull-right" data-clipboard-target="badge-markdown">Copy Markdown</button>
         </section>
         @platforms.iterator.map { platform =>
           <section class="badge-section" id="@platform">
             <h2>@platform badge</h2>
             <img src="@artifact.badgeUrl(env, Some(platform))" />
-            <pre aria-label="Badge markdown" id="badge-markdown">[![@artifact.artifactName Scala version support](@artifact.badgeUrl(env, Some(platform))](@artifact.fullHttpUrl(env))</pre>
-            <button class="btn btn-primary btn-copy pull-right" data-clipboard-target="badge-markdown">Copy Markdown</button>
+            <pre aria-label="Badge markdown" id="badge-markdown-@platform">[![@artifact.artifactName Scala version support](@artifact.badgeUrl(env, Some(platform)))](@artifact.fullHttpUrl(env))</pre>
+            <button class="btn btn-primary btn-copy pull-right" data-clipboard-target="badge-markdown-@platform">Copy Markdown</button>
           </section>
         }
       </div>


### PR DESCRIPTION
In Badges page, markdown examples are wrong (`)` is missing after the image url).

Also, "Copy Markdown" buttons for platforms copy the latest version example.