### PR TITLE
perf: bound the reverse-dependencies query on the project page

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -65,7 +65,7 @@ trait WebDatabase:
   // project dependencies
   def countProjectDependents(projectRef: Project.Reference): Future[Long]
   def getProjectDependencies(ref: Project.Reference, version: Version): Future[Seq[ProjectDependency]]
-  def getProjectDependents(ref: Project.Reference): Future[Seq[ProjectDependency]]
+  def getProjectReverseDependencies(ref: Project.Reference, limit: Int, offset: Int): Future[Seq[ProjectDependency]]
 
   // users
   def insertUser(userId: UUID, user: UserInfo): Future[Unit]

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -190,7 +190,11 @@ class InMemoryDatabase extends SchedulerDatabase:
       version: Version
   ): Future[Seq[ProjectDependency]] =
     Future.successful(Seq.empty)
-  override def getProjectDependents(ref: Project.Reference): Future[Seq[ProjectDependency]] =
+  override def getProjectReverseDependencies(
+      ref: Project.Reference,
+      limit: Int,
+      offset: Int
+  ): Future[Seq[ProjectDependency]] =
     Future.successful(Seq.empty)
   override def countVersions(ref: Project.Reference): Future[Long] =
     Future.successful(getProjectArtifactsSync(ref).map(_.version).distinct.size)

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -84,6 +84,13 @@ class SqlDatabase(xa: doobie.Transactor[IO], cacheConfig: CacheConfig) extends S
   private val reverseDependencyCountCache: AsyncLoadingCache[Artifact.Reference, Long] =
     buildCache(ref => run(ArtifactDependencyTable.countReverseDependency.unique(ref)))
 
+  private val projectReverseDependenciesCache
+      : AsyncLoadingCache[(Project.Reference, Int, Int), Seq[ProjectDependency]] =
+    buildCache {
+      case (ref, limit, offset) =>
+        run(ProjectDependenciesTable.getReverseDependenciesPage.to[Seq]((ref, limit.toLong, offset.toLong)))
+    }
+
   override def insertArtifact(artifact: Artifact): Future[Boolean] =
     run(ArtifactTable.insertIfNotExist.run(artifact)).map { inserted =>
       invalidateArtifactRefs(artifact)
@@ -282,8 +289,12 @@ class SqlDatabase(xa: doobie.Transactor[IO], cacheConfig: CacheConfig) extends S
   override def countProjectDependents(projectRef: Project.Reference): Future[Long] =
     run(ProjectDependenciesTable.countDependents.unique(projectRef))
 
-  override def getProjectDependents(ref: Project.Reference): Future[Seq[ProjectDependency]] =
-    run(ProjectDependenciesTable.getDependents.to[Seq](ref))
+  override def getProjectReverseDependencies(
+      ref: Project.Reference,
+      limit: Int,
+      offset: Int
+  ): Future[Seq[ProjectDependency]] =
+    projectReverseDependenciesCache.get((ref, limit, offset))
 
   override def computeProjectsCreationDates(): Future[Seq[(Instant, Project.Reference)]] =
     run(ArtifactTable.selectOldestByProject.to[Seq])

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
@@ -25,8 +25,24 @@ object ProjectDependenciesTable:
       Seq("target_organization", "target_repository")
     )
 
-  val getDependents: Query[Project.Reference, ProjectDependency] =
-    selectRequest(table, allFields, Seq("target_organization", "target_repository"))
+  // the first N distinct source projects are selected before fetching their rows
+  val getReverseDependenciesPage: Query[(Project.Reference, Long, Long), ProjectDependency] =
+    val outFields = allFields.map(f => s"d.$f").mkString(", ")
+    Query[(Project.Reference, Long, Long, Project.Reference), ProjectDependency](
+      s"""|SELECT $outFields
+          |FROM (
+          |  SELECT DISTINCT source_organization, source_repository
+          |  FROM $table
+          |  WHERE target_organization = ? AND target_repository = ?
+          |  ORDER BY source_organization, source_repository
+          |  LIMIT ? OFFSET ?
+          |) s
+          |INNER JOIN $table d
+          |  ON d.source_organization = s.source_organization
+          |  AND d.source_repository = s.source_repository
+          |  AND d.target_organization = ? AND d.target_repository = ?""".stripMargin
+    ).contramap { case (ref, limit, offset) => (ref, limit, offset, ref) }
+  end getReverseDependenciesPage
 
   val getDependencies: Query[(Project.Reference, Version), ProjectDependency] =
     selectRequest(table, allFields, sourceFields)

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -172,18 +172,19 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       catsDependencies <- database.computeProjectDependencies(Cats.reference, Cats.`core_2.13:2.6.1`.version)
       _ <- database.insertProjectDependencies(scalafixDependencies ++ catsDependencies)
       catsDependents <- database.countProjectDependents(Cats.reference)
+      catsReverseDependencies <- database.getProjectReverseDependencies(Cats.reference, limit = 100, offset = 0)
     yield
