### PR TITLE
perf: DB statement timeout, request timeout and connection-pool tuning

### DIFF
--- a/modules/data/src/main/scala/scaladex/data/Main.scala
+++ b/modules/data/src/main/scala/scaladex/data/Main.scala
@@ -54,14 +54,15 @@ object Main extends LazyLogging:
       DoobieUtils
         .transactor(datasource)
         .use { xa =>
-          val database = new SqlDatabase(datasource, xa, config.caching)
+          val database = new SqlDatabase(xa, config.caching)
           IO.fromFuture(IO(f(database)))
         }
         .unsafeRunSync()
     end usingDatabase
 
     def init(): Unit =
-      usingDatabase(database => Init.run(database, localStorage))
+      val flyway = DoobieUtils.flyway(datasource, cleanDisabled = config.env.isProd)
+      usingDatabase(database => Init.run(flyway, database, localStorage))
 
     def subIndex(): Unit =
       val storage = FilesystemStorage(config.filesystem)

--- a/modules/data/src/main/scala/scaladex/data/init/Init.scala
+++ b/modules/data/src/main/scala/scaladex/data/init/Init.scala
@@ -10,15 +10,16 @@ import scaladex.core.util.ScalaExtensions.*
 import scaladex.infra.SqlDatabase
 
 import com.typesafe.scalalogging.LazyLogging
+import org.flywaydb.core.Flyway
 
-class Init(database: SqlDatabase, localStorage: Storage)(using ExecutionContext) extends LazyLogging:
+class Init(flyway: Flyway, database: SqlDatabase, localStorage: Storage)(using ExecutionContext) extends LazyLogging:
 
   def run(): Future[Unit] =
     logger.info("Dropping tables")
     for
-      _ <- database.dropTables.unsafeToFuture()
+      _ <- Future(flyway.clean())
       _ = logger.info("Creating tables")
