### PR TITLE
Add test for "scm:git:https://" case

### DIFF
--- a/modules/data/src/test/scala/scaladex/data/cleanup/ScmInfoParserTests.scala
+++ b/modules/data/src/test/scala/scaladex/data/cleanup/ScmInfoParserTests.scala
@@ -29,6 +29,9 @@ class ScmInfoParserTests extends AnyFunSpec with Matchers:
       ScmInfoParser
         .parse("scm:git://github.com:foobarbuz/example.git")
         .map(_.toString) shouldBe Some("foobarbuz/example")
+      ScmInfoParser
+        .parse("scm:git:https://github.com/foobarbuz/example.git")
+        .map(_.toString) shouldBe Some("foobarbuz/example")
       // SSH
       ScmInfoParser
         .parse("scm:git:ssh://git@github.com:foobarbuz/example.git")


### PR DESCRIPTION
I was trying to find out why my repos are not indexed. They use the SCM format in this test and the test passes 🤷

```
<scm>
    <url>https://github.com/matejcerny/pgmq4s</url>
    <connection>scm:git:https://github.com/matejcerny/pgmq4s.git</connection>
    <developerConnection>scm:git:git@github.com:matejcerny/pgmq4s.git</developerConnection>
</scm>
```