### PR TITLE
Switch to endpoints4s::fetch-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,7 @@ lazy val webclient = project
     scalacOptions += "-Wunused:imports",
     libraryDependencies ++= Seq(
       "com.lihaoyi" %%% "scalatags" % "0.11.1",
-      "org.endpoints4s" %%% "xhr-client" % "5.1.0"
+      "org.endpoints4s" %%% "fetch-client" % "3.0.0"
     )
   )
   .enablePlugins(ScalaJSPlugin)

--- a/modules/webclient/src/main/scala/scaladex/client/rpc/RPC.scala
+++ b/modules/webclient/src/main/scala/scaladex/client/rpc/RPC.scala
@@ -1,8 +1,8 @@
 package scaladex.client.rpc
 
-import endpoints4s.xhr
+import endpoints4s.fetch
 import scaladex.core.api.SearchEndpoints
 
-object RPC extends SearchEndpoints with xhr.future.Endpoints with xhr.JsonEntitiesFromSchemas {
-  override def settings: xhr.EndpointsSettings = xhr.EndpointsSettings()
+object RPC extends SearchEndpoints with fetch.future.Endpoints with fetch.JsonEntitiesFromSchemas {
+  override def settings: fetch.EndpointsSettings = fetch.EndpointsSettings()
 }


### PR DESCRIPTION
The fetch-client interpreter is more actively maintained than the xhr-client interpreter.