### PR TITLE
Reverse sort stats by Scala/SJS/SN/SBT/Mill version on frontpage

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
@@ -56,11 +56,11 @@ class FrontPage(env: Env, database: WebDatabase, searchEngine: SearchEngine)(imp
         "Typelevel" -> "typelevel"
       )
 
-      val scalaVersions = languages.collect { case (v: Scala, c) => (v, c) }
-      val scalaJsVersions = platforms.collect { case (v: ScalaJs, c) => (v, c) }
-      val scalaNativeVersions = platforms.collect { case (v: ScalaNative, c) => (v, c) }
-      val sbtVersions = platforms.collect { case (v: SbtPlugin, c) => (v, c) }
-      val millVersions = platforms.collect { case (v: MillPlugin, c) => (v, c) }
+      val scalaVersions = languages.collect { case (v: Scala, c) => (v, c) }.sortBy(_._1.version).reverse
+      val scalaJsVersions = platforms.collect { case (v: ScalaJs, c) => (v, c) }.sortBy(_._1.version).reverse
+      val scalaNativeVersions = platforms.collect { case (v: ScalaNative, c) => (v, c) }.sortBy(_._1.version).reverse
+      val sbtVersions = platforms.collect { case (v: SbtPlugin, c) => (v, c) }.sortBy(_._1.version).reverse
+      val millVersions = platforms.collect { case (v: MillPlugin, c) => (v, c) }.sortBy(_._1.version).reverse
 
       frontpage(
         env,

--- a/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.server.Route
 import play.twirl.api.HtmlFormat
 import scaladex.core.model.Env
 import scaladex.core.model.MillPlugin
+import scaladex.core.model.Platform
 import scaladex.core.model.SbtPlugin
 import scaladex.core.model.Scala
 import scaladex.core.model.ScalaJs
@@ -17,7 +18,6 @@ import scaladex.core.service.SearchEngine
 import scaladex.core.service.WebDatabase
 import scaladex.server.TwirlSupport._
 import scaladex.view.html.frontpage
-import scaladex.core.model.Platform
 
 class FrontPage(env: Env, database: WebDatabase, searchEngine: SearchEngine)(implicit ec: ExecutionContext) {
   val limitOfProjects = 12

--- a/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
@@ -33,7 +33,7 @@
               @if(project.scalaVersions.nonEmpty){
                 <div>
                   Scala versions:
-                  @for(scalaVersion <- project.scalaVersions) {
+                  @for(scalaVersion <- project.scalaVersions.sortBy(_.version).reverse) {
                     <span class="targets">@scalaVersion.version</span>
                   }
                 </div>
@@ -42,7 +42,7 @@
               @if(project.scalaJsVersions.nonEmpty){
                 <div>
                   Scala.js versions:
-                  @for(v <- project.scalaJsVersions) {
+                  @for(v <- project.scalaJsVersions.sortBy(_.version).reverse) {
                     <span class="targets">@v.version</span>
                   }
                 </div>
@@ -51,7 +51,7 @@
               @if(project.scalaNativeVersions.nonEmpty){
                 <div>
                   Scala Native versions:
-                  @for(v <- project.scalaNativeVersions) {
+                  @for(v <- project.scalaNativeVersions.sortBy(_.version).reverse) {
                     <span class="targets">@v.version</span>
                   }
                 </div>
@@ -60,7 +60,7 @@
               @if(project.sbtVersions.nonEmpty){
                 <div>
                   sbt plugins:
-                  @for(v <- project.sbtVersions) {
+                  @for(v <- project.sbtVersions.sortBy(_.version).reverse) {
                     <span class="targets">@v.version</span>
                   }
                 </div>
@@ -69,7 +69,7 @@
               @if(project.millVersions.nonEmpty){
                 <div>
                   Mill plugins:
-                  @for(v <- project.millVersions) {
+                  @for(v <- project.millVersions.sortBy(_.version).reverse) {
                     <span class="targets">@v.version</span>
                   }
                 </div>


### PR DESCRIPTION
Closes #1151 

Front page:

![image](https://user-images.githubusercontent.com/1052965/215576485-bc3f8728-f71c-4810-b164-717c741bc953.png)

Search results: 
![image](https://user-images.githubusercontent.com/1052965/215576516-95465c39-9388-46b6-b495-d37950986d42.png)

VS the current ordering on scaladex: 
<img width="566" alt="image" src="https://user-images.githubusercontent.com/1052965/215576645-9a576e4a-76cb-4b63-b2f2-3b9cde4bf43c.png">
