### PR TITLE
fix: lower github throttle and retry limits to avoid rate limiting

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -31,11 +31,11 @@ scaladex {
     token = ${?GITHUB_TOKEN}
     http-client {
       throttle {
-        requests = 5000
+        requests = 4000
         per = 1 hour
       }
       retry {
-        max-retries = 5
+        max-retries = 3
         initial-delay = 1 second
         max-delay = 60 seconds
       }
@@ -48,7 +48,7 @@ scaladex {
         per = 1 second
       }
       retry {
-        max-retries = 5
+        max-retries = 3
         initial-delay = 1 second
         max-delay = 60 seconds
       }


### PR DESCRIPTION
Lowers the GitHub throttle to 4000 req/hour (headroom under the 5000/hour limit) to reduce the chance of hitting GitHub rate limiting, and drops retry attempts from 5 to 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)