### PR TITLE
Fix testcontainers after clean or reload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,9 +85,7 @@ lazy val infra = project
       "io.circe" %% "circe-parser"
     ).map(_ % V.circe),
     Elasticsearch.settings(defaultPort = 9200),
-    inConfig(Compile)(
-      Postgres.settings(defaultPort = 5432, database = "scaladex")
-    ),
+    Postgres.settings(Compile, defaultPort = 5432, database = "scaladex"),
     javaOptions ++= {
       val base = (ThisBuild / baseDirectory).value
       val index = base / "small-index"
@@ -105,9 +103,7 @@ lazy val infra = project
         s"-Dscaladex.elasticsearch.port=$elasticsearchPort"
       )
     },
-    inConfig(Test)(
-      Postgres.settings(defaultPort = 5432, database = "scaladex-test")
-    ),
+    Postgres.settings(Test, defaultPort = 5432, database = "scaladex-test"),
     Test / javaOptions ++= {
       val elasticsearchPort = startElasticsearch.value
       val postgresPort = (Test / startPostgres).value

--- a/project/Docker.scala
+++ b/project/Docker.scala
@@ -1,0 +1,15 @@
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.dockerclient.DockerClientProviderStrategy
+
+object Docker {
+  lazy val client = {
+    CurrentThread.setContextClassLoader[DockerClientProviderStrategy]
+    DockerClientFactory.instance().client()
+  }
+
+  def kill(containerId: String): Unit =
+    try client.killContainerCmd(containerId).exec()
+    catch {
+      case _: Throwable => ()
+    }
+}


### PR DESCRIPTION
After a clean we could not connect to the running Postgres or Elasticsearch container and starting new containers did not work either. This PR fixes it by killing the containers on a clean.