### PR TITLE
Fix artifact selection when repository name casing differs

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/ArtifactSelection.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ArtifactSelection.scala
@@ -16,10 +16,10 @@ case class ArtifactSelection(
           project.settings.defaultArtifact.contains(artifact.name),
           // not deprecated
           !project.settings.deprecatedArtifacts.contains(artifact.name),
-          // project repository (ex: shapeless)
-          project.repository.value == artifact.name.value,
+          // project repository (ex: shapeless) - case insensitive
+          project.repository.value.equalsIgnoreCase(artifact.name.value),
           // alphabetically
-          artifact.name,
+          artifact.name.value.toLowerCase,
           // stable version first
           project.settings.preferStableVersion && !artifact.version.isStable,
           artifact.version,
@@ -31,7 +31,7 @@ case class ArtifactSelection(
             Ordering[Boolean],
             Ordering[Boolean],
             Ordering[Boolean],
-            Ordering[Artifact.Name].reverse,
+            Ordering[String].reverse,
             Ordering[Boolean].reverse,
             Ordering[Version],
             Ordering[BinaryVersion]

--- a/modules/core/shared/src/test/scala/scaladex/core/model/ArtifactSelectionTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/ArtifactSelectionTests.scala
@@ -1,0 +1,40 @@
+package scaladex.core.model
+
+import scaladex.core.model.Artifact.*
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers   
+
+class ArtifactSelectionTests extends AnyFunSpec with Matchers:
+
+  describe("ArtifactSelection") {
+
+    it("selects the artifact matching the repository name ignoring case") {
+
+      val projectRef = Project.Reference.from("ScalaFX", "ScalaFX")
+      val project = Project.default(projectRef)
+
+      val oldArtifact =
+        Artifact.Reference(
+          GroupId("org.scalafx"),
+          ArtifactId("ScalaFX"),
+          Version("8.0.0")
+        )
+
+      val currentArtifact =
+        Artifact.Reference(
+          GroupId("org.scalafx"),
+          ArtifactId("scalafx"),
+          Version("14.0.0")
+        )
+
+      val result =
+        ArtifactSelection(None, None)
+          .filterArtifacts(Seq(oldArtifact, currentArtifact), project)
+
+      result.head.name.value shouldBe "scalafx"
+      result.head.version.toString shouldBe "14.0.0"
+    }
+  }
+
+end ArtifactSelectionTests


### PR DESCRIPTION
### Context

While looking into issue #1576, I noticed that Scaladex can end up selecting an outdated artifact when the repository name and the artifact name differ only by casing (for example, `ScalaFX` vs `scalafx`). This happens because artifact selection currently relies on case sensitive string comparisons and case sensitive alphabetical ordering.

### What this PR changes

- Compare repository names and artifact names in a case-insensitive way
- Make alphabetical ordering of artifact names case insensitive as well
- Add a regression test to ensure this behavior doesn’t break again

### Why this approach

The existing selection rules and priority order are kept exactly the same. This change only normalizes string comparisons so that casing differences don’t affect which artifact is selected.

### Verification

- Added a test that reproduces the issue
- Ran the full `coreJVM/test` suite locally; all tests pass


