### PR TITLE
Add support for explicit SSH connections in SCM URLs

### DIFF
--- a/modules/data/src/main/scala/scaladex/data/cleanup/ScmInfoParser.scala
+++ b/modules/data/src/main/scala/scaladex/data/cleanup/ScmInfoParser.scala
@@ -20,7 +20,7 @@ object ScmInfoParser extends Parsers:
     else v
 
   private def ScmUrl[A: P] = P(
-    "scm:".? ~ "git:".? ~ ("git@" | "https://" | "git://" | "//") ~
+    "scm:".? ~ "git:".? ~ ("git@" | "https://" | "git://" | ("ssh://" ~ "git@".?) | "//") ~
       "github.com" ~ (":" | "/") ~ Segment
         .rep(1)
         .! ~ "/" ~ Segment.rep(1).!.map(removeDotGit)

--- a/modules/data/src/test/scala/scaladex/data/cleanup/ScmInfoParserTests.scala
+++ b/modules/data/src/test/scala/scaladex/data/cleanup/ScmInfoParserTests.scala
@@ -1,0 +1,44 @@
+package scaladex.data
+package cleanup
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScmInfoParserTests extends AnyFunSpec with Matchers:
+  describe("ScmInfoParse") {
+    it("correctly parse valid SCM strings") {
+      // Implicit protocol
+      ScmInfoParser
+        .parse("scm:git:git@github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      // HTTPS
+      ScmInfoParser
+        .parse("scm:https://github.com/foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      ScmInfoParser
+        .parse("scm:https://github.com/foobarbuz/example")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      // Git
+      ScmInfoParser
+        .parse("scm:git:git://github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      ScmInfoParser
+        .parse("scm:git://github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      // SSH
+      ScmInfoParser
+        .parse("scm:git:ssh://git@github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      ScmInfoParser
+        .parse("scm:git:ssh://github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
+      // Unknown protocol
+      ScmInfoParser
+        .parse("scm:git:unknown://git@github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe None
+      ScmInfoParser
+        .parse("scm:git:unknown://github.com:foobarbuz/example.git")
+        .map(_.toString) shouldBe None
+    }
+  }
+end ScmInfoParserTests


### PR DESCRIPTION
URLs like `scm:git:ssh://git@github.com/foo/bar.git` and `scm:git:ssh://github.com/foo/bar.git` seem to match the [spec](https://maven.apache.org/scm/git.html) and [are seen on the wild](https://github.com/search?utf8=%E2%9C%93&q=ScmInfo+language%3AScala+%22scm%3Agit%3Assh%3A%2F%2F%22&type=code).

This should help more projects to be indexed by Scaladex.