### PR TITLE
fix: make the github-info job resilient to GitHub errors

### DIFF
--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -39,6 +39,12 @@ scaladex {
         initial-delay = 1 second
         max-delay = 60 seconds
       }
+      # stop hammering GitHub once it is down or rate limiting us (HTTP 403 rate limit / 5xx)
+      circuit-breaker {
+        max-failures = 5
+        call-timeout = 2 minutes
+        reset-timeout = 10 minutes
+      }
     }
   }
   maven-central {

--- a/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
@@ -3,6 +3,8 @@ package scaladex.infra
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
 import scala.util.Try
 
 import scaladex.core.model.GithubCommitActivity
@@ -39,8 +41,16 @@ import org.apache.pekko.http.scaladsl.model.headers.OAuth2BearerToken
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
 import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
+import org.apache.pekko.pattern.CircuitBreaker
 import org.apache.pekko.stream.scaladsl.Flow
 import org.apache.pekko.util.ByteString
+
+/** Thrown by the low-level GitHub HTTP helpers when GitHub returns a non-success status. */
+final case class GithubException(code: Int, errorMessage: String) extends Exception(s"$code: $errorMessage"):
+  def isRateLimited: Boolean = code == 429 || (code == 403 && errorMessage.toLowerCase.contains("rate limit"))
+  def isServerError: Boolean = code >= 500
+  // Outcomes that legitimately mean "no data" and may safely become an empty value.
+  def isNoData: Boolean = Set(404, 410, 202, 204).contains(code) || (code == 403 && !isRateLimited)
 
 class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
     extends CommonAkkaHttpClient(config)
@@ -65,6 +75,11 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
           ConnectionPoolSettings("akka.http.host-connection-pool.response-entity-subscription-timeout = 10.seconds")
             .copy(maxConnections = 10)
       )
+
+  private val breaker: Option[CircuitBreaker] =
+    config.circuitBreaker.map(cb =>
+      CircuitBreaker(system.scheduler, cb.maxFailures, callTimeout = cb.callTimeout, resetTimeout = cb.resetTimeout)
+    )
 
   override def getProjectInfo(ref: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
     getRepository(ref).flatMap {
@@ -114,7 +129,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
         case (_, entity) =>
           entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String).map(Option.apply)
       }
-      .fallbackTo(Future.successful(None))
+      .recover { case e: GithubException if e.isNoData => None }
   end getReadme
 
   def getCommunityProfile(ref: Project.Reference): Future[Option[GithubModel.CommunityProfile]] =
@@ -123,7 +138,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
       .addHeader(RawHeader("Accept", "application/vnd.github.black-panther-preview+json"))
     get[GithubModel.CommunityProfile](request)
       .map(Some.apply)
-      .fallbackTo(Future.successful(None))
+      .recover { case e: GithubException if e.isNoData => None }
 
   def getContributors(ref: Project.Reference): Future[List[GithubModel.Contributor]] =
     def request(page: Int) =
@@ -148,7 +163,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
 
             case _ => contributors
       }
-      .fallbackTo(Future.successful(List.empty))
+      .recover { case e: GithubException if e.isNoData => List.empty }
   end getContributors
 
   def getRepository(ref: Project.Reference): Future[GithubResponse[GithubModel.Repository]] =
@@ -184,7 +199,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
 
             case _ => issues.map(_.flatten)
       }
-      .fallbackTo(Future.successful(Seq.empty))
+      .recover { case e: GithubException if e.isNoData => Seq.empty }
   end getOpenIssues
 
   def getPercentageOfLanguage(ref: Project.Reference, language: String): Future[Int] =
@@ -192,15 +207,17 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
       ((portion.toFloat / total) * 100).toInt
     val request =
       HttpRequest(uri = s"${repoUrl(ref)}/languages").addHeader(acceptJson).addCredentials(credentials)
