### PR TITLE
Update Github info of not found projects

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
@@ -10,6 +10,7 @@ import scaladex.core.model.UserState
 import scaladex.server.TwirlSupport._
 import scaladex.server.service.AdminService
 import scaladex.view
+import scaladex.view.Task
 
 class AdminPage(env: Env, adminService: AdminService) {
 
@@ -38,20 +39,29 @@ class AdminPage(env: Env, adminService: AdminService) {
               }
             } ~
             post {
-              path("tasks" / "missing-artifacts") {
+              path("tasks" / Task.findMissingArtifacts.name) {
                 formFields("group-id", "artifact-name") { (rawGroupId, rawArtifactName) =>
                   val groupId = Artifact.GroupId(rawGroupId)
                   val artifactNameOpt = if (rawArtifactName.isEmpty) None else Some(Artifact.Name(rawArtifactName))
-                  adminService.runMissingArtifactsTask(groupId, artifactNameOpt, user)
+                  adminService.findMissingArtifacts(groupId, artifactNameOpt, user)
                   redirect(Uri("/admin"), StatusCodes.SeeOther)
                 }
               }
             } ~
             post {
-              path("tasks" / "missing-project-no-artifact") {
+              path("tasks" / Task.updateGithubInfo.name) {
                 formFields("organization", "repository") { (org, repo) =>
                   val reference = Project.Reference.from(org, repo)
-                  adminService.addProjectNoArtifact(reference, user)
+                  adminService.updateGithubInfo(reference, user)
+                  redirect(Uri("/admin"), StatusCodes.SeeOther)
+                }
+              }
+            } ~
+            post {
+              path("tasks" / Task.addEmptyProject.name) {
+                formFields("organization", "repository") { (org, repo) =>
+                  val reference = Project.Reference.from(org, repo)
+                  adminService.addEmptyProject(reference, user)
                   redirect(Uri("/admin"), StatusCodes.SeeOther)
                 }
               }

--- a/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
@@ -19,7 +19,7 @@ class GithubUpdater(database: WebDatabase, github: GithubClient)(implicit ec: Ex
     database.getAllProjectsStatuses().flatMap { projectStatuses =>
       val projectToUpdate =
         projectStatuses
-          .filter { case (_, status) => !status.isMoved && !status.isNotFound }
+          .filter { case (_, status) => !status.isMoved }
           .toSeq
           .sortBy(_._2)
           .map(_._1)

--- a/modules/template/src/main/scala/scaladex/view/Task.scala
+++ b/modules/template/src/main/scala/scaladex/view/Task.scala
@@ -9,14 +9,19 @@ import scaladex.core.util.TimeUtils
 final case class Task(name: String, description: String)
 
 object Task {
-  val missingArtifacts: Task = Task(
-    "missing-artifacts",
-    "Fetch all missing artifacts from Maven Central, given a group ID and an optional artifact name."
+  val findMissingArtifacts: Task = Task(
+    "find-missing-artifacts",
+    "Find all missing artifacts from Maven Central."
   )
 
-  val missingProjectNoArtifact: Task = Task(
-    "missing-project-no-artifact",
-    "Fetch a missing project without any published artifact, given a project reference."
+  val addEmptyProject: Task = Task(
+    "add-empty-project",
+    "Add project from Github without any published artifact."
+  )
+
+  val updateGithubInfo: Task = Task(
+    "update-github-info",
+    "Update the Github info of an existing project"
   )
 
   case class Status(name: String, user: String, start: Instant, input: Seq[(String, String)], state: State) {

--- a/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
@@ -65,10 +65,10 @@
       <tbody>
         <tr>
           <td>
-            <h5>@Task.missingArtifacts.name</h5>
-            <p>@Task.missingArtifacts.description</p>
+            <h5>@Task.findMissingArtifacts.name</h5>
+            <p>@Task.findMissingArtifacts.description</p>
           </td>
-          <form action="/admin/tasks/missing-artifacts" method="POST">
+          <form action="/admin/tasks/@Task.findMissingArtifacts.name" method="POST">
             <td>
               <div class="input-group">
                 <span class="input-group-addon" id="group-id">Group ID</span>
@@ -84,10 +84,29 @@
         </tr>
         <tr>
           <td>
-            <h5>@Task.missingProjectNoArtifact.name</h5>
-            <p>@Task.missingProjectNoArtifact.description</p>
+            <h5>@Task.addEmptyProject.name</h5>
+            <p>@Task.addEmptyProject.description</p>
           </td>
-          <form action="/admin/tasks/missing-project-no-artifact" method="POST">
+          <form action="/admin/tasks/@Task.addEmptyProject.name" method="POST">
+            <td>
+              <div class="input-group">
+                <span class="input-group-addon" id="organization">Organization</span>
+                <input type="text" class="form-control" name="organization" placeholder="Ex: scalacenter" required>
+              </div>
+              <div class="input-group">
+                <span class="input-group-addon" id="repository">Repository</span>
+                <input type="text" class="form-control" name="repository" placeholder="Ex: bloop">
+              </div>
+            </td>
+            <td><button type="submit" class="btn btn-primary">Submit</button></td>
+          </form>
+        </tr>
+        <tr>
+          <td>
+            <h5>@Task.updateGithubInfo.name</h5>
+            <p>@Task.updateGithubInfo.description</p>
+          </td>
+          <form action="/admin/tasks/@Task.updateGithubInfo.name" method="POST">
             <td>
               <div class="input-group">
                 <span class="input-group-addon" id="organization">Organization</span>


### PR DESCRIPTION
Fixes #1105 

If a Github project is private, it is marked with `GithubStatus.NotFound` in Scaladex. This project can be made public later and that's why we should try to update all the not found projects.

In this PR I also added a task to trigger the Github update of a project manually (in the admin page).