-      scalafixDependencies shouldBe Seq(
-        ProjectDependency(
-          Scalafix.reference,
-          Scalafix.artifact.version,
-          Cats.reference,
-          Cats.`core_2.13:2.6.1`.version,
-          Scope("compile")
-        )
+      val expectedDependency = ProjectDependency(
+        Scalafix.reference,
+        Scalafix.artifact.version,
+        Cats.reference,
+        Cats.`core_2.13:2.6.1`.version,
+        Scope("compile")
       )
+      scalafixDependencies shouldBe Seq(expectedDependency)
       catsDependencies shouldBe empty
       catsDependents shouldBe 1
+      catsReverseDependencies shouldBe Seq(expectedDependency)
   }
   it("should update creation date") {
     for

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
@@ -9,5 +9,5 @@ class ProjectDependenciesTableTests extends AnyFunSpec with BaseDatabaseSuite wi
   it("check insertOrUpdate")(check(ProjectDependenciesTable.insertOrUpdate))
   it("check deleteBySource")(check(ProjectDependenciesTable.deleteBySource))
   it("check getDependencies")(check(ProjectDependenciesTable.getDependencies))
-  it("check getDependents")(check(ProjectDependenciesTable.getDependents))
+  it("check getReverseDependenciesPage")(check(ProjectDependenciesTable.getReverseDependenciesPage))
   it("check countDependents")(check(ProjectDependenciesTable.countDependents))

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -301,7 +301,8 @@ class ProjectPages(
           header
             .map(h => database.getProjectDependencies(ref, h.latestVersion))
             .getOrElse(Future.successful(Seq.empty))
-        reverseDependencies <- database.getProjectDependents(ref)
+        reverseDependencies <- database.getProjectReverseDependencies(ref, limit = 100, offset = 0)
+        reverseDependencyCount <- database.countProjectDependents(ref)
       yield
         val groupedDirectDependencies = directDependencies
           .groupBy(_.target)
@@ -320,7 +321,15 @@ class ProjectPages(
             (scope, version)
           }
         val page =
-          html.project(env, user, project, header, groupedDirectDependencies.toMap, groupedReverseDependencies.toMap)
+          html.project(
+            env,
+            user,
+            project,
+            header,
+            groupedDirectDependencies.toMap,
+            groupedReverseDependencies.toMap,
+            reverseDependencyCount
+          )
         complete(page)
     }
 

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -11,6 +11,7 @@
   header: Option[ProjectHeader],
   directDependencies: Map[Project.Reference, (ArtifactDependency.Scope, Seq[Version])],
   reverseDependency: Map[Project.Reference, (ArtifactDependency.Scope, Version)],
+  reverseDependencyCount: Long,
 )
 @main(env, title = project.repository.value, user, extraMeta = project.twitterCard.toHeadMeta, extraMetaProperty = project.ogp.toHeadMetaProperty) {
   <main id="container-project">
@@ -28,10 +29,10 @@
         <div class="col-md-4">
           <div class="sidebar-project">
             @communityBox
-            @project.githubInfo.map(gh => statisticsBox(gh, project.reference, reverseDependency.size))
+            @project.githubInfo.map(gh => statisticsBox(gh, project.reference, reverseDependencyCount))
             @commitActivityBox
             @directDependenciesBox(directDependencies)
-            @reverseDependenciesBox(reverseDependency)
+            @reverseDependenciesBox(reverseDependency, reverseDependencyCount)
           </div>
         </div>
       </div>
@@ -44,7 +45,7 @@
   </script>
 }
 
-@statisticsBox(github: GithubInfo, ref: Project.Reference, dependentsCount: Int) = {
+@statisticsBox(github: GithubInfo, ref: Project.Reference, dependentsCount: Long) = {
   <div class="statistic box">
     <h4>Statistics</h4>
     <div class="row">
@@ -122,11 +123,11 @@
   </div>
 }
 
-@reverseDependenciesBox(dependencies: Map[Project.Reference, (ArtifactDependency.Scope, Version)]) = {
+@reverseDependenciesBox(dependencies: Map[Project.Reference, (ArtifactDependency.Scope, Version)], count: Long) = {
   <section class="dependencies box" id="dependents">
-    <h4>@Formats.plural(dependencies.size, "Dependent")</h4>
+    <h4>@Formats.plural(count, "Dependent")</h4>
     <ul>
-      @for((ref, (scope, version)) <- dependencies.take(100).toSeq.sortBy { case (ref, _) => ref }){
+      @for((ref, (scope, version)) <- dependencies.toSeq.sortBy { case (ref, _) => ref }){
         <li>
           <div class="row">
             <div class="col-xs-8"><a href="/@ref">@ref</a> @scopeSpan(scope)</div>
@@ -134,8 +135,8 @@
           </div>
         </li>
       }
-      @if(dependencies.size > 100) {
-        <p>and @{dependencies.size - 100} more</p>
+      @if(count > 100) {
+        <p>and @{count - 100} more</p>
       }
     </ul>
   </section>


### PR DESCRIPTION
The project page fetched all reverse dependencies, grouped them in-app and displayed only the first 100. This bounds the query: `getReverseDependenciesPage` selects the first N distinct source projects before fetching their rows, and `countProjectDependents` supplies the header total. Mirrors #1770 (artifact page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)