### PR TITLE
docs: add GSoC midterm evaluation post to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ for  Scala JS or Scala Native, add a `targetType=...` query-string parameter:
 For more information read the [shields.io API](http://shields.io/)
 
 ## 🚀Google Summer of Code (GSoC)
-![Google Summer of Code (GSoC)](doc/img/gsoc-scaladex.png)
+![Google Summer of Code (GSoC)](doc/assets/Scaladex.png)
 
 
 
@@ -99,6 +99,7 @@ This project is participating in **Google Summer of Code (GSoC) 2025**! If you'r
 ### 📌 GSoC Resources
 
 👉 **Scala Center GSoC Ideas**: [https://github.com/scalacenter/GoogleSummerOfCode](https://github.com/scalacenter/GoogleSummerOfCode)
+
 📚 **Explore Past GSoC Projects with Scala Center**: [https://www.gsocorganizations.dev/organization/scala-center/](https://www.gsocorganizations.dev/organization/scala-center/)
 
 ---
@@ -121,6 +122,7 @@ This project is participating in **Google Summer of Code (GSoC) 2025**! If you'r
   * [Adrien Piquerez](https://github.com/adpi2)
   * [Kannupriya Kalra](https://github.com/kannupriyakalra)
 * **Proposal**: [GSoC 2024 Proposal](https://github.com/user-attachments/files/16697199/proposal.pdf)
+* **Announcement**: [Official Acceptance Post](https://www.linkedin.com/posts/skingle_scala-scalacenter-gsoc2024-activity-7192214506901504000-HBGc) | [Midterm evaluation post](https://www.linkedin.com/posts/skingle_scala-gsoc-gsoc2024-activity-7218525241944215552-1tpn?utm_source=share&utm_medium=member_android&rcm=ACoAAFp2nsYBNBsrS0fo8jK1QyeRCdtOBCWgUuQ) | [Final evalution post](https://www.linkedin.com/posts/skingle_certificate-activity-7236760686373007362-R1NW?utm_source=share&utm_medium=member_android&rcm=ACoAAFp2nsYBNBsrS0fo8jK1QyeRCdtOBCWgUuQ)
 * **Blog**: 📌 [How I Started My GSoC Journey](https://www.linkedin.com/pulse/how-i-started-my-gsoc24-journey-scala-center-siddharth-ingle-sdf5e/)
 * **Work Log**: 📌 [GitHub Project Board](https://github.com/users/skingle/projects/2)
 
@@ -150,8 +152,9 @@ This project is participating in **Google Summer of Code (GSoC) 2025**! If you'r
 * **Mentors**:
   * [Adrien Piquerez](https://github.com/adpi2)
   * [Kannupriya Kalra](https://github.com/kannupriyakalra)
+* **Announcement**: [Official Acceptance Post](https://www.linkedin.com/posts/vidisha-gawas-146348364_gsoc-gsoc2025-scalacenter-activity-7326793814331871232-0hGz?utm_source=share&utm_medium=member_android&rcm=ACoAAFp2nsYBNBsrS0fo8jK1QyeRCdtOBCWgUuQ) | [Midterm evaluation post](https://www.linkedin.com/posts/vidisha-gawas-146348364_gsoc2025-scalacenter-scaladex-activity-7352311549400662016-zvpl?utm_source=share&utm_medium=member_android&rcm=ACoAAFp2nsYBNBsrS0fo8jK1QyeRCdtOBCWgUuQ)
 * **Blog**: [Building with GSoC](https://opensourcegirl.hashnode.dev/)
-* **Work Log**:[https://github.com/users/vidishagawas121/projects/2](https://github.com/users/vidishagawas121/projects/2)
+* **Work Log**:[GSoC Progress Tracker](https://github.com/users/vidishagawas121/projects/2)
 * **Technologies**: Scala, SBT, Play Framework, Elasticsearch, GitHub Actions, JavaScript, HTML/CSS
 * **Topics**: Compilers, Open Source, Plugin Systems
 


### PR DESCRIPTION
This PR adds a link to my GSoC 2025 Midterm Evaluation blog post under the README section.