### PR TITLE
fix: throttle and retry HTTP requests to Maven Central

### DIFF
--- a/modules/infra/src/it/scala/scaladex/infra/GithubClientImplTests.scala
+++ b/modules/infra/src/it/scala/scaladex/infra/GithubClientImplTests.scala
@@ -19,7 +19,7 @@ class GithubClientImplTests extends AsyncFunSpec with Matchers:
   val config: GithubConfig = GithubConfig.load()
   val isCI = System.getenv("CI") != null
   val token = config.token.getOrElse(throw new Exception(s"Missing GITHUB_TOKEN"))
-  val client = new GithubClientImpl(token)
+  val client = new GithubClientImpl(token, config.httpClient)
   val userStateOpt =
     if isCI then None
     else

--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -44,7 +44,7 @@ scaladex {
   maven-central {
     http-client {
       throttle {
-        requests = 5
+        requests = 1
         per = 1 second
       }
       retry {

--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -29,6 +29,30 @@ scaladex {
   github {
     # follow this tutorial to create your token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
     token = ${?GITHUB_TOKEN}
+    http-client {
+      throttle {
+        requests = 5000
+        per = 1 hour
+      }
+      retry {
+        max-retries = 5
+        initial-delay = 1 second
+        max-delay = 60 seconds
+      }
+    }
+  }
+  maven-central {
+    http-client {
+      throttle {
+        requests = 5
+        per = 1 second
+      }
+      retry {
+        max-retries = 5
+        initial-delay = 1 second
+        max-delay = 60 seconds
+      }
+    }
   }
   filesystem {
     contrib = scaladex-contrib

--- a/modules/infra/src/main/scala/scaladex/infra/CommonAkkaHttpClient.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/CommonAkkaHttpClient.scala
@@ -4,15 +4,23 @@ import scala.annotation.nowarn
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.concurrent.duration.*
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
+import scaladex.core.util.ScalaExtensions.*
+import scaladex.infra.config.HttpClientConfig
+
 import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCode
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.pattern.after
 import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.stream.QueueOfferResult
 import org.apache.pekko.stream.scaladsl.Flow
@@ -21,7 +29,9 @@ import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.stream.scaladsl.SourceQueueWithComplete
 
-abstract class CommonAkkaHttpClient(using ActorSystem) extends FailFastCirceSupport:
+abstract class CommonAkkaHttpClient(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
+    extends FailFastCirceSupport
+    with LazyLogging:
 
   def initPoolClientFlow: Flow[
     (HttpRequest, Promise[HttpResponse]),
@@ -30,14 +40,18 @@ abstract class CommonAkkaHttpClient(using ActorSystem) extends FailFastCirceSupp
   ]
 
   val queue: SourceQueueWithComplete[(HttpRequest, Promise[HttpResponse])] =
-    Source
-      .queue[(HttpRequest, Promise[HttpResponse])](10000, OverflowStrategy.dropNew: @nowarn)
-      .via(initPoolClientFlow)
+    val requests =
+      Source
+        .queue[(HttpRequest, Promise[HttpResponse])](10000, OverflowStrategy.dropNew: @nowarn)
+        .via(initPoolClientFlow)
+    config.throttle
+      .fold(requests)(t => requests.throttle(t.requests, t.per))
       .toMat(Sink.foreach {
         case (Success(resp), p) => p.success(resp)
         case (Failure(e), p) => p.failure(e)
       })(Keep.left)
       .run()
+  end queue
 
   def queueRequest(
       request: HttpRequest
@@ -53,4 +67,38 @@ abstract class CommonAkkaHttpClient(using ActorSystem) extends FailFastCirceSupp
         )
     }
   end queueRequest
+
+  private val retriableStatusCodes: Set[StatusCode] = Set(
+    StatusCodes.RequestTimeout,
+    StatusCodes.TooManyRequests,
+    StatusCodes.InternalServerError,
+    StatusCodes.BadGateway,
+    StatusCodes.ServiceUnavailable,
+    StatusCodes.GatewayTimeout
+  )
+
+  def queueRequestWithRetry(
+      request: HttpRequest,
+      attempt: Int = 0
+  )(using ExecutionContextExecutor): Future[HttpResponse] =
+    queueRequest(request).flatMap { response =>
+      config.retry match
+        case Some(retry) if retriableStatusCodes(response.status) && attempt < retry.maxRetries =>
+          val backoff = retryDelay(response, retry, attempt)
+          logger.warn(
+            s"${response.status.intValue} for ${request.uri}, retrying in ${backoff.shortPrint} " +
+              s"(attempt ${attempt + 1}/${retry.maxRetries})"
+          )
+          response.discardEntityBytes()
+          after(backoff, system.scheduler)(queueRequestWithRetry(request, attempt + 1))
+        case _ =>
+          Future.successful(response)
+    }
+
+  /** Honor the Retry-After header if present, otherwise use capped exponential backoff. */
+  private def retryDelay(response: HttpResponse, retry: HttpClientConfig.Retry, attempt: Int): FiniteDuration =
+    val retryAfter = response.headers.find(_.is("retry-after")).flatMap(h => h.value.toIntOption).map(_.seconds)
+    val backoff = retry.initialDelay * math.pow(2, attempt).toLong
+    val delay = retryAfter.getOrElse(backoff)
+    if delay < retry.maxDelay then delay else retry.maxDelay
 end CommonAkkaHttpClient

--- a/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
@@ -3,7 +3,6 @@ package scaladex.infra
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
 import scaladex.core.model.GithubCommitActivity
@@ -17,6 +16,7 @@ import scaladex.core.model.UserState
 import scaladex.core.service.GithubClient
 import scaladex.core.util.ScalaExtensions.*
 import scaladex.core.util.Secret
+import scaladex.infra.config.HttpClientConfig
 import scaladex.infra.github.GithubModel
 import scaladex.infra.github.GithubModel.{*, given}
 
@@ -42,8 +42,8 @@ import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
 import org.apache.pekko.stream.scaladsl.Flow
 import org.apache.pekko.util.ByteString
 
-class GithubClientImpl(token: Secret)(using system: ActorSystem)
-    extends CommonAkkaHttpClient
+class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
+    extends CommonAkkaHttpClient(config)
     with GithubClient
     with LazyLogging:
   private val credentials: OAuth2BearerToken = OAuth2BearerToken(token.decode)
@@ -65,7 +65,6 @@ class GithubClientImpl(token: Secret)(using system: ActorSystem)
           ConnectionPoolSettings("akka.http.host-connection-pool.response-entity-subscription-timeout = 10.seconds")
             .copy(maxConnections = 10)
       )
-      .throttle(elements = 5000, per = 1.hour)
 
   override def getProjectInfo(ref: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
     getRepository(ref).flatMap {
@@ -376,7 +375,7 @@ class GithubClientImpl(token: Secret)(using system: ActorSystem)
 
   private def process(request: HttpRequest): Future[GithubResponse[(Seq[HttpHeader], ResponseEntity)]] =
     assert(request.headers.contains(Authorization(credentials)))
-    queueRequest(request).flatMap {
+    queueRequestWithRetry(request).flatMap {
       case HttpResponse(StatusCodes.OK, headers, entity, _) =>
         Future.successful(GithubResponse.Ok((headers, entity)))
       case HttpResponse(StatusCodes.MovedPermanently, headers, entity, _) =>

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -15,6 +15,7 @@ import scaladex.core.model.SbtPlugin
 import scaladex.core.model.Version
 import scaladex.core.service.MavenCentralClient
 import scaladex.core.util.JsoupUtils
+import scaladex.infra.config.HttpClientConfig
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
@@ -27,8 +28,8 @@ import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import org.apache.pekko.stream.scaladsl.Flow
 
-class MavenCentralClientImpl()(using system: ActorSystem)
-    extends CommonAkkaHttpClient
+class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
+    extends CommonAkkaHttpClient(config)
     with MavenCentralClient
     with LazyLogging:
   private given ExecutionContextExecutor = system.dispatcher
@@ -50,7 +51,7 @@ class MavenCentralClientImpl()(using system: ActorSystem)
       HttpRequest(uri = uri)
 
     for
-      response <- queueRequest(request)
+      response <- queueRequestWithRetry(request)
       directories <- listDirectories(uri, response)
     yield directories.map(Artifact.ArtifactId.apply)
   end getAllArtifactIds
@@ -59,7 +60,7 @@ class MavenCentralClientImpl()(using system: ActorSystem)
     val uri = s"$baseUri/${groupId.mavenUrl}/${artifactId.value}/"
     val request = HttpRequest(uri = uri)
     val future = for
-      response <- queueRequest(request)
+      response <- queueRequestWithRetry(request)
       directories <- listDirectories(uri, response)
     yield directories.map(Version.apply)
     future.recoverWith {
@@ -72,7 +73,7 @@ class MavenCentralClientImpl()(using system: ActorSystem)
   override def getPomFile(ref: Artifact.Reference): Future[Option[(String, Instant)]] =
     val pomUri = getPomUri(ref)
     val future = for
-      response <- queueRequest(HttpRequest(uri = pomUri))
+      response <- queueRequestWithRetry(HttpRequest(uri = pomUri))
       res <- getPomFileWithLastModifiedTime(response, pomUri)
     yield res
     future.recoverWith {

--- a/modules/infra/src/main/scala/scaladex/infra/config/GithubConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/GithubConfig.scala
@@ -5,7 +5,7 @@ import scaladex.core.util.Secret
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-case class GithubConfig(token: Option[Secret])
+case class GithubConfig(token: Option[Secret], httpClient: HttpClientConfig)
 
 object GithubConfig:
   def load(): GithubConfig =
@@ -15,4 +15,8 @@ object GithubConfig:
     val tokenOpt =
       if config.hasPath("scaladex.github.token") then Some(config.getString("scaladex.github.token"))
       else None
-    GithubConfig(tokenOpt.map(Secret.apply))
+    GithubConfig(
+      tokenOpt.map(Secret.apply),
+      HttpClientConfig.from(config.getConfig("scaladex.github.http-client"))
+    )
+end GithubConfig

--- a/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
@@ -25,8 +25,7 @@ object HttpClientConfig:
     def duration(key: String): FiniteDuration =
       FiniteDuration(config.getDuration(key).toNanos, NANOSECONDS)
     val throttle =
-      if config.hasPath("throttle") then
-        Some(Throttle(config.getInt("throttle.requests"), duration("throttle.per")))
+      if config.hasPath("throttle") then Some(Throttle(config.getInt("throttle.requests"), duration("throttle.per")))
       else None
     val retry =
       if config.hasPath("retry") then

--- a/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
@@ -1,0 +1,43 @@
+package scaladex.infra.config
+
+import scala.concurrent.duration.*
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+final case class HttpClientConfig(
+    throttle: Option[HttpClientConfig.Throttle],
+    retry: Option[HttpClientConfig.Retry]
+)
+
+object HttpClientConfig:
+  final case class Throttle(requests: Int, per: FiniteDuration)
+  final case class Retry(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration)
+
+  /** No throttling and no retry. */
+  val default: HttpClientConfig =
+    HttpClientConfig(throttle = None, retry = None)
+
+  def load(path: String): HttpClientConfig =
+    from(ConfigFactory.load().getConfig(path))
+
+  def from(config: Config): HttpClientConfig =
+    def duration(key: String): FiniteDuration =
+      FiniteDuration(config.getDuration(key).toNanos, NANOSECONDS)
+    val throttle =
+      if config.hasPath("throttle") then
+        Some(Throttle(config.getInt("throttle.requests"), duration("throttle.per")))
+      else None
+    val retry =
+      if config.hasPath("retry") then
+        Some(
+          Retry(
+            config.getInt("retry.max-retries"),
+            duration("retry.initial-delay"),
+            duration("retry.max-delay")
+          )
+        )
+      else None
+    HttpClientConfig(throttle, retry)
+  end from
+end HttpClientConfig

--- a/modules/infra/src/main/scala/scaladex/infra/config/MavenCentralConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/MavenCentralConfig.scala
@@ -1,0 +1,13 @@
+package scaladex.infra.config
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+case class MavenCentralConfig(httpClient: HttpClientConfig)
+
+object MavenCentralConfig:
+  def load(): MavenCentralConfig =
+    from(ConfigFactory.load())
+
+  def from(config: Config): MavenCentralConfig =
+    MavenCentralConfig(HttpClientConfig.from(config.getConfig("scaladex.maven-central.http-client")))

--- a/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import scaladex.core.model.Artifact
 import scaladex.core.model.Artifact.*
 import scaladex.core.model.Version
+import scaladex.infra.config.MavenCentralConfig
 
 import org.apache.pekko.actor.ActorSystem
 import org.scalatest.funspec.AsyncFunSpec
@@ -12,7 +13,7 @@ import org.scalatest.matchers.should.Matchers
 
 class MavenCentralClientImplTests extends AsyncFunSpec with Matchers:
   given ActorSystem = ActorSystem("maven-central-client-tests")
-  val client = new MavenCentralClientImpl()
+  val client = new MavenCentralClientImpl(MavenCentralConfig.load().httpClient)
   val groupId: GroupId = GroupId("ch.epfl.scala")
   val artifactId: ArtifactId = ArtifactId("sbt-scalafix_2.12_1.0")
   val version: Version = Version("0.9.23")

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -68,7 +68,7 @@ object Server extends LazyLogging:
             val webDatabase = new SqlDatabase(webPool, config.caching, Some(config.database.maxConcurrentQueries))
             val schedulerDatabase = new SqlDatabase(schedulerPool, config.caching)
             val flyway = DoobieUtils.flyway(migrationDatasource, cleanDisabled = true)
-            val githubClient = config.github.token.map(new GithubClientImpl(_))
+            val githubClient = config.github.token.map(new GithubClientImpl(_, config.github.httpClient))
             val paths = DataPaths.from(config.filesystem)
             val filesystem = FilesystemStorage(config.filesystem)
             // Web publishes (sbt/coursier) use the web pool; batch jobs use the scheduler pool
@@ -76,7 +76,7 @@ object Server extends LazyLogging:
             val publishProcess = PublishProcess(paths, filesystem, webDatabase, config.env)(using publishPool, system)
             val schedulerPublishProcess =
               PublishProcess(paths, filesystem, schedulerDatabase, config.env)(using publishPool, system)
-            val mavenCentralClient = new MavenCentralClientImpl()
+            val mavenCentralClient = new MavenCentralClientImpl(config.mavenCentral.httpClient)
             val mavenCentralService =
               new MavenCentralService(paths, schedulerDatabase, mavenCentralClient, schedulerPublishProcess)(
                 using system.dispatcher,

--- a/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
+++ b/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
@@ -7,6 +7,7 @@ import scaladex.infra.config.CacheConfig
 import scaladex.infra.config.ElasticsearchConfig
 import scaladex.infra.config.FilesystemConfig
 import scaladex.infra.config.GithubConfig
+import scaladex.infra.config.MavenCentralConfig
 import scaladex.infra.config.PostgreSQLConfig
 
 import com.softwaremill.pekkohttpsession.SessionConfig
@@ -24,6 +25,7 @@ case class ServerConfig(
     elasticsearch: ElasticsearchConfig,
     filesystem: FilesystemConfig,
     github: GithubConfig,
+    mavenCentral: MavenCentralConfig,
     caching: CacheConfig
 )
 
@@ -44,6 +46,7 @@ object ServerConfig:
 
     val filesystem = FilesystemConfig.from(config)
     val github = GithubConfig.from(config)
+    val mavenCentral = MavenCentralConfig.from(config)
     val caching = CacheConfig.from(config)
 
     ServerConfig(
@@ -57,6 +60,7 @@ object ServerConfig:
       elasticsearch,
       filesystem,
       github,
+      mavenCentral,
       caching
     )
   end load


### PR DESCRIPTION
Adds a client-side rate limiter and bounded 429/503 backoff (honoring `Retry-After`) so the Maven Central crawl stops getting rate limited. Throttle + retry live in `CommonAkkaHttpClient`, driven by a shared `HttpClientConfig` (`http-client` blocks in `reference.conf`); both are optional and default-off, so incidental GitHub clients opt out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)