### PR TITLE
Make the database connection pool size configurable

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -16,6 +16,7 @@ scaladex {
     name = scaladex
     name = ${?POSTGRESQL_DATABASE}
     port = 5432
+    pool-size = 25
     url = "jdbc:postgresql://"${scaladex.database.user}":"${scaladex.database.password}"@localhost:"${scaladex.database.port}"/"${scaladex.database.name}
   }
   github {

--- a/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
@@ -9,7 +9,7 @@ import scaladex.core.util.Secret
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-final case class PostgreSQLConfig(url: String, user: String, pass: Secret):
+final case class PostgreSQLConfig(url: String, user: String, pass: Secret, poolSize: Int):
   val driver = "org.postgresql.Driver"
 
 object PostgreSQLConfig:
@@ -21,10 +21,10 @@ object PostgreSQLConfig:
     from(config)
 
   def from(config: Config): Try[PostgreSQLConfig] =
-    from(config.getString("scaladex.database.url"))
+    from(config.getString("scaladex.database.url"), config.getInt("scaladex.database.pool-size"))
 
-  private def from(url: String): Try[PostgreSQLConfig] = url match
+  private def from(url: String, poolSize: Int): Try[PostgreSQLConfig] = url match
     case postgreSQLRegex(login, pass, url) =>
-      Success(PostgreSQLConfig(s"jdbc:postgresql://$url", login, Secret(pass)))
+      Success(PostgreSQLConfig(s"jdbc:postgresql://$url", login, Secret(pass), poolSize))
     case _ => Failure(new Exception(s"Unknown database url: $url"))
 end PostgreSQLConfig

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
@@ -33,6 +33,7 @@ object DoobieUtils:
     config.setJdbcUrl(conf.url)
     config.setUsername(conf.user)
     config.setPassword(conf.pass.decode)
+    config.setMaximumPoolSize(conf.poolSize)
     new HikariDataSource(config)
   end getHikariDataSource
 


### PR DESCRIPTION
## What

Makes the Postgres (HikariCP) connection pool size configurable, and sets an explicit default of **25** (previously it relied on HikariCP's implicit default of 10).

## Details

- Add `scaladex.database.pool-size` (default `25`) to `PostgreSQLConfig`.
- Apply it in `DoobieUtils.getHikariDataSource` via `config.setMaximumPoolSize(conf.poolSize)`.

Override per environment via `scaladex.database.pool-size` in `application.conf` (or a `-D` system property).

## Note

The server opens two datasources (web + scheduler), so the process uses up to `2 × pool-size` connections — make sure Postgres `max_connections` accommodates that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)