### PR TITLE
update scala-cli dependency using directive

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -191,13 +191,13 @@ case class Artifact(
   def scalaCliInstall: Option[String] =
     binaryVersion.platform match {
       case MillPlugin(_) | SbtPlugin(_) => None
-      case ScalaNative(_) | ScalaJs(_)  => Some(s"""//> using lib "$groupId::$artifactName::$version"""")
+      case ScalaNative(_) | ScalaJs(_)  => Some(s"""//> using dep "$groupId::$artifactName::$version"""")
       case Jvm =>
         binaryVersion.language match {
-          case _ if isNonStandardLib        => Some(s"""//> using lib "$groupId:$artifactId:$version"""")
-          case Java                         => Some(s"""//> using lib "$groupId:$artifactId:$version"""")
-          case Scala(PatchVersion(_, _, _)) => Some(s"""//> using lib "$groupId:::$artifactName:$version"""")
-          case _                            => Some(s"""//> using lib "$groupId::$artifactName:$version"""")
+          case _ if isNonStandardLib        => Some(s"""//> using dep "$groupId:$artifactId:$version"""")
+          case Java                         => Some(s"""//> using dep "$groupId:$artifactId:$version"""")
+          case Scala(PatchVersion(_, _, _)) => Some(s"""//> using dep "$groupId:::$artifactName:$version"""")
+          case _                            => Some(s"""//> using dep "$groupId::$artifactName:$version"""")
         }
     }
 


### PR DESCRIPTION
with scala-cli v0.2.0 the dependency using directive is renamed to `dep`. see release notes: https://github.com/VirtusLab/scala-cli/releases/tag/v0.2.0