### PR TITLE
Separate developers by |

### DIFF
--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -110,11 +110,12 @@
   @if(artifact.developers.nonEmpty){
     @info("Developers"){
       <div class="developers">
-        @for(developer <- artifact.developers) {
+        @for((developer, i) <- artifact.developers.zipWithIndex) {
           <span>
+            @if(i != 0){ | }
             <a href="@developer.url">
               @developer.name
-            </a> |
+            </a>
           </span>
         }
       </div>
@@ -142,7 +143,7 @@
           <div class="row">
             <div class="col-xs-9">
               <a href="@dep.url">@dep.groupIdAndName</a>
-              @if(dep.artifactDep.scope.value != "compile") { 
+              @if(dep.artifactDep.scope.value != "compile") {
                 <span class="label label-default">@dep.artifactDep.scope</span>
               }
             </div>


### PR DESCRIPTION
but don't leave a trailing |

I think this should fix the trailing | behind the last developer.

<img width="447" alt="Scherm­afbeelding 2024-11-05 om 17 13 10" src="https://github.com/user-attachments/assets/975ec1be-89f0-4e3d-95d3-fd049c56e4d2">
