### PR TITLE
fix: return empty search results on malformed query instead of crashing

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -196,16 +196,20 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
     esClient
       .execute(pagedRequest)
       .map { response =>
-        Page(
-          Pagination(
-            current = clamp,
-            pageCount = Math
-              .ceil(response.result.totalHits / page.size.toDouble)
-              .toInt,
-            totalSize = response.result.totalHits
-          ),
-          response.result.hits.hits.toSeq
-        )
+        if response.isError then
+          logger.warn(s"Search request failed: ${response.error.reason}")
+          Page.empty[SearchHit]
+        else
+          Page(
+            Pagination(
+              current = clamp,
+              pageCount = Math
+                .ceil(response.result.totalHits / page.size.toDouble)
+                .toInt,
+              totalSize = response.result.totalHits
+            ),
+            response.result.hits.hits.toSeq
+          )
       }
   end findPage
 

--- a/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
@@ -54,6 +54,13 @@ class ElasticsearchEngineTests extends AsyncFreeSpec with Matchers with BeforeAn
     yield page.items.map(_.document) should contain theSameElementsAs List(Cats.projectDocument)
   }
 
+  "return an empty page for a malformed query instead of failing" in {
+    for
+      _ <- insertAll(projects)
+      page <- searchEngine.find(SearchParams(queryString = ":https://tinyurl.com/txy3b83h"), pageParams)
+    yield page.items shouldBe empty
+  }
+
   "sort by dependent, created, stars, forks, and contributors" in {
     val params = SearchParams(queryString = "*")
     val catsFirst = Seq(Cats.projectDocument, Scalafix.projectDocument)


### PR DESCRIPTION
A search query with Lucene reserved characters (e.g. a leading `:`) fails to parse in Elasticsearch. `findPage` called `.result` on the failed response, throwing and returning a 500:

```
ERROR scaladex.server.Server$ - Unhandled exception in http://index.scala-lang.org/GET?q=%3Ahttps%3A%2F%2Ftinyurl.com%2Ftxy3b83h
java.util.NoSuchElementException: Request Failure ElasticError(search_phase_execution_exception,all shards failed,...
    at com.sksamuel.elastic4s.RequestFailure.result(responses.scala:71)
    at scaladex.infra.ElasticsearchEngine.findPage$$anonfun$1(ElasticsearchEngine.scala:203)
```

Now `findPage` handles a failed response by logging and returning an empty page. Added a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)