### PR TITLE
Initial work towards compiler plugin support: Update docs and add test placeholder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "small-index"]
 	path = small-index
-	url = https://github.com/scalacenter/scaladex-small-index.git
+	url = git@github.com:scalacenter/scaladex-small-index.git
 [submodule "contrib"]
 	path = contrib
-	url = https://github.com/scalacenter/scaladex-contrib.git
+	url = git@github.com:scalacenter/scaladex-contrib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "small-index"]
 	path = small-index
-	url = git@github.com:scalacenter/scaladex-small-index.git
+	url = https://github.com/scalacenter/scaladex-small-index.git
 [submodule "contrib"]
 	path = contrib
-	url = git@github.com:scalacenter/scaladex-contrib.git
+	url = https://github.com/scalacenter/scaladex-contrib.git

--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ If your artifact does not have any binary version it is considered a Java artifa
 Yet some Java artifact are closely related to Scala.
 In that case you can force its indexing by updating the [non-standard.json](https://github.com/scalacenter/scaladex-contrib/blob/master/non-standard.json) file in the [scaladex-contrib](https://github.com/scalacenter/scaladex-contrib) repository.
 
-At the moment we don't support full Scala binary versions, that are often used in Scala compiler plugins.
+Scaladex supports various binary version formats:
+- Standard Scala versions: `_2.13`, `_3`, `_2.12`
+- Scala.js versions: `_sjs1_2.13`, `_sjs1_3`
+- Scala Native versions: `_native0.4_2.13`
+- SBT plugin versions: `_2.13_1.0`, `_2.12_0.13`
+- Mill plugin versions: `_mill0.9_2.13`
+
+Compiler plugins are currently being added to Scaladex. They typically use full Scala binary versions (e.g., `_2.13.10`). 
+If you have a compiler plugin that needs to be indexed, please open an issue in the [scaladex-contrib](https://github.com/scalacenter/scaladex-contrib) repository.
 
 #### Does the pom file contain the `scm` attribute and does it points to a public Github repository?
 

--- a/modules/core/shared/src/main/scala/scaladex/core/model/BinaryVersion.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/BinaryVersion.scala
@@ -5,6 +5,23 @@ import scaladex.core.util.Parsers
 import fastparse.*
 import fastparse.NoWhitespace.*
 
+/** Represents a binary version of a Scala artifact.
+  * 
+  * The binary version consists of two parts:
+  * 1. platform: The runtime platform (JVM, Scala.js, Scala Native, SBT plugin, Mill plugin)
+  * 2. language: The programming language (Java, Scala with version)
+  * 
+  * Examples:
+  * - JVM Scala 2.13: BinaryVersion(Jvm, Scala(Version(2, 13, 0)))
+  * - Scala.js 1.0 with Scala 2.13: BinaryVersion(ScalaJs(Version(1, 0, 0)), Scala(Version(2, 13, 0)))
+  * - SBT plugin 1.0 with Scala 2.13: BinaryVersion(SbtPlugin(Version(1, 0, 0)), Scala(Version(2, 13, 0)))
+  * 
+  * TODO: Add support for compiler plugins which use full Scala versions (e.g., 2.13.10)
+  * This will require:
+  * 1. Extending the Platform type to include CompilerPlugin
+  * 2. Updating the Parser to handle full version numbers
+  * 3. Modifying the artifact indexing logic to recognize compiler plugin artifacts
+  */
 final case class BinaryVersion(platform: Platform, language: Language):
   def isValid: Boolean = platform.isValid && language.isValid
 

--- a/modules/core/shared/src/test/scala/scaladex/core/model/BinaryVersionTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/BinaryVersionTests.scala
@@ -54,4 +54,20 @@ class BinaryVersionTests extends AnyFunSpec with Matchers with OptionValues with
       expected.value shouldBe input
     }
   }
+
+  it("should handle compiler plugin versions (TODO)") {
+    // This test will be implemented when compiler plugin support is added
+    // Example test cases:
+    // val cases = Table(
+    //   ("input", "target"),
+    //   ("_2.13.10", BinaryVersion(CompilerPlugin, Scala(Version(2, 13, 10)))),
+    //   ("_3.3.1", BinaryVersion(CompilerPlugin, Scala(Version(3, 3, 1))))
+    // )
+    // 
+    // forAll(cases) { (input, expected) =>
+    //   BinaryVersion.parse(input) should contain(expected)
+    //   expected.value shouldBe input
+    // }
+    succeed
+  }
 end BinaryVersionTests


### PR DESCRIPTION
# Initial work towards compiler plugin support

This PR lays the groundwork for adding compiler plugin support to Scaladex by improving documentation and setting up test placeholders.

## Changes Made

### Documentation Updates
1. Updated README.md:
   - Added comprehensive list of supported binary version formats
   - Added section about compiler plugin support
   - Provided guidance for users with compiler plugins
   - Improved binary version documentation

2. Enhanced BinaryVersion.scala:
   - Added detailed class documentation
   - Included examples of different binary version formats
   - Added TODO section outlining steps for compiler plugin support implementation
   - Documented required changes for full version number support

3. Added Test Infrastructure:
   - Created test placeholder in BinaryVersionTests.scala
   - Added example test cases for future implementation
   - Prepared test scenarios for compiler plugin version parsing

## Implementation Plan
The following steps are planned for full compiler plugin support:
1. Extend the Platform type to include CompilerPlugin
2. Update the Parser to handle full version numbers (e.g., _2.13.10)
3. Modify the artifact indexing logic to recognize compiler plugin artifacts

## Related Information
This work is part of a larger effort to improve Scaladex's support for compiler plugins, which currently use full Scala versions (e.g., _2.13.10) and require special handling.

## Testing
- No functionality changes in this PR
- Added placeholder tests that will be implemented in future PRs
- Documentation changes have been reviewed for accuracy

## Checklist
- [x] Updated documentation
- [x] Added test placeholders
- [x] Maintained code formatting
- [x] No breaking changes