### PR TITLE
Rename FunctionnalProgrammingAndCategoryTheory and add migration

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Category.scala
@@ -73,9 +73,7 @@ object Category {
   case object Compilers extends Category
   case object CodeGeneration extends Category
   case object DependencyInjection extends Category
-  case object FunctionnalProgrammingAndCategoryTheory extends Category {
-    override val title: String = "Functional Programming and Category Theory"
-  }
+  case object FunctionalProgrammingAndCategoryTheory extends Category
   case object LogicProgrammingAndTypeConstraints extends Category
   case object MiscellaneousUtils extends Category
   case object Parsing extends Category

--- a/modules/core/shared/src/main/scala/scaladex/core/model/MetaCategory.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/MetaCategory.scala
@@ -70,7 +70,7 @@ object MetaCategory {
       Category.CodeGeneration,
       Category.Compilers,
       Category.DependencyInjection,
-      Category.FunctionnalProgrammingAndCategoryTheory,
+      Category.FunctionalProgrammingAndCategoryTheory,
       Category.LogicProgrammingAndTypeConstraints,
       Category.MiscellaneousUtils,
       Category.Parsing,

--- a/modules/infra/src/main/resources/migrations/V27__fix_functionnal.sql
+++ b/modules/infra/src/main/resources/migrations/V27__fix_functionnal.sql
@@ -1,0 +1,1 @@
+UPDATE project_settings SET category='functional-programming-and-category-theory' WHERE category='functionnal-programming-and-category-theory';


### PR DESCRIPTION
Follow-up of https://github.com/scalacenter/scaladex/pull/1494. It looks like migrations V25 and V26 are hidden in another directory.