### PR TITLE
Fixing ordering of semantic versions in OldSearchApi response

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/api/OldSearchApi.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/OldSearchApi.scala
@@ -190,7 +190,8 @@ class OldSearchApi(searchEngine: SearchEngine, database: WebDatabase)(
       selected <- filteredArtifacts.headOption
     } yield {
       val artifacts = filteredArtifacts.map(_.artifactName).distinct
-      val versions = filteredArtifacts.map(_.version).distinct
+      // Sort semantic versions by descending order
+      val versions = filteredArtifacts.map(_.version).distinct.sorted(Ordering[SemanticVersion].reverse)
       OldSearchApi.ArtifactOptions(
         artifacts.map(_.value),
         versions.map(_.toString),

--- a/modules/server/src/test/scala/scaladex/server/route/api/SearchApiTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/api/SearchApiTests.scala
@@ -43,7 +43,7 @@ class OldSearchApiTests extends ControllerBaseSuite with PlayJsonSupport {
       Get("/api/project?organization=typelevel&repository=cats") ~> searchApi.routes ~> check {
         val result = responseAs[OldSearchApi.ArtifactOptions]
         (result.artifacts should contain).theSameElementsInOrderAs(Seq("cats-core", "cats-kernel", "cats-laws"))
-        result.versions should contain theSameElementsAs Seq(`2.7.0`, `2.6.1`).map(_.toString)
+        (result.versions should contain).theSameElementsInOrderAs(Seq(`2.7.0`, `2.6.1`).map(_.toString))
         result.groupId shouldBe Cats.groupId.value
         result.artifactId shouldBe Cats.`core_3:2.7.0`.artifactId
         result.version shouldBe `2.7.0`.toString


### PR DESCRIPTION
Versions should now be returned by the API in descending order. Resolves #1059.