### PR TITLE
feat: make Elasticsearch REST client pool and timeouts configurable

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -3,6 +3,10 @@ scaladex {
     index = scaladex-dev
     port = 9200
     reset = false
+    max-connections = 50
+    connect-timeout-ms = 5000
+    socket-timeout-ms = 60000
+    connection-request-timeout-ms = 5000
   }
   database {
     user = user

--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -49,6 +49,9 @@ import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.ScoreFunction
 import com.sksamuel.elastic4s.requests.searches.sort.SortOrder
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.*
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
+import org.elasticsearch.client.RestClientBuilder
 
 /** @param esClient
   *   TCP client of the elasticsearch server
@@ -499,8 +502,22 @@ object ElasticsearchEngine extends LazyLogging:
     logger.info(s"Using elasticsearch index: ${config.index}")
 
     val props = ElasticProperties(s"http://localhost:${config.port}")
-    val esClient = ElasticClient(JavaClient(props))
+    val esClient = ElasticClient(JavaClient(props, requestConfigCallback(config), httpClientConfigCallback(config)))
     new ElasticsearchEngine(esClient, config.index)
+
+  // Bounded timeouts so a request can never hang indefinitely (e.g. waiting to lease a connection).
+  private def requestConfigCallback(config: ElasticsearchConfig): RestClientBuilder.RequestConfigCallback =
+    (builder: RequestConfig.Builder) =>
+      builder
+        .setConnectTimeout(config.connectTimeoutMs)
+        .setSocketTimeout(config.socketTimeoutMs)
+        .setConnectionRequestTimeout(config.connectionRequestTimeoutMs)
+
+  private def httpClientConfigCallback(config: ElasticsearchConfig): RestClientBuilder.HttpClientConfigCallback =
+    (builder: HttpAsyncClientBuilder) =>
+      builder
+        .setMaxConnPerRoute(config.maxConnections)
+        .setMaxConnTotal(config.maxConnections)
 
   def fieldAccess(name: String): String =
     s"doc['$name'].value"

--- a/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
@@ -3,7 +3,15 @@ package scaladex.infra.config
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-final case class ElasticsearchConfig(port: Int, index: String, reset: Boolean)
+final case class ElasticsearchConfig(
+    port: Int,
+    index: String,
+    reset: Boolean,
+    maxConnections: Int,
+    connectTimeoutMs: Int,
+    socketTimeoutMs: Int,
+    connectionRequestTimeoutMs: Int
+)
 
 object ElasticsearchConfig:
   def load(): ElasticsearchConfig =
@@ -13,6 +21,10 @@ object ElasticsearchConfig:
     ElasticsearchConfig(
       config.getInt("scaladex.elasticsearch.port"),
       config.getString("scaladex.elasticsearch.index"),
-      config.getBoolean("scaladex.elasticsearch.reset")
+      config.getBoolean("scaladex.elasticsearch.reset"),
+      config.getInt("scaladex.elasticsearch.max-connections"),
+      config.getInt("scaladex.elasticsearch.connect-timeout-ms"),
+      config.getInt("scaladex.elasticsearch.socket-timeout-ms"),
+      config.getInt("scaladex.elasticsearch.connection-request-timeout-ms")
     )
 end ElasticsearchConfig


### PR DESCRIPTION
Raise the ES client connection pool above the default (10/route) and set bounded connect/socket/lease timeouts so concurrent requests neither starve for a connection nor hang indefinitely. All values are externalized to reference.conf under scaladex.elasticsearch.