### PR TITLE
fix: count deduplicated artifact reverse dependencies

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactDependencyTable.scala
@@ -83,7 +83,11 @@ object ArtifactDependencyTable:
   end selectReverseDependencyPage
 
   val countReverseDependency: Query[Artifact.Reference, Long] =
-    selectRequest1[Artifact.Reference, Long](table, Seq("COUNT(*)"), keys = targetFields)
+    selectRequest[Artifact.Reference, Long](
+      table,
+      Seq("COUNT(DISTINCT (source_group_id, source_artifact_id))"),
+      targetFields
+    )
 
   val computeProjectDependencies: Query[(Project.Reference, Version), ProjectDependency] =
     selectRequest1[(Project.Reference, Version, Project.Reference), ProjectDependency](

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -141,7 +141,7 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       sources should contain theSameElementsAs List(Cats.`core_3:2.6.1`)
   }
 
-  it("should dedup reverse dependencies but count all of them") {
+  it("should dedup reverse dependencies and count the deduped ones") {
     val deps = Seq(
       ArtifactDependency(Cats.`core_3:2.6.1`.reference, Cats.`laws_3:2.6.1`.reference, Scope("compile")),
       ArtifactDependency(Cats.`core_3:4`.reference, Cats.`laws_3:2.6.1`.reference, Scope("compile"))
@@ -153,7 +153,7 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       count <- database.countReverseDependencies(Cats.`laws_3:2.6.1`)
     yield
       reverseDependencies should have size 1
-      count shouldBe 2L
+      count shouldBe 1L
   }
 
   it("should compute project dependencies") {

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactDependencyTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ArtifactDependencyTableTests.scala
@@ -10,4 +10,5 @@ class ArtifactDependencyTableTests extends AnyFunSpec with BaseDatabaseSuite wit
   it("check select")(check(ArtifactDependencyTable.select))
   it("check selectDirectDependency")(check(ArtifactDependencyTable.selectDirectDependency))
   it("check selectReverseDependency")(check(ArtifactDependencyTable.selectReverseDependency))
+  it("check countReverseDependency")(check(ArtifactDependencyTable.countReverseDependency))
   it("check computeProjectDependencies")(check(ArtifactDependencyTable.computeProjectDependencies))


### PR DESCRIPTION
The "N Dependents" label used `COUNT(*)`, but the list below dedups by `(source_group_id, source_artifact_id)`. The label now counts distinct dependents so it matches the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)