### PR TITLE
fix: don't 500 on malformed search queries (centralize ES failure handling)

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/ElasticsearchEngine.scala
@@ -127,7 +127,7 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
   override def count(): Future[Int] =
     val query = must(matchAllQuery())
     val request = search(index).query(query).size(0)
-    esClient.execute(request).map(_.result.totalHits.toInt)
+    executeOrEmpty(esClient.execute(request), 0)(_.totalHits.toInt)
 
   override def countByTopics(limit: Int): Future[Seq[TopicCount]] =
     countAllUnique("githubInfo.topics.keyword", matchAllQuery(), limit)
@@ -141,15 +141,15 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
 
   override def getMostDependedUpon(limit: Int): Future[Seq[ProjectDocument]] =
     val request = searchRequest(matchAllQuery(), Sorting.Dependent).limit(limit)
-    esClient.execute(request).map(extractDocuments)
+    executeOrEmpty(esClient.execute(request), Seq.empty[ProjectDocument])(extractDocuments)
 
   override def getLatest(limit: Int): Future[Seq[ProjectDocument]] =
     val request = searchRequest(matchAllQuery(), Sorting.Created).limit(limit)
-    esClient.execute(request).map(extractDocuments)
+    executeOrEmpty(esClient.execute(request), Seq.empty[ProjectDocument])(extractDocuments)
 
   override def autocomplete(params: SearchParams, limit: Int): Future[Seq[ProjectDocument]] =
     val request = searchRequest(filteredSearchQuery(params), params.sorting).limit(limit)