-    get[Map[String, Int]](request).map { response =>
-      val totalNumBytes = response.values.sum
-      response.get(language).fold(0)(toPercentage(_, totalNumBytes))
-    }
+    get[Map[String, Int]](request)
+      .map { response =>
+        val totalNumBytes = response.values.sum
+        response.get(language).fold(0)(toPercentage(_, totalNumBytes))
+      }
+      .recover { case e: GithubException if e.isNoData => 0 }
 
   def getCommitActivity(ref: Project.Reference): Future[Seq[GithubCommitActivity]] =
     val request =
       HttpRequest(uri = s"${repoUrl(ref)}/stats/commit_activity").addHeader(acceptJson).addCredentials(credentials)
-    get[Seq[GithubCommitActivity]](request).fallbackTo(Future.successful(Seq.empty))
+    get[Seq[GithubCommitActivity]](request).recover { case e: GithubException if e.isNoData => Seq.empty }
 
   def getUserOrganizations(user: String): Future[Seq[Project.Organization]] =
     getAllRecursively(getUserOrganizationsPage(user))
@@ -370,12 +387,15 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
     process(request).map {
       case GithubResponse.Ok((headers, entity)) => (headers, entity)
       case GithubResponse.MovedPermanently((headers, entity)) => (headers, entity)
-      case GithubResponse.Failed(code, reason) => throw new Exception(s"$code: $reason")
+      case GithubResponse.Failed(code, reason) => throw GithubException(code, reason)
     }
 
   private def process(request: HttpRequest): Future[GithubResponse[(Seq[HttpHeader], ResponseEntity)]] =
     assert(request.headers.contains(Authorization(credentials)))
-    queueRequestWithRetry(request).flatMap {
+    val response = breaker match
+      case Some(cb) => cb.withCircuitBreaker(queueRequestWithRetry(request), GithubClientImpl.isBreakerFailure)
+      case None => queueRequestWithRetry(request)
+    response.flatMap {
       case HttpResponse(StatusCodes.OK, headers, entity, _) =>
         Future.successful(GithubResponse.Ok((headers, entity)))
       case HttpResponse(StatusCodes.MovedPermanently, headers, entity, _) =>
@@ -397,4 +417,16 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
     s"https://api.github.com/repos/$ref"
 
   private def perPage(value: Int = 100) = s"per_page=$value"
+end GithubClientImpl
+
+object GithubClientImpl:
+  /** A response meaning GitHub is unavailable or rate limiting us — counts towards opening the breaker. */
+  private[infra] def isBreakerFailure(result: Try[HttpResponse]): Boolean = result match
+    case Success(response) =>
+      val code = response.status.intValue
+      def rateLimited =
+        response.headers.exists(h => h.is("x-ratelimit-remaining") && h.value == "0") ||
+          response.headers.exists(_.is("retry-after"))
+      code == 429 || (code == 403 && rateLimited) || code >= 500
+    case Failure(_) => true
 end GithubClientImpl

--- a/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/HttpClientConfig.scala
@@ -7,16 +7,18 @@ import com.typesafe.config.ConfigFactory
 
 final case class HttpClientConfig(
     throttle: Option[HttpClientConfig.Throttle],
-    retry: Option[HttpClientConfig.Retry]
+    retry: Option[HttpClientConfig.Retry],
+    circuitBreaker: Option[HttpClientConfig.CircuitBreaker]
 )
 
 object HttpClientConfig:
   final case class Throttle(requests: Int, per: FiniteDuration)
   final case class Retry(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration)
+  final case class CircuitBreaker(maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration)
 
-  /** No throttling and no retry. */
+  /** No throttling, no retry and no circuit breaker. */
   val default: HttpClientConfig =
-    HttpClientConfig(throttle = None, retry = None)
+    HttpClientConfig(throttle = None, retry = None, circuitBreaker = None)
 
   def load(path: String): HttpClientConfig =
     from(ConfigFactory.load().getConfig(path))
@@ -37,6 +39,16 @@ object HttpClientConfig:
           )
         )
       else None