-      _ <- database.migrate.unsafeToFuture()
+      _ <- Future(flyway.migrate())
       _ = logger.info("Inserting all projects from local storage...")
       projectIterator = localStorage.loadAllProjects()
       _ <- projectIterator.foreachSync {
@@ -52,8 +53,8 @@ class Init(database: SqlDatabase, localStorage: Storage)(using ExecutionContext)
 end Init
 
 object Init:
-  def run(database: SqlDatabase, localStorage: Storage)(
+  def run(flyway: Flyway, database: SqlDatabase, localStorage: Storage)(
       using ExecutionContext
   ): Future[Unit] =
-    val init = new Init(database, localStorage)
+    val init = new Init(flyway, database, localStorage)
     init.run()

--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -22,6 +22,7 @@ scaladex {
     name = ${?POSTGRESQL_DATABASE}
     port = 5432
     pool-size = 25
+    statement-timeout = 10 seconds
     url = "jdbc:postgresql://"${scaladex.database.user}":"${scaladex.database.password}"@localhost:"${scaladex.database.port}"/"${scaladex.database.name}
   }
   github {

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -16,13 +16,9 @@ import cats.effect.IO
 import com.github.blemale.scaffeine.AsyncLoadingCache
 import com.github.blemale.scaffeine.Scaffeine
 import com.typesafe.scalalogging.LazyLogging
-import com.zaxxer.hikari.HikariDataSource
 import doobie.implicits.*
 
-class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO], cacheConfig: CacheConfig)
-    extends SchedulerDatabase
-    with LazyLogging:
-  private val flyway = DoobieUtils.flyway(datasource)
+class SqlDatabase(xa: doobie.Transactor[IO], cacheConfig: CacheConfig) extends SchedulerDatabase with LazyLogging:
 
   private def buildCache[K, V](loader: K => Future[V]): AsyncLoadingCache[K, V] =
     Scaffeine()
@@ -87,9 +83,6 @@ class SqlDatabase(datasource: HikariDataSource, xa: doobie.Transactor[IO], cache
 
   private val reverseDependencyCountCache: AsyncLoadingCache[Artifact.Reference, Long] =
     buildCache(ref => run(ArtifactDependencyTable.countReverseDependency.unique(ref)))
-
-  def migrate: IO[Unit] = IO(flyway.migrate())
-  def dropTables: IO[Unit] = IO(flyway.clean())
 
   override def insertArtifact(artifact: Artifact): Future[Boolean] =
     run(ArtifactTable.insertIfNotExist.run(artifact)).map { inserted =>

--- a/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
@@ -1,5 +1,6 @@
 package scaladex.infra.config
 
+import scala.concurrent.duration.*
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -9,7 +10,13 @@ import scaladex.core.util.Secret
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-final case class PostgreSQLConfig(url: String, user: String, pass: Secret, poolSize: Int):
+final case class PostgreSQLConfig(
+    url: String,
+    user: String,
+    pass: Secret,
+    poolSize: Int,
+    statementTimeout: FiniteDuration
+):
   val driver = "org.postgresql.Driver"
 
 object PostgreSQLConfig:
@@ -21,10 +28,12 @@ object PostgreSQLConfig:
     from(config)
 
   def from(config: Config): Try[PostgreSQLConfig] =
-    from(config.getString("scaladex.database.url"), config.getInt("scaladex.database.pool-size"))
+    val statementTimeout =
+      FiniteDuration(config.getDuration("scaladex.database.statement-timeout").toNanos, NANOSECONDS)
+    from(config.getString("scaladex.database.url"), config.getInt("scaladex.database.pool-size"), statementTimeout)
 
-  private def from(url: String, poolSize: Int): Try[PostgreSQLConfig] = url match
+  private def from(url: String, poolSize: Int, statementTimeout: FiniteDuration): Try[PostgreSQLConfig] = url match
     case postgreSQLRegex(login, pass, url) =>
-      Success(PostgreSQLConfig(s"jdbc:postgresql://$url", login, Secret(pass), poolSize))
+      Success(PostgreSQLConfig(s"jdbc:postgresql://$url", login, Secret(pass), poolSize, statementTimeout))
     case _ => Failure(new Exception(s"Unknown database url: $url"))
 end PostgreSQLConfig

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DoobieUtils.scala
@@ -16,15 +16,12 @@ object DoobieUtils:
   private given ContextShift[IO] =
     IO.contextShift(ExecutionContext.global)
 
-  def flyway(conf: PostgreSQLConfig): Flyway =
-    val datasource = getHikariDataSource(conf)
-    flyway(datasource)
-
-  def flyway(datasource: HikariDataSource): Flyway =
+  def flyway(datasource: HikariDataSource, cleanDisabled: Boolean): Flyway =
     Flyway
       .configure()
       .dataSource(datasource)
       .locations("migrations", "scaladex/infra/migrations")
+      .cleanDisabled(cleanDisabled)
       .load()
 
   def getHikariDataSource(conf: PostgreSQLConfig): HikariDataSource =
@@ -34,12 +31,14 @@ object DoobieUtils:
     config.setUsername(conf.user)
     config.setPassword(conf.pass.decode)
     config.setMaximumPoolSize(conf.poolSize)
+    if conf.statementTimeout.toMillis > 0 then
+      config.setConnectionInitSql(s"SET statement_timeout = ${conf.statementTimeout.toMillis}")
     new HikariDataSource(config)
   end getHikariDataSource
 
   def transactor(datasource: HikariDataSource): Resource[IO, HikariTransactor[IO]] =
     for
-      ce <- ExecutionContexts.fixedThreadPool[IO](32) // our connect EC
+      ce <- ExecutionContexts.fixedThreadPool[IO](datasource.getMaximumPoolSize) // our connect EC
       be <- Blocker[IO] // our blocking EC
     yield Transactor.fromDataSource[IO](datasource, ce, be)
 

--- a/modules/infra/src/test/scala/scaladex/infra/BaseDatabaseSuite.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/BaseDatabaseSuite.scala
@@ -33,15 +33,16 @@ trait BaseDatabaseSuite extends IOChecker with BeforeAndAfterEach:
         config.pass.decode
       )
 
-  lazy val database = new SqlDatabase(BaseDatabaseSuite.datasource, transactor, cacheConfig)
+  lazy val database = new SqlDatabase(transactor, cacheConfig)
 
   override def beforeEach(): Unit =
     Await.result(cleanTables(), Duration.Inf)
 
   private def cleanTables(): Future[Unit] =
+    val flyway = DoobieUtils.flyway(BaseDatabaseSuite.datasource, cleanDisabled = false)
     val reset = for
-      _ <- database.dropTables
-      _ <- database.migrate
+      _ <- IO(flyway.clean())
+      _ <- IO(flyway.migrate())
     yield ()
     reset.unsafeToFuture()
 end BaseDatabaseSuite

--- a/modules/server/src/it/scala/scaladex/RelevanceTest.scala
+++ b/modules/server/src/it/scala/scaladex/RelevanceTest.scala
@@ -31,10 +31,11 @@ class RelevanceTest extends TestKit(ActorSystem("SbtActorTest")) with AsyncFunSu
   override def beforeAll(): Unit =
     given ContextShift[IO] = IO.contextShift(ExecutionContext.global)
     val datasource = DoobieUtils.getHikariDataSource(config.database)
+    val flyway = DoobieUtils.flyway(datasource, cleanDisabled = config.env.isProd)
     val transactor = DoobieUtils.transactor(datasource)
     transactor
       .use { xa =>
-        val database = new SqlDatabase(datasource, xa, config.caching)
+        val database = new SqlDatabase(xa, config.caching)
         val filesystem = FilesystemStorage(config.filesystem)
 
         val projectService = new ProjectService(database, searchEngine)
@@ -44,7 +45,7 @@ class RelevanceTest extends TestKit(ActorSystem("SbtActorTest")) with AsyncFunSu
 
         IO.fromFuture(IO {
           for
-            _ <- Init.run(database, filesystem)
+            _ <- Init.run(flyway, database, filesystem)
             _ <- searchEngine.init(true)
             _ <- artifactService.updateAllLatestVersions().zip(projectDependenciesUpdater.updateAll())
             _ <- searchSync.syncAll()

--- a/modules/server/src/main/resources/reference.conf
+++ b/modules/server/src/main/resources/reference.conf
@@ -7,6 +7,7 @@ scaladex {
     endpoint = localhost
     port = 8080
     session-secret = WWItju7orWthk7vbAPqI72XOBCfZFxbVjMH169o9eLjHmMCGXw2VdBsQeTNF3WH0
+    request-timeout = 20 seconds
   }
 
   oauth2 {

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -33,6 +33,7 @@ import org.apache.pekko.http.scaladsl.*
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.server.*
 import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.flywaydb.core.Flyway
 
 object Server extends LazyLogging:
 
@@ -53,17 +54,19 @@ object Server extends LazyLogging:
 
       val resources =
         val datasourceWeb = DoobieUtils.getHikariDataSource(config.database)
-        val datasourceScheduler = DoobieUtils.getHikariDataSource(config.database)
+        val datasourceScheduler =
+          DoobieUtils.getHikariDataSource(config.database.copy(statementTimeout = Duration.Zero, poolSize = 10))
         for
           webPool <- DoobieUtils.transactor(datasourceWeb)
           schedulerPool <- DoobieUtils.transactor(datasourceScheduler)
           publishPool <- ExecutionContexts.fixedThreadPool[IO](8)
-        yield (webPool, schedulerPool, publishPool, datasourceWeb)
+        yield (webPool, schedulerPool, publishPool, datasourceScheduler)
       resources
         .use {
-          case (webPool, schedulerPool, publishPool, datasourceForFlyway) =>
-            val webDatabase = new SqlDatabase(datasourceForFlyway, webPool, config.caching)
-            val schedulerDatabase = new SqlDatabase(datasourceForFlyway, schedulerPool, config.caching)
+          case (webPool, schedulerPool, publishPool, migrationDatasource) =>
+            val webDatabase = new SqlDatabase(webPool, config.caching)
+            val schedulerDatabase = new SqlDatabase(schedulerPool, config.caching)
+            val flyway = DoobieUtils.flyway(migrationDatasource, cleanDisabled = true)
             val githubClient = config.github.token.map(new GithubClientImpl(_))
             val paths = DataPaths.from(config.filesystem)
             val filesystem = FilesystemStorage(config.filesystem)
@@ -82,7 +85,7 @@ object Server extends LazyLogging:
               new AdminService(config.env, schedulerDatabase, searchEngine, githubClient, mavenCentralService)
 
             for
-              _ <- init(webDatabase, adminService, searchEngine, config.elasticsearch.reset)
+              _ <- init(flyway, adminService, searchEngine, config.elasticsearch.reset)
               routes = configureRoutes(
                 config,
                 searchEngine,
@@ -117,7 +120,7 @@ object Server extends LazyLogging:
         sys.exit(1)
 
   private def init(
-      database: SqlDatabase,
+      flyway: Flyway,
       adminService: AdminService,
       searchEngine: ElasticsearchEngine,
       resetElastic: Boolean
@@ -126,7 +129,7 @@ object Server extends LazyLogging:
   ): IO[Unit] =
     logger.info("Applying flyway migration to database")
     for
-      _ <- database.migrate
+      _ <- IO(flyway.migrate())
       _ = logger.info("Waiting for ElasticSearch to start")
       _ <- IO.fromFuture(IO(searchEngine.init(resetElastic)))
       _ = logger.info("Starting all schedulers")
@@ -193,9 +196,11 @@ object Server extends LazyLogging:
         }
     }
     HttpRequestLogging.logAccess {
-      handleExceptions(exceptionHandler) {
-        handleRejections(RejectionHandler.default) {
-          route
+      withRequestTimeout(config.requestTimeout) {
+        handleExceptions(exceptionHandler) {
+          handleRejections(RejectionHandler.default) {
+            route
+          }
         }
       }
     }

--- a/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
+++ b/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
@@ -1,5 +1,7 @@
 package scaladex.server.config
 
+import scala.concurrent.duration.*
+
 import scaladex.core.model.Env
 import scaladex.infra.config.CacheConfig
 import scaladex.infra.config.ElasticsearchConfig
@@ -16,6 +18,7 @@ case class ServerConfig(
     session: SessionConfig,
     endpoint: String,
     port: Int,
+    requestTimeout: FiniteDuration,
     oAuth2: OAuth2Config,
     database: PostgreSQLConfig,
     elasticsearch: ElasticsearchConfig,
@@ -33,6 +36,8 @@ object ServerConfig:
 
     val endpoint = config.getString("scaladex.server.endpoint")
     val port = config.getInt("scaladex.server.port")
+    val requestTimeout =
+      FiniteDuration(config.getDuration("scaladex.server.request-timeout").toNanos, NANOSECONDS)
     val oauth2 = OAuth2Config.from(config)
     val database = PostgreSQLConfig.from(config).get
     val elasticsearch = ElasticsearchConfig.from(config)
@@ -41,6 +46,18 @@ object ServerConfig:
     val github = GithubConfig.from(config)
     val caching = CacheConfig.from(config)
 
-    ServerConfig(env, session, endpoint, port, oauth2, database, elasticsearch, filesystem, github, caching)
+    ServerConfig(
+      env,
+      session,
+      endpoint,
+      port,
+      requestTimeout,
+      oauth2,
+      database,
+      elasticsearch,
+      filesystem,
+      github,
+      caching
+    )
   end load
 end ServerConfig


### PR DESCRIPTION
Hardens database connection management against pool starvation, where slow queries under heavy (crawler) traffic held connections long enough to exhaust the pool.

- **Configurable DB statement timeout** (`scaladex.database.statement-timeout`, default `10 seconds`): applied to the web connection pool via Hikari `connectionInitSql`, so a runaway query is cancelled by Postgres and its connection returned instead of being held for the full request. Set to `0` (disabled) on the scheduler pool, since batch jobs may run legitimately long queries.
- **Configurable HTTP request timeout** (`scaladex.server.request-timeout`, default `20 seconds`): applied with `withRequestTimeout`.
- **Scheduler pool is timeout-free and smaller** (size 10): batch jobs and Flyway migrations run on it without the statement timeout, so a long-running migration (e.g. creating an index) is never cancelled.
- **Connect EC sized to the JDBC pool**: the doobie connect execution context now matches the connection-pool size instead of a hardcoded 32. Per the [doobie docs](https://typelevel.org/doobie/docs/14-Managing-Connections.html): *"The maximum thread limit for connectEC should be the same as your underlying JDBC connection pool, since any more threads are guaranteed to be blocked."*
- **Flyway extracted from `SqlDatabase`**: `SqlDatabase` is now purely a query layer; migrations/clean go through `DoobieUtils.flyway(...)`, with `clean` disabled in the prod environment via Flyway's `cleanDisabled`.