### PR TITLE
perf: bound the reverse-dependencies query on the artifact page

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/ArtifactDependency.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ArtifactDependency.scala
@@ -44,15 +44,6 @@ object ArtifactDependency:
   object Reverse:
     given ordering: Ordering[Reverse] =
       Ordering.by(d => (d.dependency.scope, d.groupIdAndName))
-    def sample(deps: Seq[Reverse], sampleSize: Int): Seq[Reverse] =
-      deps
-        .groupBy(r => (r.source.projectRef, r.source.artifactId))
-        .values
-        .map(_.sortBy(_.source.version))
-        .map(_.head)
-        .toSeq
-        .sorted
-        .take(sampleSize)
   end Reverse
 
   // current values in the database: optional, macro, runtime, compile, provided, test

--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -32,7 +32,8 @@ trait WebDatabase:
 
   // artifact dependencies
   def getDirectDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Direct]]
-  def getReverseDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Reverse]]
+  def getReverseDependencies(artifact: Artifact, limit: Int, offset: Int): Future[Seq[ArtifactDependency.Reverse]]
+  def countReverseDependencies(artifact: Artifact): Future[Long]
 
   // projects
   def insertProjectRef(ref: Project.Reference, status: GithubStatus): Future[Boolean]

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -128,8 +128,15 @@ class InMemoryDatabase extends SchedulerDatabase:
   override def getDirectDependencies(artifact: Artifact): Future[List[ArtifactDependency.Direct]] =
     Future.successful(Nil)
 
-  override def getReverseDependencies(artifact: Artifact): Future[List[ArtifactDependency.Reverse]] =
+  override def getReverseDependencies(
+      artifact: Artifact,
+      limit: Int,
+      offset: Int
+  ): Future[List[ArtifactDependency.Reverse]] =
     Future.successful(Nil)
+
+  override def countReverseDependencies(artifact: Artifact): Future[Long] =
+    Future.successful(0L)
 
   override def countArtifacts(): Future[Long] =
     Future.successful(allArtifacts.size)

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -77,8 +77,16 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO], cache
   private val directDependenciesCache: AsyncLoadingCache[Artifact.Reference, Seq[ArtifactDependency.Direct]] =
     buildCache(ref => run(ArtifactDependencyTable.selectDirectDependency.to[Seq](ref)))
 
-  private val reverseDependenciesCache: AsyncLoadingCache[Artifact.Reference, Seq[ArtifactDependency.Reverse]] =
-    buildCache(ref => run(ArtifactDependencyTable.selectReverseDependency.to[Seq](ref)))
+  private val reverseDependenciesCache
+      : AsyncLoadingCache[(Artifact.Reference, Int, Int), Seq[ArtifactDependency.Reverse]] =
+    buildCache {
+      case (ref, limit, offset) =>
+        run(ArtifactDependencyTable.selectReverseDependencyPage.to[Seq]((ref, limit.toLong, offset.toLong)))
+          .map(_.sorted)
+    }
+
+  private val reverseDependencyCountCache: AsyncLoadingCache[Artifact.Reference, Long] =
+    buildCache(ref => run(ArtifactDependencyTable.countReverseDependency.unique(ref)))
 
   def migrate: IO[Unit] = IO(flyway.migrate())
   def dropTables: IO[Unit] = IO(flyway.clean())
@@ -249,8 +257,15 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO], cache
   override def getDirectDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Direct]] =
     directDependenciesCache.get(artifact.reference)
 
-  override def getReverseDependencies(artifact: Artifact): Future[Seq[ArtifactDependency.Reverse]] =
-    reverseDependenciesCache.get(artifact.reference)
+  override def getReverseDependencies(
+      artifact: Artifact,
+      limit: Int,
+      offset: Int
+  ): Future[Seq[ArtifactDependency.Reverse]] =
+    reverseDependenciesCache.get((artifact.reference, limit, offset))
+
+  override def countReverseDependencies(artifact: Artifact): Future[Long] =
+    reverseDependencyCountCache.get(artifact.reference)
 
   def countGithubInfo(): Future[Long] =
     run(GithubInfoTable.count.unique)

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
@@ -64,6 +64,27 @@ object ArtifactDependencyTable:
       targetFields.map(f => s"d.$f")
     )
 