-    HttpClientConfig(throttle, retry)
+    val circuitBreaker =
+      if config.hasPath("circuit-breaker") then
+        Some(
+          CircuitBreaker(
+            config.getInt("circuit-breaker.max-failures"),
+            duration("circuit-breaker.call-timeout"),
+            duration("circuit-breaker.reset-timeout")
+          )
+        )
+      else None
+    HttpClientConfig(throttle, retry, circuitBreaker)
   end from
 end HttpClientConfig

--- a/modules/infra/src/test/scala/scaladex/infra/GithubClientImplUnitTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/GithubClientImplUnitTests.scala
@@ -1,0 +1,43 @@
+package scaladex.infra
+
+import scala.util.Failure
+import scala.util.Success
+
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCode
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class GithubClientImplUnitTests extends AnyFunSpec with Matchers:
+  private def response(status: StatusCode, headers: (String, String)*) =
+    HttpResponse(status = status, headers = headers.map((k, v) => RawHeader(k, v)).toList)
+
+  describe("isBreakerFailure") {
+    it("trips on a rate-limited 403 (X-RateLimit-Remaining: 0)") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.Forbidden, "X-RateLimit-Remaining" -> "0"))) shouldBe true
+    }
+    it("trips on a 403 carrying a Retry-After header") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.Forbidden, "Retry-After" -> "60"))) shouldBe true
+    }
+    it("does not trip on a plain 403 (e.g. contributor list too large)") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.Forbidden))) shouldBe false
+    }
+    it("trips on 429") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.TooManyRequests))) shouldBe true
+    }
+    it("trips on 5xx") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.BadGateway))) shouldBe true
+    }
+    it("does not trip on 404") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.NotFound))) shouldBe false
+    }
+    it("does not trip on 200") {
+      GithubClientImpl.isBreakerFailure(Success(response(StatusCodes.OK))) shouldBe false
+    }
+    it("trips on a failed request (timeout/connection error)") {
+      GithubClientImpl.isBreakerFailure(Failure(new RuntimeException("boom"))) shouldBe true
+    }
+  }
+end GithubClientImplUnitTests

--- a/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
@@ -4,6 +4,9 @@ import java.time.Instant
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.NonFatal
 
 import scaladex.core.model.GithubInfo
 import scaladex.core.model.GithubResponse
@@ -11,9 +14,10 @@ import scaladex.core.model.GithubStatus
 import scaladex.core.model.Project
 import scaladex.core.service.GithubClient
 import scaladex.core.service.WebDatabase
-import scaladex.core.util.ScalaExtensions.*
+import scaladex.infra.GithubException
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.pattern.CircuitBreakerOpenException
 
 class GithubUpdater(database: WebDatabase, github: GithubClient)(using ExecutionContext) extends LazyLogging:
   def updateAll(): Future[String] =
@@ -26,14 +30,45 @@ class GithubUpdater(database: WebDatabase, github: GithubClient)(using Execution
           .map(_._1)
 
       logger.info(s"Updating github info of ${projectToUpdate.size} projects")
-      projectToUpdate.mapSync(update).map { statuses =>
-        val totalOk = statuses.count(_.isOk)
-        val totalNotFound = statuses.count(_.isNotFound)
-        val totalFailed = statuses.count(_.isFailed)
-        val totalMoved = statuses.count(_.isMoved)
-        s"Updated ${projectToUpdate.size} projects: $totalOk OK, $totalNotFound Not Found, $totalFailed Failed, $totalMoved Moved"
-      }
+      updateSequentially(projectToUpdate.toList, Nil)
     }
