### PR TITLE
Override title because of typo in case object

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
@@ -73,7 +73,9 @@ object Category {
   case object Compilers extends Category
   case object CodeGeneration extends Category
   case object DependencyInjection extends Category
-  case object FunctionnalProgrammingAndCategoryTheory extends Category
+  case object FunctionnalProgrammingAndCategoryTheory extends Category {
+    override val title: String = "Functional Programming and Category Theory"
+  }
   case object LogicProgrammingAndTypeConstraints extends Category
   case object MiscellaneousUtils extends Category
   case object Parsing extends Category


### PR DESCRIPTION
Ideally we would change the name of the case object and add a migration I think? But not completely sure how that works, any pointers would be appreciated.