### PR TITLE
Update README To Remove Gitter Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scaladex
 
 ![CI](https://github.com/scalacenter/scaladex/actions/workflows/ci.yml/badge.svg)
-[![Gitter](https://img.shields.io/gitter/room/scalacenter/scaladex.svg?style=flat-square)](https://gitter.im/scalacenter/scaladex)
+![GitHub Discussions](https://img.shields.io/github/discussions/scalacenter/scaladex)
 
 Scaladex is the website where the open source Scala libraries are indexed.
 Its main purpose is to help Scala developers find useful libraries and to help library authors promote their libraries and find new contributors.
@@ -57,7 +57,7 @@ Read [How to improve the visibility of your project](doc/user/improve-visibility
 
 ## How to contribute
 
-Join the [gitter.im channel](https://gitter.im/scalacenter/scaladex) and read the [Contributing Guide](/CONTRIBUTING.md)
+Read the [Contributing Guide](/CONTRIBUTING.md) and use [Github Discussions](https://github.com/scalacenter/scaladex/discussions) for doubts.
 
 ## Badges
 


### PR DESCRIPTION
Gitter is not used anymore so replace it with Github discussions

@adpi2 Please review. Thank you