+
+  /** Update projects one by one, tolerating single-item failures and stopping early when the GitHub circuit breaker
+    * opens (GitHub is rate limiting us or is down), so we don't fire thousands of doomed requests.
+    */
+  private def updateSequentially(remaining: List[Project.Reference], done: List[GithubStatus]): Future[String] =
+    remaining match
+      case Nil => Future.successful(summary(done, stoppedEarly = 0))
+      case ref :: rest =>
+        update(ref).transformWith {
+          case Success(status) => updateSequentially(rest, status :: done)
+          case Failure(_: CircuitBreakerOpenException) =>
+            val notProcessed = remaining.size
+            logger.error(
+              s"GitHub circuit breaker is open (rate limited or unavailable): stopping github-info early, " +
+                s"$notProcessed of ${done.size + notProcessed} projects not processed"
+            )
+            Future.successful(summary(done, stoppedEarly = notProcessed))
+          case Failure(NonFatal(cause)) =>
+            logger.warn(s"Failed to update github info for $ref, skipping", cause)
+            val status = failedStatus(cause)
+            database.updateGithubStatus(ref, status).transformWith(_ => updateSequentially(rest, status :: done))
+        }
+
+  private def failedStatus(cause: Throwable): GithubStatus =
+    val now = Instant.now()
+    cause match
+      case e: GithubException => GithubStatus.Failed(now, e.code, e.errorMessage)
+      case e => GithubStatus.Failed(now, -1, e.getMessage)
+
+  private def summary(statuses: List[GithubStatus], stoppedEarly: Int): String =
+    val totalOk = statuses.count(_.isOk)
+    val totalNotFound = statuses.count(_.isNotFound)
+    val totalFailed = statuses.count(_.isFailed)
+    val totalMoved = statuses.count(_.isMoved)
+    val base =
+      s"Updated ${statuses.size} projects: $totalOk OK, $totalNotFound Not Found, $totalFailed Failed, $totalMoved Moved"
+    if stoppedEarly > 0 then s"$base (stopped early, $stoppedEarly not processed)" else base
 
   def update(ref: Project.Reference): Future[GithubStatus] =
     for

