### PR TITLE
fix: encode redirect URIs to avoid crash on artifact names with special chars

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -204,11 +204,12 @@ class ProjectPages(
               _ <- artifactService.updateLatestVersions(projectRef, form.preferStableVersion)
               _ <- searchSynchronizer.syncProject(projectRef)
             yield ()
+            val projectUri = Uri((Path.Empty / projectRef.organization.value / projectRef.repository.value).toString)
             onComplete(updateF) {
-              case Success(()) => redirect(Uri(s"/$projectRef"), StatusCodes.SeeOther)
+              case Success(()) => redirect(projectUri, StatusCodes.SeeOther)
               case Failure(e) =>
                 logger.error(s"Cannot save settings of project $projectRef", e)
-                redirect(Uri(s"/$projectRef"), StatusCodes.SeeOther) // maybe we can print that it wasn't saved
+                redirect(projectUri, StatusCodes.SeeOther) // maybe we can print that it wasn't saved
             }
           }
         }
@@ -217,8 +218,10 @@ class ProjectPages(
         // redirect to new artifacts page
         path(projectM / artifactNameM)((projectRef, artifactName) =>
           parameter("binaryVersion".?) { binaryVersion =>
-            val filter = binaryVersion.map(bv => s"?binary-version=$bv").getOrElse("")
-            redirect(s"/$projectRef/artifacts/$artifactName$filter", StatusCodes.MovedPermanently)
+            val path = Path.Empty / projectRef.organization.value /
+              projectRef.repository.value / "artifacts" / artifactName.value
+            val query = binaryVersion.map(bv => Query("binary-version" -> bv)).getOrElse(Query.Empty)
+            redirect(Uri(path.toString).withQuery(query), StatusCodes.MovedPermanently)
           }
         )
       },
@@ -226,8 +229,10 @@ class ProjectPages(
         // redirect to new artifact page
         path(projectM / artifactNameM / versionM)((projectRef, artifactName, version) =>
           parameter("binaryVersion".?) { binaryVersion =>
-            val filter = binaryVersion.map(bv => s"binary-version=$bv").getOrElse("")
-            redirect(s"/$projectRef/artifacts/$artifactName/$version?$filter", StatusCodes.MovedPermanently)
+            val path = Path.Empty / projectRef.organization.value /
+              projectRef.repository.value / "artifacts" / artifactName.value / version.value
+            val query = binaryVersion.map(bv => Query("binary-version" -> bv)).getOrElse(Query.Empty)
+            redirect(Uri(path.toString).withQuery(query), StatusCodes.MovedPermanently)
           }
         )
       }

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -73,6 +73,16 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
     }
   }
 
+  it("should redirect legacy artifact url with special characters in the name") {
+    Get("/some-org/some-repo/Feathr%20Feature%20Store%20Talk.pdf") ~> route ~> check {
+      status shouldEqual StatusCodes.MovedPermanently
+      val location = headers.collectFirst { case Location(uri) => uri }
+      location.map(_.toString) should contain(
+        "/some-org/some-repo/artifacts/Feathr%20Feature%20Store%20Talk.pdf"
+      )
+    }
+  }
+
   describe("POST /<orga/repo>/settings") {
     it("should replace empty customScalaDoc with None") {
       val formData = FormData(


### PR DESCRIPTION
## Problem

Legacy artifact redirect routes built the redirect target by interpolating the already-decoded path segments into a string, which was then re-parsed as a `Uri`. When an artifact name contains a character that needs percent-encoding (e.g. a space), parsing fails and the request returns a **500** instead of redirecting.

Example that failed in production:

```
GET /linkedin/talks/Feathr%20Feature%20Store%20Talk.pdf

org.apache.pekko.http.scaladsl.model.IllegalUriException: Illegal URI reference:
  Invalid input ' ', expected pchar, '/', '?', '#' or 'EOI'
  /linkedin/talks/artifacts/Feathr Feature Store Talk.pdf
```

The `Segment` matcher decodes `%20` → space, then `redirect(s"/$projectRef/artifacts/$artifactName")` re-parses the raw string (with the space) as a `Uri` and throws.

## Fix

Build the redirect target with pekko's `Uri.Path` / `Uri.Query` builders, which percent-encode each segment/param automatically. The settings redirect is hardened the same way for consistency.

Added a regression test covering an artifact name with a space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)