### PR TITLE
Fix artifacts page filters

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -6,7 +6,6 @@ import java.util.UUID
 import scala.concurrent.Future
 
 import scaladex.core.model._
-import scaladex.core.web.ArtifactsPageParams
 
 trait WebDatabase {
   // artifacts
@@ -14,11 +13,7 @@ trait WebDatabase {
   def insertArtifact(artifact: Artifact, dependencies: Seq[ArtifactDependency], time: Instant): Future[Boolean]
   def getArtifacts(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Artifact]]
   def getArtifacts(projectRef: Project.Reference): Future[Seq[Artifact]]
-  def getArtifacts(
-      ref: Project.Reference,
-      artifactName: Artifact.Name,
-      params: ArtifactsPageParams
-  ): Future[Seq[Artifact]]
+  def getArtifacts(ref: Project.Reference, artifactName: Artifact.Name, preReleases: Boolean): Future[Seq[Artifact]]
   def getArtifacts(ref: Project.Reference, artifactName: Artifact.Name, version: SemanticVersion): Future[Seq[Artifact]]
   def getArtifactsByName(projectRef: Project.Reference, artifactName: Artifact.Name): Future[Seq[Artifact]]
   def getLatestArtifacts(ref: Project.Reference, preferStableVersions: Boolean): Future[Seq[Artifact]]

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -19,7 +19,6 @@ import scaladex.core.model.SemanticVersion
 import scaladex.core.model.UserInfo
 import scaladex.core.model.UserState
 import scaladex.core.service.SchedulerDatabase
-import scaladex.core.web.ArtifactsPageParams
 
 class InMemoryDatabase extends SchedulerDatabase {
   private val allProjects = mutable.Map[Project.Reference, Project]()
@@ -161,9 +160,9 @@ class InMemoryDatabase extends SchedulerDatabase {
   override def getArtifacts(
       ref: Project.Reference,
       artifactName: Artifact.Name,
-      params: ArtifactsPageParams
+      preReleases: Boolean
   ): Future[Seq[Artifact]] =
-    // does not filter with params
+    // TODO: use preReleases to filter
     Future.successful(allArtifacts.getOrElse(ref, Seq.empty).filter(_.artifactName == artifactName))
   override def getProjectDependencies(
       ref: Project.Reference,

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -23,7 +23,6 @@ import scaladex.core.model.SemanticVersion
 import scaladex.core.model.UserInfo
 import scaladex.core.model.UserState
 import scaladex.core.service.SchedulerDatabase
-import scaladex.core.web.ArtifactsPageParams
 import scaladex.infra.sql.ArtifactDependencyTable
 import scaladex.infra.sql.ArtifactTable
 import scaladex.infra.sql.DoobieUtils
@@ -235,13 +234,9 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO]) exten
   override def getArtifacts(
       ref: Project.Reference,
       artifactName: Artifact.Name,
-      params: ArtifactsPageParams
+      preReleases: Boolean
   ): Future[Seq[Artifact]] =
-    run(
-      ArtifactTable
-        .selectArtifactByParams(params.binaryVersions, params.preReleases)
-        .to[Seq](ref, artifactName)
-    )
+    run(ArtifactTable.selectArtifactByParams(preReleases).to[Seq](ref, artifactName))
 
   override def countVersions(ref: Project.Reference): Future[Long] =
     run(ArtifactTable.countVersionsByProject.unique(ref))

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactTableTests.scala
@@ -5,7 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import scaladex.core.model.Jvm
 import scaladex.core.model.Scala
 import scaladex.core.model.ScalaJs
-import scaladex.core.test.Values._
 import scaladex.infra.BaseDatabaseSuite
 
 class ArtifactTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers {
@@ -29,9 +28,8 @@ class ArtifactTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers
   it("check getReleasesFromArtifacts")(check(getReleasesFromArtifacts))
   it("check countVersionsByProject")(check(countVersionsByProject))
   it("check selectArtifactByParams") {
-    check(selectArtifactByParams(Seq.empty, false))
-    check(selectArtifactByParams(Seq.empty, true))
-    check(selectArtifactByParams(Seq(`_sjs0.6_2.13`), false))
+    check(selectArtifactByParams(false))
+    check(selectArtifactByParams(true))
   }
   it("check selectMavenReferenceWithNoReleaseDate")(check(selectMavenReferenceWithNoReleaseDate))
   it("check selectLatestArtifacts") {

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -41,7 +41,7 @@ class ProjectPages(env: Env, database: WebDatabase, searchEngine: SearchEngine)(
         path(projectM / "artifacts" / artifactNameM) { (ref, artifactName) =>
           artifactsParams { params =>
             getProjectOrRedirect(ref, user) { project =>
-              val artifactsF = database.getArtifacts(ref, artifactName, params)
+              val artifactsF = database.getArtifacts(ref, artifactName, params.preReleases)
               val headerF = service.getProjectHeader(project).map(_.get)
               for (artifacts <- artifactsF; header <- headerF) yield {
                 val binaryVersions = artifacts


### PR DESCRIPTION
We get all artifacts from database and then we filter the groups of artifact IDs which don't contain all the required binary versions.