### PR TITLE
perf: shed excess web DB queries instead of queuing unboundedly

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -23,6 +23,7 @@ scaladex {
     port = 5432
     pool-size = 25
     statement-timeout = 10 seconds
+    max-concurrent-queries = 50
     url = "jdbc:postgresql://"${scaladex.database.user}":"${scaladex.database.password}"@localhost:"${scaladex.database.port}"/"${scaladex.database.name}
   }
   github {

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -2,6 +2,7 @@ package scaladex.infra
 
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.Semaphore
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -18,7 +19,14 @@ import com.github.blemale.scaffeine.Scaffeine
 import com.typesafe.scalalogging.LazyLogging
 import doobie.implicits.*
 
-class SqlDatabase(xa: doobie.Transactor[IO], cacheConfig: CacheConfig) extends SchedulerDatabase with LazyLogging:
+class SqlDatabase(
+    xa: doobie.Transactor[IO],
+    cacheConfig: CacheConfig,
+    maxConcurrentQueries: Option[Int] = None
+) extends SchedulerDatabase
+    with LazyLogging:
+
+  private val queryPermits: Option[Semaphore] = maxConcurrentQueries.map(new Semaphore(_))
 
   private def buildCache[K, V](loader: K => Future[V]): AsyncLoadingCache[K, V] =
     Scaffeine()
@@ -353,5 +361,14 @@ class SqlDatabase(xa: doobie.Transactor[IO], cacheConfig: CacheConfig) extends S
     run(ProjectTable.updateGithubStatus.run(githubStatus, ref)).map(_ => invalidateProject(ref))
 
   private def run[A](v: doobie.ConnectionIO[A]): Future[A] =
-    v.transact(xa).unsafeToFuture()
+    queryPermits match
+      case None => v.transact(xa).unsafeToFuture()
+      case Some(permits) =>
+        if !permits.tryAcquire() then Future.failed(DatabaseOverloadedException)
+        else
+          val future = v.transact(xa).unsafeToFuture()
+          future.onComplete(_ => permits.release())
+          future
 end SqlDatabase
+
+object DatabaseOverloadedException extends RuntimeException("database overloaded")

--- a/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/PostgreSQLConfig.scala
@@ -15,7 +15,8 @@ final case class PostgreSQLConfig(
     user: String,
     pass: Secret,
     poolSize: Int,
-    statementTimeout: FiniteDuration
+    statementTimeout: FiniteDuration,
+    maxConcurrentQueries: Int
 ):
   val driver = "org.postgresql.Driver"
 
@@ -30,10 +31,29 @@ object PostgreSQLConfig:
   def from(config: Config): Try[PostgreSQLConfig] =
     val statementTimeout =
       FiniteDuration(config.getDuration("scaladex.database.statement-timeout").toNanos, NANOSECONDS)
-    from(config.getString("scaladex.database.url"), config.getInt("scaladex.database.pool-size"), statementTimeout)
+    from(
+      config.getString("scaladex.database.url"),
+      config.getInt("scaladex.database.pool-size"),
+      statementTimeout,
+      config.getInt("scaladex.database.max-concurrent-queries")
+    )
 
-  private def from(url: String, poolSize: Int, statementTimeout: FiniteDuration): Try[PostgreSQLConfig] = url match
+  private def from(
+      url: String,
+      poolSize: Int,
+      statementTimeout: FiniteDuration,
+      maxConcurrentQueries: Int
+  ): Try[PostgreSQLConfig] = url match
     case postgreSQLRegex(login, pass, url) =>
-      Success(PostgreSQLConfig(s"jdbc:postgresql://$url", login, Secret(pass), poolSize, statementTimeout))
+      Success(
+        PostgreSQLConfig(
+          s"jdbc:postgresql://$url",
+          login,
+          Secret(pass),
+          poolSize,
+          statementTimeout,
+          maxConcurrentQueries
+        )
+      )
     case _ => Failure(new Exception(s"Unknown database url: $url"))
 end PostgreSQLConfig

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -9,6 +9,7 @@ import scala.util.control.NonFatal
 import scaladex.core.service.ProjectService
 import scaladex.data.util.PidLock
 import scaladex.infra.DataPaths
+import scaladex.infra.DatabaseOverloadedException
 import scaladex.infra.ElasticsearchEngine
 import scaladex.infra.FilesystemStorage
 import scaladex.infra.GithubClientImpl
@@ -64,7 +65,7 @@ object Server extends LazyLogging:
       resources
         .use {
           case (webPool, schedulerPool, publishPool, migrationDatasource) =>
-            val webDatabase = new SqlDatabase(webPool, config.caching)
+            val webDatabase = new SqlDatabase(webPool, config.caching, Some(config.database.maxConcurrentQueries))
             val schedulerDatabase = new SqlDatabase(schedulerPool, config.caching)
             val flyway = DoobieUtils.flyway(migrationDatasource, cleanDisabled = true)
             val githubClient = config.github.token.map(new GithubClientImpl(_))
@@ -188,6 +189,8 @@ object Server extends LazyLogging:
         )
       }
     val exceptionHandler = ExceptionHandler {
+      case DatabaseOverloadedException =>
+        complete(StatusCodes.ServiceUnavailable, "Server is overloaded, please retry later")
       case NonFatal(cause) =>
         extractUri { uri =>
           import scaladex.server.TwirlSupport.given


### PR DESCRIPTION
Under load, requests piled up in doobie's unbounded connect-EC queue waiting for a web-pool connection (handler times up to ~763s). `statement_timeout` only caps a *running* query and `withRequestTimeout` doesn't cancel the handler, so neither bounds that wait.

This bounds concurrent queries on the **web** `SqlDatabase` with a `Semaphore`: excess `run` calls fail fast with `DatabaseOverloadedException`, mapped to **503**, so the connect-EC queue can't grow. Configurable via `scaladex.database.max-concurrent-queries` (default 50, kept a bit above `pool-size`); the scheduler database stays unbounded.