### PR TITLE
fix: fix crash on latest-by-scala-version badge for unknown project/artifact

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -84,17 +84,23 @@ class Badges(projectService: ProjectService)(using ExecutionContext):
     // in case targetType is defined we choose the most recent corresponding platform
     parameters("targetType".?, "platform".?) { (targetTypeParam, platformParam) =>
       shields { (color, style, logo, logoWidth) =>
-        val headerF = projectService.getHeader(ref).map(_.get)
-        onSuccess(headerF) { header =>
-          val platforms = header.platforms(artifactName)
-          val platform = platformParam
-            .flatMap(Platform.parse)
-            .orElse(targetTypeParam.flatMap(selectPlatformFromTargetType(_, platforms)))
-            .getOrElse(platforms.max)
-          val artifacts = header.artifacts(artifactName, platform)
-          val summary = Badges.summaryOfLatestVersions(artifacts.map(_.reference), platform)
-          shieldsSvg(s"$artifactName - $platform", summary, color, style, logo, logoWidth)
+        def error(msg: String) = shieldsSvg(artifactName.value, msg, color.orElse(Some("lightgrey")), style, logo, logoWidth)
+
+        val res = projectService.getHeader(ref).map {
+          case None => error("project not found")
+          case Some(header) =>
+            val platforms = header.platforms(artifactName)
+            if platforms.isEmpty then error("no published artifacts")
+            else
+              val platform = platformParam
+                .flatMap(Platform.parse)
+                .orElse(targetTypeParam.flatMap(selectPlatformFromTargetType(_, platforms)))
+                .getOrElse(platforms.max)
+              val artifacts = header.artifacts(artifactName, platform)
+              val summary = Badges.summaryOfLatestVersions(artifacts.map(_.reference), platform)
+              shieldsSvg(s"$artifactName - $platform", summary, color, style, logo, logoWidth)
         }
+        onSuccess(res)(identity)
       }
     }
 

--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -84,7 +84,8 @@ class Badges(projectService: ProjectService)(using ExecutionContext):
     // in case targetType is defined we choose the most recent corresponding platform
     parameters("targetType".?, "platform".?) { (targetTypeParam, platformParam) =>
       shields { (color, style, logo, logoWidth) =>
-        def error(msg: String) = shieldsSvg(artifactName.value, msg, color.orElse(Some("lightgrey")), style, logo, logoWidth)
+        def error(msg: String) =
+          shieldsSvg(artifactName.value, msg, color.orElse(Some("lightgrey")), style, logo, logoWidth)
 
         val res = projectService.getHeader(ref).map {
           case None => error("project not found")

--- a/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
@@ -63,6 +63,26 @@ class BadgesTests extends ControllerBaseSuite with BeforeAndAfterAll:
       )
     }
   }
+
+  it("error badge instead of crashing for an unknown project") {
+    Get("/nebula-contrib/zio-nebula/zio-nebula/latest-by-scala-version.svg?platform=jvm") ~> route ~> check {
+      status shouldEqual StatusCodes.TemporaryRedirect
+      val redirection = headers.collectFirst { case Location(uri) => uri }
+      redirection should contain(
+        Uri("https://img.shields.io/badge/zio--nebula-project_not_found-lightgrey.svg?")
+      )
+    }
+  }
+
+  it("error badge instead of crashing for an unknown artifact of a known project") {
+    Get(s"/${Cats.reference}/does-not-exist/latest-by-scala-version.svg") ~> route ~> check {
+      status shouldEqual StatusCodes.TemporaryRedirect
+      val redirection = headers.collectFirst { case Location(uri) => uri }
+      redirection should contain(
+        Uri("https://img.shields.io/badge/does--not--exist-no_published_artifacts-lightgrey.svg?")
+      )
+    }
+  }
 end BadgesTests
 
 class BadgesUnitTests extends AnyFunSpec with Matchers:


### PR DESCRIPTION
The `latest-by-scala-version.svg` badge did `getHeader(ref).map(_.get)`, which threw `None.get` (→ 500) when the project or artifact was unknown:

```
ERROR scaladex.server.Server$ - Unhandled exception in http://index.scala-lang.org/nebula-contrib/zio-nebula/zio-nebula/latest-by-scala-version.svg?platform=jvm
java.util.NoSuchElementException: None.get
    at scala.None$.get(Option.scala:627)
    at scaladex.server.route.Badges.$anonfun$10(Badges.scala:87)
```

Now it returns an error badge (`project not found` / `no published artifacts`) instead of crashing, matching the existing `latest.svg` behavior. Added regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)