### PR TITLE
Fix header row overflow

### DIFF
--- a/modules/server/src/main/assets/css/partials/_header.scss
+++ b/modules/server/src/main/assets/css/partials/_header.scss
@@ -51,6 +51,10 @@
     nav {
         background: $gray-darker;
         padding: 30px 0;
+        
+        .row {
+            margin: 0;
+        }
 
         .logo {
             margin-bottom: 15px;


### PR DESCRIPTION
The negative margin of `row` is causing the header to overflow and trigger horizontal scrolling. This fixes it.