-    esClient.execute(request).map(extractDocuments)
+    executeOrEmpty(esClient.execute(request), Seq.empty[ProjectDocument])(extractDocuments)
 
   override def find(
       queryString: String,
@@ -178,39 +178,44 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
   private def scroll(request: SearchRequest, timeout: FiniteDuration): Future[Seq[Hit]] =
     val r0 = request.keepAlive(timeout)
     val keepAlive = r0.keepAlive.get
-    def recur(resp: Response[SearchResponse]): Future[Seq[Hit]] =
-      val hits = resp.result.hits.hits.toSeq
-      resp.result.scrollId match
-        case None => Future.successful(hits)
-        case Some(id) =>
-          for
-            r <- esClient.execute(searchScroll(id, keepAlive))
-            nextHits <- recur(r)
-          yield hits ++ nextHits
+    def recur(response: Response[SearchResponse]): Future[Seq[Hit]] =
+      if response.isError then
+        logger.warn(s"Elasticsearch request failed: ${response.error.reason}")
+        Future.successful(Seq.empty)
+      else
+        val result = response.result
+        val hits = result.hits.hits.toSeq
+        result.scrollId match
+          case None => Future.successful(hits)
+          case Some(id) =>
+            for
+              r <- esClient.execute(searchScroll(id, keepAlive))
+              nextHits <- recur(r)
+            yield hits ++ nextHits
     esClient.execute(request).flatMap(recur)
   end scroll
+
+  private def executeOrEmpty[U, B](execution: => Future[Response[U]], empty: => B)(onSuccess: U => B): Future[B] =
+    execution.map { response =>
+      if response.isError then
+        logger.warn(s"Elasticsearch request failed: ${response.error.reason}")
+        empty
+      else onSuccess(response.result)
+    }
 
   private def findPage(request: SearchRequest, page: PageParams): Future[Page[SearchHit]] =
     val clamp = if page.page <= 0 then 1 else page.page
     val pagedRequest = request.from(page.size * (clamp - 1)).size(page.size)
-    esClient
-      .execute(pagedRequest)
-      .map { response =>
-        if response.isError then
-          logger.warn(s"Search request failed: ${response.error.reason}")
-          Page.empty[SearchHit]
-        else
-          Page(
-            Pagination(
-              current = clamp,
-              pageCount = Math
-                .ceil(response.result.totalHits / page.size.toDouble)
-                .toInt,
-              totalSize = response.result.totalHits
-            ),
-            response.result.hits.hits.toSeq
-          )
-      }
+    executeOrEmpty(esClient.execute(pagedRequest), Page.empty[SearchHit]) { result =>
+      Page(
+        Pagination(
+          current = clamp,
+          pageCount = Math.ceil(result.totalHits / page.size.toDouble).toInt,
+          totalSize = result.totalHits
+        ),
+        result.hits.hits.toSeq
+      )
+    }
   end findPage
 
   private def searchRequest(query: Query, sorting: Sorting): SearchRequest =
@@ -236,8 +241,8 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
       .sortBy(sortQuery)
   end searchRequest
 
-  private def extractDocuments(response: Response[SearchResponse]): Seq[ProjectDocument] =
-    response.result.hits.hits.toSeq.flatMap(toProjectDocument)
+  private def extractDocuments(response: SearchResponse): Seq[ProjectDocument] =
+    response.hits.hits.toSeq.flatMap(toProjectDocument)
 
   private def toProjectDocument(hit: SearchHit): Option[ProjectDocument] =
     parser.decode[RawProjectDocument](hit.sourceAsString) match
@@ -321,16 +326,14 @@ class ElasticsearchEngine(esClient: ElasticClient, index: String)(using Executio
       .map(_.sortBy(_._1)(Platform.ordering.reverse))
 
   private def countAllUnique(field: String, query: Query, limit: Int): Future[Seq[(String, Int)]] =
-    aggregation(field, query, limit).map(_.buckets.map(b => b.key -> b.docCount.toInt))
+    aggregation(field, query, limit).map(_.map(b => b.key -> b.docCount.toInt))
 
-  private def aggregation(field: String, query: Query, limit: Int): Future[Terms] =
+  private def aggregation(field: String, query: Query, limit: Int) =
     val aggName = s"${field}_count"
     val aggregation = termsAgg(aggName, field).size(limit)
 
     val request = search(index).query(query).aggregations(aggregation)
-    for response <- esClient.execute(request)
-    yield response.result.aggregations
-      .result[Terms](aggName)
+    executeOrEmpty(esClient.execute(request), Seq.empty)(_.aggregations.result[Terms](aggName).buckets)
 
   private def combinedWithPercentage(sortingField: String): ScoreFunction =
     val sortingFieldAccess = fieldAccess(sortingField, default = "0")

--- a/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/ElasticsearchEngineTests.scala
@@ -61,6 +61,17 @@ class ElasticsearchEngineTests extends AsyncFreeSpec with Matchers with BeforeAn
     yield page.items shouldBe empty
   }
 
+  "return empty facet counts for a malformed query instead of failing" in {
+    val params = SearchParams(queryString = ":https://tinyurl.com/txy3b83h")
+    for
+      _ <- insertAll(projects)
+      languages <- searchEngine.countByLanguages(params)
+      platforms <- searchEngine.countByPlatforms(params)
+    yield
+      languages shouldBe empty
+      platforms shouldBe empty
+  }
+
   "sort by dependent, created, stars, forks, and contributors" in {
     val params = SearchParams(queryString = "*")
     val catsFirst = Seq(Cats.projectDocument, Scalafix.projectDocument)


### PR DESCRIPTION
Same class of bug as #1764, which fixed `findPage` — but the facet aggregations (`countByLanguages`/`Platforms`/`Topics`), `autocomplete`, and `scroll` still called `.result` on the ES response directly, so a malformed query 500'd there:

```
ERROR scaladex.server.Server$ - Unhandled exception in .../GET?q=(venv) PS D:\SAAS-ERP2> git config --get-regexp "credential|remote"
java.util.NoSuchElementException: Request Failure ElasticError(search_phase_execution_exception, ... parse_exception, Cannot parse ...)
    at com.sksamuel.elastic4s.RequestFailure.result(responses.scala:71)
    at scaladex.infra.ElasticsearchEngine.aggregation$$anonfun$1(ElasticsearchEngine.scala:332)
```

Centralize the handling in an `executeOrEmpty` helper used by all read paths (and guard `scroll`'s recursion): on a failed request, log a warning and return empty results instead of throwing. Added a regression test for the aggregation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)