### PR TITLE
Add CompilerPlugin platform support in Scala models

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -60,6 +60,7 @@ case class Artifact(
 
   def sbtInstall: Option[String] =
     val install = platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin sbtInstall not supported yet")
       case SbtPlugin(_) => Some(s"""addSbtPlugin("$groupId" % "$name" % "$version")""")
       case MillPlugin(_) => None
       case _ if isNonStandardLib => Some(s"""libraryDependencies += "$groupId" % "$artifactId" % "$version"""")
@@ -96,6 +97,7 @@ case class Artifact(
           |interp.resolvers() = interp.resolvers() :+ res""".stripMargin
 
     val install = platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin ammInstall not supported yet")
       case MillPlugin(_) | SbtPlugin(_) | ScalaNative(_) | ScalaJs(_) => None
       case Jvm =>
         language match
@@ -115,6 +117,7 @@ case class Artifact(
     */
   def mavenInstall: Option[String] =
     platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin mavenInstall not supported yet")
       case MillPlugin(_) | SbtPlugin(_) | ScalaNative(_) | ScalaJs(_) => None
       case Jvm =>
         Some(
@@ -130,6 +133,7 @@ case class Artifact(
     */
   def gradleInstall: Option[String] =
     platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin gradleInstall not supported yet")
       case MillPlugin(_) | SbtPlugin(_) | ScalaNative(_) | ScalaJs(_) => None
       case Jvm => Some(s"compile group: '$groupId', name: '$artifactId', version: '$version'")
 
@@ -138,6 +142,7 @@ case class Artifact(
     */
   def millInstall: Option[String] =
     val install = platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin millInstall not supported yet")
       case MillPlugin(_) => Some(s"import $$ivy.`$groupId::$name::$version`")
       case SbtPlugin(_) => None
       case ScalaNative(_) | ScalaJs(_) => Some(s"""ivy"$groupId::$name::$version"""")
@@ -159,6 +164,7 @@ case class Artifact(
 
   def scalaCliInstall: Option[String] =
     binaryVersion.platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin scalaCliInstall not supported yet")
       case MillPlugin(_) | SbtPlugin(_) => None
       case ScalaNative(_) | ScalaJs(_) => Some(s"""//> using dep "$groupId::$name::$version"""")
       case Jvm =>
@@ -170,6 +176,7 @@ case class Artifact(
 
   def csLaunch: Option[String] =
     platform match
+      case CompilerPlugin => throw new UnsupportedOperationException("CompilerPlugin csLaunch not supported yet")
       case MillPlugin(_) | SbtPlugin(_) => None
       case ScalaNative(_) | ScalaJs(_) => Some(s"cs launch $groupId::$name::$version")
       case Jvm =>
@@ -190,6 +197,7 @@ case class Artifact(
     val targetParam = platform match
       case ScalaJs(_) => Some("t" -> "JS")
       case Jvm => Some("t" -> "JVM")
+      case CompilerPlugin => None
       case _ => None
 
     val scalaVersionParam = language match

--- a/modules/core/shared/src/main/scala/scaladex/core/model/BinaryVersion.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/BinaryVersion.scala
@@ -28,6 +28,7 @@ final case class BinaryVersion(platform: Platform, language: Language):
     case Jvm => language.toString
     case p: SbtPlugin => p.toString
     case p: MillPlugin => p.toString
+    case CompilerPlugin => s"CompilerPlugin ($language)"
     case _ => s"$platform ($language)"
 end BinaryVersion
 

--- a/modules/core/shared/src/main/scala/scaladex/core/model/Platform.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Platform.scala
@@ -9,6 +9,11 @@ case object Jvm extends Platform:
   override def value: String = "jvm"
   override def isValid: Boolean = true
 
+case object CompilerPlugin extends Platform:
+  override def toString: String = "CompilerPlugin"
+  override def value: String = "compiler-plugin"
+  override def isValid: Boolean = true
+
 case class ScalaJs(version: Version) extends Platform:
   override def toString: String = s"Scala.js $version"
   override def value: String = s"sjs${version.value}"
@@ -80,6 +85,7 @@ object Platform:
     case ScalaNative(version) => (3, Some(version))
     case SbtPlugin(version) => (2, Some(version))
     case MillPlugin(version) => (1, Some(version))
+    case CompilerPlugin => (0, None)
   }
 
   def parse(input: String): Option[Platform] =

--- a/modules/core/shared/src/test/scala/scaladex/core/model/ArtifactTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/ArtifactTests.scala
@@ -196,6 +196,20 @@ class ArtifactTests extends AnyFunSpec with Matchers:
         )
       )
     }
+
+    it("should allow creating Artifact with CompilerPlugin platform without exceptions") {
+      val artifact = createArtifact(
+        groupId = "org.example",
+        artifactId = "myplugin_2.13",
+        version = "1.0.0",
+        binaryVersion = BinaryVersion(CompilerPlugin, Scala.`2.13`),
+        artifactName = Some(Name("myplugin"))
+      )
+
+      artifact.platform shouldBe CompilerPlugin
+      artifact.language shouldBe Scala.`2.13`
+      artifact.binaryVersion.isValid shouldBe true
+    }
   }
 
   private def createArtifact(


### PR DESCRIPTION
- Introduce CompilerPlugin in Platform.scala
- Update BinaryVersion.toString to handle CompilerPlugin
- Update all platform matches in Artifact.scala to explicitly handle CompilerPlugin
- Throw UnsupportedOperationException where features aren’t implemented
- Add unit test for creating Artifact with CompilerPlugin
- Lints clean