### PR TITLE
Fixing bullet list rendering (closes #1043)

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Platform.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Platform.scala
@@ -25,10 +25,10 @@ object ScalaJs {
 }
 
 case class SbtPlugin(version: SemanticVersion) extends Platform {
-  override def toString: String = 
+  override def toString: String =
     version match {
       case MinorVersion(1, 0) => s"sbt 1.x"
-      case _ => s"sbt $version"
+      case _                  => s"sbt $version"
     }
   override def label: String = s"sbt${version.encode}"
   override def isValid: Boolean = SbtPlugin.stableVersions.contains(this)

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -75,11 +75,6 @@
   .box {
     margin-bottom: 30px;
   }
-  
-  ul {
-    padding: 15px;
-    margin: 8px;
-  }
 
   .dependencies,
   .dependents {
@@ -95,6 +90,14 @@
       top: -2px;
       position: relative;
       margin-left: 5px;
+    }
+    
+    ul {
+      padding: 0;
+      margin: 0;
+      li {
+        list-style: none;
+      }
     }
   }
   

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -77,11 +77,8 @@
   }
   
   ul {
-    padding: 0;
-    margin: 0;
-    li {
-      list-style: none;
-    }
+    padding: 15px;
+    margin: 8px;
   }
 
   .dependencies,


### PR DESCRIPTION
Bullet lists should now render correctly in pages.

Previously (e.g., for the `scalafmt` page)
![image](https://user-images.githubusercontent.com/24359440/189566159-e79070ef-49b3-4d48-ab61-03f07da78bfa.png)

With the changes in this PR, the same section now renders as follows:
![image](https://user-images.githubusercontent.com/24359440/189566182-b7b3a588-dd4e-489f-b995-983aad7241a1.png)