+  // deduped and limited before the artifacts join, so the join runs only for the kept rows
+  val selectReverseDependencyPage: Query[(Artifact.Reference, Long, Long), ArtifactDependency.Reverse] =
+    val depFields = fields.mkString(", ")
+    val outFields = dependencyAndArtifactFields.mkString(", ")
+    Query(
+      s"""|SELECT $outFields
+          |FROM (
+          |  SELECT DISTINCT ON (source_group_id, source_artifact_id) $depFields
+          |  FROM $table
+          |  WHERE target_group_id = ? AND target_artifact_id = ? AND target_version = ?
+          |  ORDER BY source_group_id, source_artifact_id, source_version
+          |  LIMIT ? OFFSET ?
+          |) d
+          |INNER JOIN ${ArtifactTable.table} a
+          |  ON d.source_group_id = a.group_id AND d.source_artifact_id = a.artifact_id AND d.source_version = a.version""".stripMargin
+    )
+  end selectReverseDependencyPage
+
+  val countReverseDependency: Query[Artifact.Reference, Long] =
+    selectRequest1[Artifact.Reference, Long](table, Seq("COUNT(*)"), keys = targetFields)
+
   val computeProjectDependencies: Query[(Project.Reference, Version), ProjectDependency] =
     selectRequest1[(Project.Reference, Version, Project.Reference), ProjectDependency](
       fullJoin,

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -135,10 +135,25 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
     for
       _ <- database.insertArtifacts(Seq(Cats.`core_3:2.6.1`, Cats.`kernel_3:2.6.1`))
       _ <- database.insertDependencies(Cats.dependencies)
-      reverseDependencies <- database.getReverseDependencies(Cats.`kernel_3:2.6.1`)
+      reverseDependencies <- database.getReverseDependencies(Cats.`kernel_3:2.6.1`, limit = 100, offset = 0)
     yield
       val sources = reverseDependencies.map(_.source)
       sources should contain theSameElementsAs List(Cats.`core_3:2.6.1`)
+  }
+
+  it("should dedup reverse dependencies but count all of them") {
+    val deps = Seq(
+      ArtifactDependency(Cats.`core_3:2.6.1`.reference, Cats.`laws_3:2.6.1`.reference, Scope("compile")),
+      ArtifactDependency(Cats.`core_3:4`.reference, Cats.`laws_3:2.6.1`.reference, Scope("compile"))
+    )
+    for
+      _ <- database.insertArtifacts(Seq(Cats.`core_3:2.6.1`, Cats.`core_3:4`, Cats.`laws_3:2.6.1`))
+      _ <- database.insertDependencies(deps)
+      reverseDependencies <- database.getReverseDependencies(Cats.`laws_3:2.6.1`, limit = 100, offset = 0)
+      count <- database.countReverseDependencies(Cats.`laws_3:2.6.1`)
+    yield
+      reverseDependencies should have size 1
+      count shouldBe 2L
   }
 
   it("should compute project dependencies") {

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -137,7 +137,8 @@ class ProjectPages(
                   case Some(artifact) =>
                     for
                       directDeps <- database.getDirectDependencies(artifact)
-                      reverseDeps <- database.getReverseDependencies(artifact)
+                      reverseDeps <- database.getReverseDependencies(artifact, limit = 100, offset = 0)
+                      reverseDepCount <- database.countReverseDependencies(artifact)
                     yield
                       val page = html.artifact(
                         env,
@@ -148,7 +149,8 @@ class ProjectPages(
                         binaryVersions,
                         params,
                         directDeps,
-                        reverseDeps
+                        reverseDeps,
+                        reverseDepCount
                       )
                       complete(page)
               yield route

--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -15,7 +15,8 @@
     binaryVersions: Seq[BinaryVersion],
     params: ArtifactPageParams,
     directDeps: Seq[ArtifactDependency.Direct],
-    reverseDeps: Seq[ArtifactDependency.Reverse]
+    reverseDeps: Seq[ArtifactDependency.Reverse],
+    reverseDependencyCount: Long
 )
 @main(env, title = project.repository.toString, user) {
   <main id="container-project">
@@ -155,13 +156,12 @@
   </div>
 }
 
-@sample = @{ArtifactDependency.Reverse.sample(reverseDeps, 100)}
 @dependentsBox = {
   <div class="dependents box">
-    <h4>@Formats.plural(reverseDeps.size, "Dependent")</h4>
+    <h4>@Formats.plural(reverseDependencyCount, "Dependent")</h4>
     <hr>
     <ul>
-      @for(dep <- sample){
+      @for(dep <- reverseDeps){
         <li>
           <div class="row">
             <div class="col-xs-9">
@@ -174,8 +174,8 @@
           </div>
         </li>
       }
-      @if(reverseDeps.size > 100) {
-        <p>and @{reverseDeps.size - 100} more</p>
+      @if(reverseDependencyCount > 100) {
+        <p>and @{reverseDependencyCount - 100} more</p>
       }
     </ul>
   </div>


### PR DESCRIPTION
For artifacts with many reverse dependencies (e.g. `scala-library`), the reverse-dependency query took a long time to compute and returned a large number of rows — while the artifact page only ever displays the first 100 and discards the rest.

This bounds the query:

- `getReverseDependencies` now takes `limit`/`offset` (matching `getGroupIds`/`getArtifactRefs`), hardcoded to the first 100 in `ProjectPages`.
- The page query dedups (`DISTINCT ON`) and applies `LIMIT`/`OFFSET` before joining `artifacts`, so the join runs only for the kept rows.
- A separate `COUNT(*)` (index-backed, no join) provides the header total.
- Results are re-sorted in-app by `(scope, groupIdAndName)`.