### PR TITLE
fix: decode github commit-activity week as unix seconds

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
@@ -17,7 +17,6 @@ import scaladex.core.model.UserState
 import scaladex.core.service.GithubClient
 import scaladex.core.util.ScalaExtensions.*
 import scaladex.core.util.Secret
-import scaladex.infra.Codecs.given
 import scaladex.infra.github.GithubModel
 import scaladex.infra.github.GithubModel.{*, given}
 


### PR DESCRIPTION
The commit-activity chart rendered every project starting around 1970.

`GithubClientImpl` imported the millis-based `Codec[GithubCommitActivity]` from `Codecs`. Because a `Codec[X]` is a subtype of `Decoder[X]`, it was more specific and silently shadowed `GithubModel`'s correct seconds-based `Decoder` when parsing the GitHub API response. GitHub returns `week` as unix **seconds**, but it was decoded as **milliseconds** (÷1000), placing all dates near the epoch.

The import was unused here, so removing it leaves `GithubModel`'s decoder as the only candidate and `week` decodes correctly.

Note: existing charts in the UI will only correct themselves once the `github-info` job re-fetches and overwrites the stored data for all projects.