### PR TITLE
fix: return 404 instead of crashing on artifact page with unknown binary-version

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -128,25 +128,30 @@ class ProjectPages(
                 artifacts <- artifactsF
                 header <- headerF
                 binaryVersions = artifacts.map(_.binaryVersion).distinct.sorted(BinaryVersion.ordering.reverse)
-                binaryVersion = params.binaryVersion.getOrElse(binaryVersions.head)
-                artifact = artifacts.find(_.binaryVersion == binaryVersion).get
-                directDepsF = database.getDirectDependencies(artifact)
-                reverseDepsF = database.getReverseDependencies(artifact)
-                directDeps <- directDepsF
-                reverseDeps <- reverseDepsF
-              yield
-                val page = html.artifact(
-                  env,
-                  user,
-                  project,
-                  header,
-                  artifact,
-                  binaryVersions,
-                  params,
-                  directDeps,
-                  reverseDeps
-                )
-                complete(page)
+                selectedArtifact = params.binaryVersion
+                  .orElse(binaryVersions.headOption)
+                  .flatMap(bv => artifacts.find(_.binaryVersion == bv))
+                route <- selectedArtifact match
+                  case None =>
+                    Future.successful(complete(StatusCodes.NotFound, notfound(env, user)))
+                  case Some(artifact) =>
+                    for
+                      directDeps <- database.getDirectDependencies(artifact)
+                      reverseDeps <- database.getReverseDependencies(artifact)
+                    yield
+                      val page = html.artifact(
+                        env,
+                        user,
+                        project,
+                        header,
+                        artifact,
+                        binaryVersions,
+                        params,
+                        directDeps,
+                        reverseDeps
+                      )
+                      complete(page)
+              yield route
               end for
             }
           }

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -54,6 +54,11 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
       status shouldEqual StatusCodes.OK
     }
   }
+  it("should return NotFound for an artifact version with a non-existing binary-version") {
+    Get(s"/${PlayJsonExtra.reference}/artifacts/play-json-extra/0.1.1-play2.3-M1?binary-version=java") ~> route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
 
   it("should redirect on moved project") {
     val destination = PlayJsonExtra.reference.copy(repository = Project.Repository("play-json-extra-2"))

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -55,7 +55,9 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
     }
   }
   it("should return NotFound for an artifact version with a non-existing binary-version") {
-    Get(s"/${PlayJsonExtra.reference}/artifacts/play-json-extra/0.1.1-play2.3-M1?binary-version=java") ~> route ~> check {
+    Get(
+      s"/${PlayJsonExtra.reference}/artifacts/play-json-extra/0.1.1-play2.3-M1?binary-version=java"
+    ) ~> route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }


### PR DESCRIPTION
This replaces the unsafe .get/.head with an Option-based lookup: if no artifact matches the requested (or default) binary version, the route now responds 404 Not Found instead of crashing.

Error in logs:
```
2026-08-12 18:31:42,899 ERROR scaladex.server.Server$:191  - Unhandled exception in http://index-dev.scala-lang.org/timt/sbt-dist-zip/artifacts/sbt-dist-zip/10.x?bin
ary-version=java
java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:627)
        at scala.None$.get(Option.scala:626)
        at scaladex.server.route.ProjectPages.route$$anonfun$4$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1$$anonfun$1(ProjectPages.scala:132)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:500)
        at org.apache.pekko.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:73)
        at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$1(BatchingExecutor.scala:110)
        at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$adapted$1(BatchingExecutor.scala:119)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
        at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:119)
        at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)
        at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:61)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```
