### PR TITLE
perf: serve stale cache entries while refreshing in background

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 scaladex {
   caching {
-    ttl = 10 minutes
+    refresh-after = 5 minutes
+    expire-after = 1 hour
     max-size = 10000
   }
   elasticsearch {

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -26,7 +26,8 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO], cache
 
   private def buildCache[K, V](loader: K => Future[V]): AsyncLoadingCache[K, V] =
     Scaffeine()
-      .expireAfterWrite(cacheConfig.ttl)
+      .refreshAfterWrite(cacheConfig.refreshAfter)
+      .expireAfterWrite(cacheConfig.expireAfter)
       .maximumSize(cacheConfig.maxSize)
       .buildAsyncFuture(loader)
 

--- a/modules/infra/src/main/scala/scaladex/infra/config/CacheConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/CacheConfig.scala
@@ -5,15 +5,18 @@ import scala.concurrent.duration.*
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-final case class CacheConfig(ttl: FiniteDuration, maxSize: Long)
+final case class CacheConfig(refreshAfter: FiniteDuration, expireAfter: FiniteDuration, maxSize: Long)
 
 object CacheConfig:
   def load(): CacheConfig =
     from(ConfigFactory.load())
 
   def from(config: Config): CacheConfig =
+    def duration(key: String): FiniteDuration =
+      FiniteDuration(config.getDuration(s"scaladex.caching.$key").toNanos, NANOSECONDS)
     CacheConfig(
-      FiniteDuration(config.getDuration("scaladex.caching.ttl").toNanos, NANOSECONDS),
-      config.getLong("scaladex.caching.max-size")
+      refreshAfter = duration("refresh-after"),
+      expireAfter = duration("expire-after"),
+      maxSize = config.getLong("scaladex.caching.max-size")
     )
 end CacheConfig


### PR DESCRIPTION
The scaffeine caches used `expireAfterWrite` only, so when a hot entry's TTL elapsed, a burst of requests would all block on one expensive reload (a cache stampede) — most visible on `/api/project` for huge projects like `zio-aws`.

Switch to `refreshAfterWrite` + a longer `expireAfterWrite` backstop: once an entry passes the refresh age it's served **stale immediately** and reloaded in the **background**, so requests no longer wait on the reload. Only truly idle entries (past the expiry) fall back to a blocking load.

Driven by two config keys (replacing the single `caching.ttl`):

```hocon
caching {
  refresh-after = 5 minutes   # serve + background-refresh after this age
  expire-after  = 1 hour      # hard cap; evict entries idle this long
  max-size      = 10000
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)