--- a/modules/server/src/test/scala/scaladex/server/service/GithubUpdaterTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/service/GithubUpdaterTests.scala
@@ -1,0 +1,103 @@
+package scaladex.server.service
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+import scaladex.core.model.GithubInfo
+import scaladex.core.model.GithubResponse
+import scaladex.core.model.GithubStatus
+import scaladex.core.model.Project
+import scaladex.core.model.UserInfo
+import scaladex.core.model.UserState
+import scaladex.core.service.GithubClient
+import scaladex.core.test.InMemoryDatabase
+import scaladex.core.test.Values.*
+import scaladex.infra.GithubException
+
+import org.apache.pekko.pattern.CircuitBreakerOpenException
+import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.matchers.should.Matchers
+
+/** A GithubClient whose getProjectInfo is scripted; other methods are unused by GithubUpdater. */
+class StubGithubClient(
+    getProjectInfoFn: Project.Reference => Future[GithubResponse[(Project.Reference, GithubInfo)]]
+) extends GithubClient:
+  override def getProjectInfo(ref: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
+    getProjectInfoFn(ref)
+  override def getUserInfo(): Future[GithubResponse[UserInfo]] = ???
+  override def getUserState(): Future[GithubResponse[UserState]] = ???
+  override def getUserOrganizations(login: String): Future[Seq[Project.Organization]] = ???
+  override def getUserRepositories(login: String, filterPermissions: Seq[String]): Future[Seq[Project.Reference]] = ???
+  override def getOrganizationRepositories(
+      user: String,
+      organization: Project.Organization,
+      filterPermissions: Seq[String]
+  ): Future[Seq[Project.Reference]] = ???
+end StubGithubClient
+
+class GithubUpdaterTests extends AsyncFunSpec with Matchers:
+  private def ref(repo: String): Project.Reference = Project.Reference.from("org", repo)
+
+  it("does not overwrite existing github info when the update fails") {
+    val db = new InMemoryDatabase()
+    val projectRef = ref("repo1")
+    val goodInfo = GithubInfo.empty.copy(stars = Some(42))
+    val updater = new GithubUpdater(db, new StubGithubClient(_ => Future.failed(GithubException(500, "boom"))))(using
+      executionContext
+    )
+    for
+      _ <- db.insertProjectRef(projectRef, unknown)
+      _ <- db.updateGithubInfoAndStatus(projectRef, goodInfo, ok)
+      _ <- updater.updateAll()
+      project <- db.getProject(projectRef)
+    yield
+      project.flatMap(_.githubInfo) shouldBe Some(goodInfo)
+      project.map(_.githubStatus) should matchPattern { case Some(_: GithubStatus.Failed) => () }
+  }
+
+  it("continues updating remaining projects when a single project fails") {
+    val db = new InMemoryDatabase()
+    val okRef1 = ref("ok1")
+    val failRef = ref("fail")
+    val okRef2 = ref("ok2")
+    val info = GithubInfo.empty.copy(stars = Some(7))
+    def stub(r: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
+      if r == failRef then Future.failed(GithubException(500, "boom"))
+      else Future.successful(GithubResponse.Ok(r -> info))
+    val updater = new GithubUpdater(db, new StubGithubClient(stub))(using executionContext)
+    for
+      _ <- db.insertProjectRef(okRef1, unknown)
+      _ <- db.insertProjectRef(failRef, unknown)
+      _ <- db.insertProjectRef(okRef2, unknown)
+      summary <- updater.updateAll()
+      p1 <- db.getProject(okRef1)
+      p2 <- db.getProject(failRef)
+      p3 <- db.getProject(okRef2)
+    yield
+      p1.flatMap(_.githubInfo) shouldBe Some(info)
+      p3.flatMap(_.githubInfo) shouldBe Some(info)
+      p2.map(_.githubStatus) should matchPattern { case Some(_: GithubStatus.Failed) => () }
+      summary should include("Failed")
+  }
+
+  it("stops the run early when the github circuit breaker is open") {
+    val db = new InMemoryDatabase()
+    val refs = (1 to 3).map(i => ref(s"repo$i"))
+    val calls = new AtomicInteger(0)
+    val info = GithubInfo.empty.copy(stars = Some(1))
+    def stub(r: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
+      if calls.incrementAndGet() == 1 then Future.successful(GithubResponse.Ok(r -> info))
+      else Future.failed(new CircuitBreakerOpenException(0.seconds))
+    val updater = new GithubUpdater(db, new StubGithubClient(stub))(using executionContext)
+    for
+      _ <- Future.traverse(refs)(db.insertProjectRef(_, unknown))
+      summary <- updater.updateAll()
+      statuses <- db.getAllProjectsStatuses()
+    yield
+      calls.get() shouldBe 2 // one success, one breaker-open, then stop before the third
+      statuses.values.count(_.isInstanceOf[GithubStatus.Ok]) shouldBe 1
+      summary should include("stopped early")
+  }
+end GithubUpdaterTests


### PR DESCRIPTION
Fixes three problems in the `github-info` job that surface when GitHub errors (esp. the per-user 403 rate limit):

- **No more data loss.** The client only falls back to empty on genuine "no data" statuses (404/410/202/204/non-rate-limit 403); rate-limit/5xx/timeout now propagate, so a partial fetch no longer overwrites a good `github_info` row with `NULL`/`[]`. `getRaw` throws a typed `GithubException`.
- **Per-item resilience.** `GithubUpdater` updates projects one by one; a single failing project is marked `Failed` (status only — info preserved) and skipped instead of aborting the whole run.
- **Stop early on rate-limit/outage.** A pekko `CircuitBreaker` in the GitHub client (config-driven, header-based detection) opens when GitHub is rate limiting us or down; the updater then stops the run instead of firing thousands of doomed requests.

New unit tests cover the updater (no-overwrite, skip-and-continue, early-stop) and the breaker failure classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)