### PR TITLE
feat: express Elasticsearch timeouts as durations

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -4,9 +4,9 @@ scaladex {
     port = 9200
     reset = false
     max-connections = 50
-    connect-timeout-ms = 5000
-    socket-timeout-ms = 60000
-    connection-request-timeout-ms = 5000
+    connect-timeout = 5 seconds
+    socket-timeout = 60 seconds
+    connection-request-timeout = 5 seconds
   }
   database {
     user = user

--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -509,9 +509,9 @@ object ElasticsearchEngine extends LazyLogging:
   private def requestConfigCallback(config: ElasticsearchConfig): RestClientBuilder.RequestConfigCallback =
     (builder: RequestConfig.Builder) =>
       builder
-        .setConnectTimeout(config.connectTimeoutMs)
-        .setSocketTimeout(config.socketTimeoutMs)
-        .setConnectionRequestTimeout(config.connectionRequestTimeoutMs)
+        .setConnectTimeout(config.connectTimeout.toMillis.toInt)
+        .setSocketTimeout(config.socketTimeout.toMillis.toInt)
+        .setConnectionRequestTimeout(config.connectionRequestTimeout.toMillis.toInt)
 
   private def httpClientConfigCallback(config: ElasticsearchConfig): RestClientBuilder.HttpClientConfigCallback =
     (builder: HttpAsyncClientBuilder) =>

--- a/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
@@ -31,4 +31,5 @@ object ElasticsearchConfig:
       duration("socket-timeout"),
       duration("connection-request-timeout")
     )
+  end from
 end ElasticsearchConfig

--- a/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/ElasticsearchConfig.scala
@@ -1,5 +1,7 @@
 package scaladex.infra.config
 
+import scala.concurrent.duration.*
+
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -8,9 +10,9 @@ final case class ElasticsearchConfig(
     index: String,
     reset: Boolean,
     maxConnections: Int,
-    connectTimeoutMs: Int,
-    socketTimeoutMs: Int,
-    connectionRequestTimeoutMs: Int
+    connectTimeout: FiniteDuration,
+    socketTimeout: FiniteDuration,
+    connectionRequestTimeout: FiniteDuration
 )
 
 object ElasticsearchConfig:
@@ -18,13 +20,15 @@ object ElasticsearchConfig:
     from(ConfigFactory.load())
 
   def from(config: Config): ElasticsearchConfig =
+    def duration(key: String): FiniteDuration =
+      FiniteDuration(config.getDuration(s"scaladex.elasticsearch.$key").toNanos, NANOSECONDS)
     ElasticsearchConfig(
       config.getInt("scaladex.elasticsearch.port"),
       config.getString("scaladex.elasticsearch.index"),
       config.getBoolean("scaladex.elasticsearch.reset"),
       config.getInt("scaladex.elasticsearch.max-connections"),
-      config.getInt("scaladex.elasticsearch.connect-timeout-ms"),
-      config.getInt("scaladex.elasticsearch.socket-timeout-ms"),
-      config.getInt("scaladex.elasticsearch.connection-request-timeout-ms")
+      duration("connect-timeout"),
+      duration("socket-timeout"),
+      duration("connection-request-timeout")
     )
 end ElasticsearchConfig


### PR DESCRIPTION
The Elasticsearch connect/socket/connection-request timeouts were integer milliseconds. Change them to `FiniteDuration` so they can be written as e.g. `connect-timeout = 5 seconds` in the config; the values are converted back to millis when configuring the REST client.

Note: the config keys were renamed (dropped the `-ms` suffix), so any environment overriding them needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)