### PR TITLE
perf: add database indexes for artifact query hotspots

### DIFF
--- a/modules/infra/src/main/resources/migrations/V28__add_indexes.sql
+++ b/modules/infra/src/main/resources/migrations/V28__add_indexes.sql
@@ -1,0 +1,10 @@
+CREATE INDEX IF NOT EXISTS artifact_latest_version_index
+  ON artifacts (organization, repository)
+  WHERE is_latest_version;
+
+-- the following indexes were created manually on prod; reconciled here so fresh databases match
+CREATE INDEX IF NOT EXISTS "artifact-dependencies-index"
+  ON artifact_dependencies (target_group_id, target_artifact_id, target_version);
+
+CREATE INDEX IF NOT EXISTS artifact_index_4
+  ON artifacts (organization, repository, group_id, artifact_id, release_date);

--- a/modules/infra/src/main/resources/migrations/V28__add_is_latest_version_index.sql
+++ b/modules/infra/src/main/resources/migrations/V28__add_is_latest_version_index.sql
@@ -1,3 +1,0 @@
-CREATE INDEX IF NOT EXISTS artifact_latest_version_index
-  ON artifacts (organization, repository)
-  WHERE is_latest_version;

--- a/modules/infra/src/main/resources/migrations/V28__add_is_latest_version_index.sql
+++ b/modules/infra/src/main/resources/migrations/V28__add_is_latest_version_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS artifact_latest_version_index
+  ON artifacts (organization, repository)
+  WHERE is_latest_version;


### PR DESCRIPTION
Adds three indexes (migration V28):

- **`artifact_latest_version_index`** — partial index on `artifacts (organization, repository) WHERE is_latest_version`. Speeds up the project/artifact header query, which previously scanned every artifact of large projects (e.g. `zio-aws`) just to filter out non-latest rows.
- **`artifact-dependencies-index`** — on `artifact_dependencies (target_group_id, target_artifact_id, target_version)`, for reverse-dependency lookups. Created manually on prod, reconciled here so fresh databases match.
- **`artifact_index_4`** — on `artifacts (organization, repository, group_id, artifact_id, release_date)`, for project + Maven-coordinate lookups. Created manually on prod, reconciled here so fresh databases match.

Plain `CREATE INDEX` (no `CONCURRENTLY`): migrations run before the server binds and before jobs start, so there are no writers to block.