### PR TITLE
discover new Maven Central namespaces and admin review

### DIFF
--- a/doc/dev/maven-central-discovery.md
+++ b/doc/dev/maven-central-discovery.md
@@ -1,0 +1,560 @@
+# Discovering new Scala organisations on Maven Central
+
+Research notes — 2026-09-02. Context: artifacts under new namespaces (e.g.
+`com.halotukozak`) never appear in Scaladex even though they are live on Maven
+Central, are valid Scala 3 / Scala.js / Native artifacts, and would be useful for
+the community build regression net (scala/scala3#26958).
+
+This document describes **how discovery works today**, **why it misses new
+namespaces**, **what Maven Central actually offers as an API**, and a
+**recommended pipeline** to close the gap.
+
+---
+
+## 1. How Scaladex ingests artifacts today
+
+Every artifact that enters the index goes through exactly one function:
+
+`PublishProcess.publishPom` → `ArtifactConverter.convert` → `artifactService.insertArtifact`
+(`modules/server/src/main/scala/scaladex/server/service/PublishProcess.scala`).
+
+There are only four callers:
+
+| Caller | Trigger | Can discover a brand-new groupId? |
+|---|---|---|
+| `PublishApi` `PUT /publish` | external HTTP push (sbt plugin / CI / Sonatype) | **yes** |
+| `MavenCentralService.findMissing` | job `missing-maven-artifacts`, every 24h | no — iterates `database.getGroupIds()` |
+| `MavenCentralService.findNonStandard` | job `non-standard-artifacts`, every 2h | no — fixed list from `non-standard.json` |
+| `AdminService.findMissingArtifacts` / `syncOne` | manual admin action, groupId typed by hand | no (human supplies the groupId) |
+
+`database.getGroupIds()` is `SELECT DISTINCT group_id FROM artifacts`
+(`SqlDatabase.getGroupIds` → `ArtifactTable.selectGroupIds`). So the periodic
+Maven Central sync is a **closed loop**: it can only re-scan namespaces that are
+*already* in the index. It backfills missing versions/artifacts of known groups;
+it can never see a new group.
+
+### The Maven Central client is a directory scraper
+
+`MavenCentralClientImpl` (`modules/infra/.../MavenCentralClientImpl.scala`) has
+three operations, all against `https://repo1.maven.org/maven2`:
+
+- `getAllArtifactIds(groupId)` — GET `…/<group/as/path>/`, parse the Apache
+  autoindex HTML with `JsoupUtils.listDirectories`.
+- `getAllVersions(groupId, artifactId)` — same, one level deeper.
+- `getPomFile(ref)` — GET the `.pom`.
+
+There is **no** call to any search/enumeration API. Given a groupId it works
+fine — e.g. `https://repo1.maven.org/maven2/com/halotukozak/` returns
+`alpaca_3/`, `commons_3/`, `mcodec_sjs1_3/`, … right now. The missing piece is
+purely *knowing the groupId exists*.
+
+### Where new groups used to come from
+
+Historically Scaladex "receives poms automatically from Maven Central (Sonatype)"
+(README) via an OSSRH/Sonatype post-deploy notification hitting `PUT /publish`,
+plus an initial bulk seed (Bintray + the Central Lucene index). With the OSSRH →
+**Central Portal** migration, publishers that use the Portal (its own
+`central-ossrh` upload or the Portal API) no longer trigger that notification.
+`com.halotukozak` publishes through the Portal → nothing calls `/publish` → the
+namespace is invisible to Scaladex forever.
+
+The `central-ossrh` username handled in `PublishApi.authenticateUser` covers the
+case where a publisher *also* points their build at `index.scala-lang.org`, but
+that is opt-in and most people don't do it.
+
+---
+
+## 2. Maven Central data sources (surveyed & tested 2026-09-02)
+
+### 2.1 `repo1.maven.org` autoindex HTML — *current*
+- Pros: authoritative, always up to date, no auth, already wired in.
+- Cons: no enumeration of top-level groups, no "what changed" feed, one HTTP
+  request per directory. Rate-limited (see recent commits lowering the throttle
+  to 1 req/s + retry caps).
+
+### 2.2 Legacy Solr API — `https://search.maven.org/solrsearch/select` — **unreliable**
+- `?q=g:com.halotukozak&core=gav&wt=json` → `numFound: 0` today, although the
+  artifacts are live on `repo1` and on `central.sonatype.com`.
+- The legacy Solr index lags badly / omits many Central Portal publishers.
+  Multiple upstream issues about `sort` being ignored and versions ordered by
+  name not date.
+- Default sort already is `score desc, timestamp desc, …`; leading-wildcard
+  queries (`a:*_3`) return HTTP 400.
+- **Verdict: not trustworthy as a discovery source in 2026.**
+
+### 2.3 Central Portal browse API — `POST https://central.sonatype.com/api/internal/browse/components` — **works, undocumented**
+
+This backs the search box on `central.sonatype.com`.
+
+```
+POST https://central.sonatype.com/api/internal/browse/components
+content-type: application/json
+
+{"page":0,"size":20,"sortField":"publishedDate","sortDirection":"desc"}
+```
+
+Returns, newest first across *all* of Maven Central:
+
+```json
+{"pageCount":667,"totalResultCount":10000,"components":[
+  {"namespace":"io.github.makingthematrix","name":"signals3_3",
+   "projectName":"signals3","latestVersionInfo":{"version":"1.2.1","timestampUnixWithMS":1788366045000,"licenses":["MIT"]},
+   "ec":["-sources.jar",".pom","-javadoc.jar",".jar"],"packaging":"jar", ...}
+]}
+```
+
+- A global **"recently published" feed** — exactly what discovery needs. A single
+  page already surfaced a Scala 3 artifact (`signals3_3`).
+- `filter`/`searchTerm` also allow `namespace:<group>` scoped queries.
+- Caveats: `/api/internal/` = **no stability guarantee**; result window capped at
+  10 000; small page size (20 OK, 50 → HTTP 400); no published rate limits.
+- Good as a *low-latency signal*, risky as the *only* source.
+
+### 2.4 Central Portal published API — `https://central.sonatype.com/api/v1/...`
+- Documented, but scoped to **publishing** (upload, deployment status) and to
+  *your own* namespaces. No public "search everything" endpoint documented.
+- Not useful for third-party discovery.
+
+### 2.5 Maven Central Index (`nexus-maven-repository-index`) — the "IntelliJ" approach — **deep dive**
+
+This is the Apache **maven-indexer** published index: a decade-old mechanism used
+by Nexus, Artifactory, Eclipse m2e, and IntelliJ's *"Maven repository index"*
+feature. Everything below was verified live on 2026-09-02 (parsed a real chunk
+byte-for-byte).
+
+#### 2.5.1 What Maven Central publishes
+
+At `https://repo1.maven.org/maven2/.index/` (mirror: `repo.maven.apache.org`):
+
+| File | Purpose | Size (2026-09-01) |
+|---|---|---|
+| `nexus-maven-repository-index.properties` | control file / cursor | ~2 KB |
+| `nexus-maven-repository-index.gz` | **full** index (one chunk) | **3.24 GB** |
+| `nexus-maven-repository-index.<N>.gz` | incremental chunk `N` | ~1–45 MB |
+
+`repo1` currently retains chunks **323 … 936** (614 files). The `.properties`:
+
+```
+nexus.index.id=central
+nexus.index.chain-id=1318453614498          # identity of the whole chunk chain
+nexus.index.timestamp=20260901193333        # publish time of the newest chunk
+nexus.index.last-incremental=936            # newest chunk number
+nexus.index.incremental-0=936               # sliding window of recent chunk ids
+nexus.index.incremental-1=935               # (…-0 … -29), used to decide whether
+...                                         # an incremental catch-up is still possible
+nexus.index.incremental-29=907
+```
+
+#### 2.5.2 Wire format (no Lucene, no library needed)
+
+Each `.gz` is a gzip stream wrapping a trivial binary framing
+(`org.apache.maven.index.reader.ChunkReader`):
+
+```
+byte    version            # always 1
+long    timestamp (ms)      # index time of this chunk
+repeat until EOF:
+  int   fieldCount
+  repeat fieldCount times:
+    byte   flags            # ignored
+    UTF    name             # java modified-UTF-8, 2-byte length  (field names are ASCII)
+    int    valueLength
+    bytes  value            # java modified-UTF-8
+```
+
+Records are untyped maps; the kind is inferred from which key is present
+(`RecordExpander`):
+
+| Key present | Meaning | Fields that matter |
+|---|---|---|
+| `u` | **artifact added** | `u = groupId\|artifactId\|version\|classifier-or-"NA"[\|ext]`, `i = packaging\|fileMtime\|size\|hasSrc\|hasDoc\|hasSig\|ext`, `n` name, `d` description, `1` sha1, `classnames` (bulk), plugin/OSGi extras |
+| `del` | **artifact removed** | `del` = same UINFO layout, `m` = timestamp |
+| `allGroups` / `allGroupsList` | full list of every groupId | **empty in incremental chunks — only populated in the full index** |
+| `rootGroups` / `rootGroupsList` | first path segment of every groupId | same caveat |
+| `DESCRIPTOR` | repo id | — |
+
+Real records pulled from chunk 323:
+
+```
+add: u=xyz.danoz|recyclerviewfastscroller|0.1.3|NA   i=aar|1429833125000|19638|1|1|1|aar  n=RecyclerViewFastScroller
+del: del=org.siani|magritte|1.1.2|javadoc|jar        m=1430071994196
+```
+
+A complete parser is **~30 lines of Scala** (`GZIPInputStream` + `DataInputStream`
++ the loop above). For discovery you only read `u` / `del` and ignore
+`classnames` (which is most of the bytes). Alternatively depend on
+`org.apache.maven.indexer:indexer-reader:7.1.6` — it is genuinely dependency-free
+(no Lucene, no Plexus) and gives you `IndexReader` / `ChunkReader` / `Record` /
+`RecordExpander`.
+
+#### 2.5.3 Incremental / cursor mechanism
+
+`IndexReader(local, remote)` reads both `.properties` files and decides:
+
+- `chain-id` differs, or the gap since your `last-incremental` has scrolled out
+  of the `incremental-0..29` window → **full re-pull** (`…index.gz`).
+- otherwise → fetch chunks `localLastIncremental+1 … remoteLastIncremental`,
+  iterate their records, and on `close()` write the remote `.properties` back to
+  `local` (that is the commit of the cursor).
+
+For Scaladex the "local" side is a single DB row: `(chain_id, last_incremental)`.
+A custom implementation doesn't need the `ResourceHandler` SPI at all — just
+GET the `.properties`, compare, GET the missing `.N.gz`, parse, update the row.
+
+#### 2.5.4 Freshness — the catch (verified from chunk timestamps)
+
+| chunk | index time | compressed size |
+|---|---|---|
+| 323 | 2015-04-26 | 1.1 MB |
+| 800 | 2023-04-08 | — |
+| 900 | 2025-08-17 | 8.5 MB |
+| 920 | 2026-03-11 | — |
+| 930 | 2026-06-20 | 43 MB |
+| 934 | 2026-07-23 | — |
+| 936 | 2026-09-01 | 41 MB |
+
+⇒ **the publish cadence is ~1–4 weeks and irregular, trending slower.** It is
+*not* daily (the `.properties` `last-modified` misleads — only the newest chunk's
+timestamp matters). A namespace that first publishes today can take up to a month
+to appear in this index. Chunk size has grown with Maven Central's throughput:
+now ~40 MB per (roughly monthly) chunk ≈ **40–170 MB/month** of transfer once
+seeded.
+
+#### 2.5.5 One-time seed cost
+
+The full index is **3.24 GB** to download once, then a streaming parse (most
+bytes are `classnames`/`d`/`n` you discard). There is no lighter "all groupIds"
+file — `allGroupsList` only exists *inside* that 3.2 GB blob. **Better seed:** skip
+it. Scaladex already indexes a large fraction of the ecosystem; set the cursor to
+today's `last-incremental` and only catch *future* first-publishers, with a
+Central Portal feed pass (§2.3) to backfill the recent weeks.
+
+#### 2.5.6 How IntelliJ actually uses this — and why it's a cautionary tale
+
+IntelliJ's *"Maven repository index"* is exactly this nexus index via
+maven-indexer + **Lucene**. For Maven Central it is **disabled / manual by
+default**: the multi-GB download plus building the local Lucene index costs too
+much disk and RAM. JetBrains steered users to **Package Search** (a separate
+hosted API) instead — which was then **shut down in April 2025**. Current IntelliJ
+falls back to `~/.m2` local completion plus on-demand Central REST calls.
+
+So the project most associated with the full-index approach has spent a decade
+migrating *away* from it. Scaladex should take the mechanism (incremental chunks
+are a solid authoritative delta feed, including deletes) but not the framing
+(don't download 3.2 GB, don't pull in Lucene, don't treat it as low-latency).
+
+### 2.6 Third-party: libraries.io, ecosyste.ms, deps.dev
+- `deps.dev` (Google) and `ecosyste.ms` both expose Maven package lists + APIs
+  and are reasonably current. Usable as a cross-check / backfill, adds an
+  external dependency and their own lag.
+
+---
+
+## 3. Recommended approach
+
+Add a **discovery stage** in front of the existing sync. Its only job is to
+produce candidate `groupId`s; everything downstream already works
+(`MavenCentralService.syncOne` → `getAllArtifactIds` → `getPomFile` →
+`publishPom` → `scm` → project).
+
+```
+  ┌──────────────────────────┐        ┌──────────────────────────┐
+  │ Tier 1 — FRESHNESS       │        │ Tier 2 — COMPLETENESS    │
+  │ Central Portal browse    │        │ nexus incremental index  │
+  │ POST …/browse/components │        │ .index/*.N.gz since       │
+  │ sortField=publishedDate  │        │ (chain_id,last_incremental)│
+  │ poll ~hourly             │        │ poll ~weekly              │
+  │ near-real-time, cheap    │        │ authoritative + deletes  │
+  │ undocumented → defensive │        │ ~40 MB/chunk, ~monthly    │
+  └───────────┬──────────────┘        └───────────┬──────────────┘
+              └───────────────┬────────────────────┘
+                              ▼
+              Scala filter — reuse core/model/Artifact.scala:
+              Artifact.ArtifactId.parse(a).isScala && .binaryVersion.isValid
+              (matches _2.13, _3, _sjs1_3, _native0.5_3, _2.12_1.0, …)
+                              ▼
+              groupId ∉ database.getGroupIds()  ?
+                              ▼
+              ┌─────────────────────────────────────────┐
+              │ discovered_group_ids                    │
+              │  group_id, source, first_seen,          │
+              │  status(pending|synced|no_github|error),│
+              │  last_synced, artifact_count            │
+              └─────────────────┬───────────────────────┘
+                                ▼
+              job: for N pending → mavenCentralService.syncOne(g, None)
+```
+
+### Why two tiers
+
+- The nexus index is **authoritative and complete** (and is the only source that
+  reports **deletions**), but it lags **1–4 weeks** (§2.5.4). Too slow on its own
+  for "a new org just appeared".
+- The Portal feed is **near-real-time and cheap**, but it is an **undocumented
+  `/api/internal/` endpoint**, capped at 10 000 results, and could change or
+  vanish. Fine as a fast path, not as the system of record.
+- Together: the feed catches new namespaces within the hour; the weekly index
+  pass reconciles anything the feed dropped and keeps the picture honest.
+- **Legacy Solr (`search.maven.org`) is not used at all** — §2.2.
+
+### Do NOT
+
+- Download the 3.24 GB full index. Seed the cursor at today's `last-incremental`
+  and let Tier 1 backfill recent weeks (§2.5.5).
+- Pull in `maven-indexer` core / Lucene. Either a ~30-line `ChunkReader` (§2.5.2)
+  or `indexer-reader` (dependency-free).
+- Hammer `repo1` autoindex for discovery — it is being actively rate-limited
+  (recent commits dropped it to 1 req/s). Discovery reads CDN files
+  (`.index/*.gz`) and one JSON endpoint; the per-group crawl stays inside the
+  existing throttled `MavenCentralClient`.
+
+### New pieces
+
+| Layer | Addition |
+|---|---|
+| `core/shared/.../service` | `MavenCentralIndexClient` trait (`fetchCursor`, `chunksSince(cursor)`), `MavenCentralPortalClient` trait (`recentComponents(since): Seq[GroupId]`) |
+| `infra` | `MavenCentralIndexClientImpl` (GET `.properties` + `.N.gz`, gzip+DataInputStream parse), `MavenCentralPortalClientImpl` (POST browse, pekko-http, defensive) |
+| `infra` (SQL) | `discovered_group_ids` table + Flyway migration; `index_cursor` row; `SchedulerDatabase`: `insertDiscoveredGroupIds`, `getPendingDiscoveredGroupIds(limit)`, `markDiscovered(groupId, status)`, `get/setIndexCursor` |
+| `server/.../service` | `DiscoveryService`: run each tier → Scala-filter → diff vs `getGroupIds()` → upsert `discovered_group_ids` → drain N pending via `mavenCentralService.syncOne` |
+| `server/.../service/AdminService` | jobs (guard `!env.isLocal`): `discover-portal-feed` ~1h, `discover-index-chunks` ~24h (does work only when a new chunk landed) |
+| `view` + `route/AdminPage` | table of discovered namespaces + status counters + "sync now" button (clone of the existing `findMissingArtifacts` task UI) |
+
+### Sketch — the chunk reader (Tier 2 core, ~all of the custom code)
+
+```scala
+// infra: parse one nexus-maven-repository-index.<N>.gz stream
+final case class IndexEntry(groupId: String, artifactId: String, version: String, deleted: Boolean)
+
+def readChunk(in: InputStream): LazyList[IndexEntry] =
+  val d = new DataInputStream(new GZIPInputStream(in, 8192))
+  d.readByte()            // version (== 1)
+  d.readLong()            // chunk timestamp
+  def loop(): LazyList[IndexEntry] =
+    val fieldCount =
+      try d.readInt() catch case _: EOFException => -1
+    if fieldCount < 0 then { d.close(); LazyList.empty }
+    else
+      val m = collection.mutable.Map.empty[String, String]
+      for _ <- 0 until fieldCount do
+        d.readByte()                       // flags
+        val name = d.readUTF()             // ASCII field name
+        val len = d.readInt()
+        val buf = new Array[Byte](len); d.readFully(buf)
+        m(name) = new String(buf, UTF_8)   // ok: coordinates are ASCII/BMP
+      val uinfo = m.get("u").orElse(m.get("del"))
+      uinfo match
+        case Some(u) =>
+          u.split('|') match
+            case Array(g, a, v, _*) => IndexEntry(g, a, v, m.contains("del")) #:: loop()
+            case _                  => loop()
+        case None => loop()                // allGroups / rootGroups / DESCRIPTOR
+  loop()
+```
+
+Discovery then = `readChunk` → keep entries where
+`Artifact.ArtifactId.parse(artifactId)` is Scala & valid → distinct `groupId` not
+in `getGroupIds()`.
+
+### Guard rails
+
+- A new Scala namespace can still have hundreds of artifacts → reuse the existing
+  paging/delay machinery in `MavenCentralService` (`processPages`, `pageDelay`,
+  `publishDelay`); don't sync all discovered groups in one tick — cap N per run.
+- Namespaces whose POMs have no GitHub `scm` produce `NoGithubRepo` and no
+  project — record the outcome so they aren't retried forever.
+- Respect the same Maven Central `HttpClientConfig` throttle already tuned in
+  recent commits.
+
+---
+
+## 4. Quick experiment to validate (no code in Scaladex needed)
+
+Reproduces both tiers in a scratch script; ~1 h of work.
+
+**Tier 2 (index):**
+1. `curl -s .../.index/nexus-maven-repository-index.properties` → read
+   `last-incremental` and `incremental-0..29`.
+2. Download the last ~5 incremental chunks (`…index.<N>.gz`, ~40 MB each).
+3. Parse with the §2.5.2 framing (30 lines, any language) — emit `u` / `del`.
+4. Keep `u` where the artifactId parses as a valid Scala binary version;
+   collect distinct groupIds; subtract what `index.scala-lang.org` already knows
+   (`GET https://index.scala-lang.org/api/…` or a DB dump).
+5. The residual set = "new Scala orgs we're missing". Expect `com.halotukozak`
+   only if it published in the covered window (it may be too recent — see Tier 1).
+
+**Tier 1 (Portal feed):**
+```
+curl -s -X POST https://central.sonatype.com/api/internal/browse/components \
+  -H 'content-type: application/json' \
+  -d '{"page":0,"size":20,"sortField":"publishedDate","sortDirection":"desc"}' \
+  | jq '.components[] | {ns:.namespace, a:.name, t:.latestVersionInfo.timestampUnixWithMS}'
+```
+Page back (`page: 0..N`, `size` ≤ 20 — 50 returns HTTP 400) until timestamps pass
+your last cursor; Scala-filter the `name`s; diff groupIds as above.
+
+Compare the two residual sets — Tier 1 should be a superset of "very recent",
+Tier 2 the authoritative "everything up to ~a month ago".
+
+---
+
+## 4b. Experiment results (run 2026-09-02)
+
+Both tiers implemented as a throwaway Python script (`scratchpad/discover.py`).
+The dedup mirrors `database.getGroupIds()`: a groupId counts as *known* if
+Scaladex's API returns any version for **any** of its artifacts
+(`GET index.scala-lang.org/api/v1/artifacts/<g>/<a>` → non-empty array).
+
+### Tier 2 — nexus index, chunks 935 + 936
+
+| | |
+|---|---|
+| chunk 935 / 936 index time | 2026-08-13 / 2026-09-01 (**19 days** between two publishes) |
+| download | 44.7 MB + 40.6 MB |
+| records parsed | 2 012 362 + 1 776 937 = **3.79 M** artifact rows, **0 deletes** |
+| Scala artifacts (suffix filter) | **109 258** |
+| distinct groupIds publishing Scala | **385** |
+| **groupIds absent from Scaladex** | **140 (36 %)** |
+
+Composition of the 140:
+
+- **~53** are `io.github.*` / `com.github.*` — mostly one-person projects using
+  `sbt-ci-release`, never registered with Scaladex.
+- **~40** are noise for the community-build purpose: LLM/agent SDKs
+  (`ai.fastllm`, `com.tjclp`, `io.repofyr`, `com.anymindgroup` zio-gcp-*,
+  `io.github.zyblw`…) and Spark/data connectors
+  (`io.substrait`, `io.graphframes`, `org.lance`, `dev.vortex`,
+  `com.motherduck`, `tech.ytsaurus.spyt`, `org.voltdb`, `jp.co.yahoo.yosegi`,
+  `org.apache.datafusion` Comet, `org.apache.xtable`…).
+- **~45 are real, ordinary Scala libraries that simply never got in**, e.g.:
+  `com.softwaremill.sttp.ai`, `com.softwaremill.chimp`, `org.polyvariant`
+  (smithy-ts-codegen), `com.kevel` (apso — moved from `com.velocidi`),
+  `com.colisweb` (scala-distances), `org.mongo4s`, `com.magine` (http4s-aws),
+  `me.romac` (postino), `works.iterative`, `io.onfhir`, `dev.propensive`,
+  `io.parapet`, `de.rmgk.slips`, `org.apalache-mc`, `org.finos.morphir.mill`,
+  `net.scalax.*`, `fr.maif` (otoroshi), `com.snowflake` (snowpark),
+  `dev.valentiay` (phobos fork).
+
+Spot-checking 20 of the 140 by hand (probe plain `_3` / `_2.13` of the first base
+names): **0 false positives** — all 20 were genuinely unknown. The earlier
+"38–40 %" from a naïve "first 6 artifactIds" probe *did* have false positives
+(`org.typelevel`, whose window artifacts were `scalac-compat-features_*`, which
+Scaladex lacks); the wider probe fixed that and the number barely moved.
+
+### Tier 1 — Central Portal feed, 500 most-recent components
+
+3 groupIds with Scala artifacts; **1 real gap**: `dev.valentiay` (phobos, 29
+Scala artifacts). `edu.gemini` (lucuma 0.242.0) and `io.github.makingthematrix`
+(signals3_3 1.2.1) are *known groupIds* — pure `missing-maven-artifacts` sync
+lag, not discovery gaps. Confirms Tier 1's role: catch brand-new namespaces fast,
+let Tier 2 / the existing job handle new versions of known ones.
+
+### Takeaways
+
+1. **The gap is real and large.** In 19 days, ~140 Scala-publishing namespaces
+   were invisible to Scaladex — direct confirmation that no automatic
+   Maven Central → Scaladex path survives.
+2. **A filter beyond the binary-version suffix is needed.** ~60 % of raw hits are
+   `io.github.*` hobby repos or LLM/Spark-glue noise. Options: require a GitHub
+   `scm` that resolves (the existing `syncOne` already drops the rest as
+   `NoGithubRepo`), and/or a minimum artifact/vote threshold, and/or a
+   review queue in the admin UI rather than auto-insert.
+3. **Both tiers are cheap.** Tier 1 = ~25 JSON POSTs. Tier 2 = ~85 MB/run,
+   ~4 M rows parsed in seconds by 30 lines of code, roughly monthly.
+4. Numbers scale: 385 groupIds × ~1 chunk-pair/month ⇒ order-of-1000s of new
+   candidate namespaces/year, ~a third unknown — but only a small fraction worth
+   auto-indexing.
+
+Full ranked list: `scratchpad/missing_groupids.txt`.
+
+---
+
+## 5. Immediate unblock for a single namespace (manual, works today)
+
+Admin → "Find missing artifacts" with a Group ID (no artifact name) runs
+`MavenCentralService.syncOne` → if the artifacts carry an `scm` pointing at a
+public GitHub repo, projects get created. This is the per-namespace stopgap while
+the discovery pipeline is built.
+
+`com.halotukozak` was already onboarded this way — as of 2026-09-02 it resolves
+(`index.scala-lang.org/api/v1/artifacts/com.halotukozak/commons_3` → project
+`halotukozak-com/commons`, versions `0.1.0`–`0.1.3`).
+
+---
+
+## 6. Deciding what to index (the "noise" question)
+
+Discovery is the easy half. The 140 missing groupIds from §4b are ~40 % junk for
+the community-build purpose (LLM/agent scaffolding, Spark/Databricks connectors,
+`io.github.*` experiments) and ~30 % ordinary Scala libraries — and **Maven
+metadata barely tells them apart**.
+
+### Signal strength (measured on the §4b sample, chunk 936: 87 missing vs 154 known)
+
+| Signal | Missing vs Known | Cost | Verdict |
+|---|---|---|---|
+| valid Scala binary version | — | free | base filter (already have) |
+| `<description>` present | 100 % vs 98 % | free | **useless** — Central makes it mandatory |
+| ships `-sources.jar` | ~universal both sides | free | useless |
+| ≥ 3 cross-published modules | 50 % vs 62 % | free | weak |
+| ≥ 2 binary versions (`_2.13`+`_3`) | moderate | free | one-offs publish a single target |
+| groupId is `io.github.*` / `com.github.*` | 34 % vs 16 % | free | weak — **do not hard-exclude**, Scaladex is full of legit ones |
+| artifactId `~ *-spark[34]* / *_*.dbr_* / *-agent* / *-mcp*` | precise-ish | free | good for *de-prioritising* ~15–20 of the 140, risky as a hard filter |
+| `<scm>` resolves to a live public GitHub repo | **strong** | 1 POM req (`syncOne` already does this) | **the real gate** |
+| GitHub Scala % > 0 | strong | 1 GH API req | `addEmptyProject` already uses this |
+| GitHub stars ≥ N | strong — but filters exactly the `com.halotukozak` profile | 1 GH API req | use for **ranking / surfacing, never for gating** |
+| pushed within ~18 months | strong for "alive" | same GH call | ranking |
+
+25 of 27 hand-checked missing groupIds had a resolvable GitHub `scm`
+(`propensive/proscala`, `scala-native/scala-native`, `softwaremill/sttp-ai`, …) —
+so the scm gate keeps almost all of them, which matches how Scaladex already
+treats the publish webhook.
+
+### Recommended policy — two independent knobs
+
+1. **Indexing gate — inclusive, identical to today's publish path.**
+   scm resolves to a live public GitHub repo **and** GitHub Scala % > 0 → auto
+   `syncOne`. This lets in phobos, apso, scala-distances, sttp.ai *and* `zio-nn`
+   and `fast-agent`. That is fine — Scaladex is a catalogue, and the
+   regression-net value of a project like `com.halotukozak` is unrelated to its
+   star count.
+2. **Surfacing gate — strict.** A discovered project stays off the homepage /
+   "new projects" / trending until it has GitHub info **and** (stars ≥ ~2 **or** a
+   maintainer claimed it **or** an admin approved it). Add a `discovered`
+   provenance flag next to `GithubStatus`; keeps the shop window clean without
+   dropping data.
+3. **community-build candidate list** (the original motivation) — a separate
+   curated view over `discovered ∩ {Scala 3, macro/inline usage}`. The macro
+   signal is **not** in Maven metadata; it needs a cheap repo scan (depends on
+   `scala3-library` *and* source contains `inline` / `'{` / `${`). Out of scope
+   for Scaladex itself — realistically a human picks from the filtered list.
+
+### Hard filters (small, safe — everything else is "index + rank")
+
+- groupId already in `database.getGroupIds()` → not discovery; `findMissing`
+  owns it.
+- no resolvable `<scm>` after one POM fetch → `NoGithubRepo`; record and don't
+  retry more than once.
+- GitHub repo 404 / archived / 0 % Scala.
+- `discovered_group_ids.status = rejected` (admin said no) → sticky, never
+  re-surfaced; plus a static groupId denylist for known junk namespaces.
+
+Rough effect on the 140: hard filters remove ~15–25, leaving ~115 auto-indexed,
+of which ~30–40 would actually surface after the star/claim gate.
+
+---
+
+## References
+
+- `modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala`
+- `modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala`
+- `modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala` (`ArtifactId.parse`, `isScala`, `BinaryVersion`)
+- `modules/server/src/main/scala/scaladex/server/service/AdminService.scala` (`jobs`)
+- Maven Central Index: <https://maven.apache.org/repository/central-index.html>
+- `indexer-reader` (dependency-free, no Lucene): <https://maven.apache.org/maven-indexer/indexer-reader/>,
+  source `apache/maven-indexer` → `indexer-reader/` (`IndexReader`, `ChunkReader`,
+  `RecordExpander`), coordinates `org.apache.maven.indexer:indexer-reader:7.1.6`
+- Central Portal publish API (no third-party search): <https://central.sonatype.org/publish/publish-portal-api/>
+- Legacy Solr REST guide: <https://central.sonatype.org/search/rest-api-guide/>
+- JetBrains Package Search: deprecated Dec 2024, web service + API shut down 1 Apr 2025
+  (`JetBrains/package-search-intellij-plugin` readme)
+- scala/scala3#26958 (community-build regression motivation)

--- a/modules/core/shared/src/main/scala/scaladex/core/model/DiscoveredGroupId.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/DiscoveredGroupId.scala
@@ -1,0 +1,35 @@
+package scaladex.core.model
+
+import java.time.Instant
+
+/** A Maven Central group ID found by the discovery pipeline (see `doc/dev/maven-central-discovery.md`). It is
+  * auto-indexed through the normal `syncOne` path; this row only tracks it for the admin review queue.
+  */
+final case class DiscoveredGroupId(
+    groupId: Artifact.GroupId,
+    source: DiscoveredGroupId.Source,
+    discoveredAt: Instant,
+    lastSyncedAt: Option[Instant],
+    syncSummary: Option[String],
+    projectRefs: Seq[Project.Reference],
+    status: DiscoveredGroupId.Status,
+    reviewedBy: Option[String],
+    reviewedAt: Option[Instant]
+)
+
+object DiscoveredGroupId:
+  def pending(source: Source, groupId: Artifact.GroupId, now: Instant): DiscoveredGroupId =
+    DiscoveredGroupId(groupId, source, now, None, None, Nil, Status.Pending, None, None)
+
+  enum Source:
+    case MavenIndex, Manual
+
+  enum Status:
+    case Pending, Reviewed, Rejected
+
+  /** Row plus the resolved projects, for rendering the admin panel. */
+  final case class View(discovered: DiscoveredGroupId, projects: Seq[Project])
+end DiscoveredGroupId
+
+/** Cursor into the Maven Central nexus index chunk chain. */
+final case class IndexCursor(chainId: String, lastIncremental: Int)

--- a/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralIndexClient.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralIndexClient.scala
@@ -1,0 +1,27 @@
+package scaladex.core.service
+
+import scala.concurrent.Future
+
+import scaladex.core.model.IndexCursor
+
+/** Reads the Maven Central "nexus" published index (`https://repo1.maven.org/maven2/.index/`). See
+  * `doc/dev/maven-central-discovery.md` §2.5.
+  */
+trait MavenCentralIndexClient:
+  /** Parse `nexus-maven-repository-index.properties`. */
+  def fetchRemoteCursor(): Future[IndexCursor]
+
+  /** Stream the records of the incremental chunks in `(from.lastIncremental, to.lastIncremental]`, capped at
+    * `maxChunks` per call, keeping only the records for which `keep` is true (a full chunk holds ~2M records, so
+    * filtering during the scan avoids materialising them all). Processing stops at the first chunk that fails to
+    * download or parse, and `Result.reachedIncremental` reports the last chunk fully processed so the caller advances
+    * its cursor no further.
+    */
+  def recordsSince(from: IndexCursor, to: IndexCursor, maxChunks: Int)(
+      keep: MavenCentralIndexClient.Record => Boolean
+  ): Future[MavenCentralIndexClient.Result]
+end MavenCentralIndexClient
+
+object MavenCentralIndexClient:
+  final case class Record(groupId: String, artifactId: String, version: String, deleted: Boolean)
+  final case class Result(records: Seq[Record], reachedIncremental: Int)

--- a/modules/core/shared/src/main/scala/scaladex/core/service/SchedulerDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/SchedulerDatabase.scala
@@ -6,6 +6,8 @@ import scala.concurrent.Future
 
 import scaladex.core.model.Artifact
 import scaladex.core.model.ArtifactDependency
+import scaladex.core.model.DiscoveredGroupId
+import scaladex.core.model.IndexCursor
 import scaladex.core.model.Project
 import scaladex.core.model.ProjectDependency
 import scaladex.core.model.Version
@@ -36,4 +38,33 @@ trait SchedulerDatabase extends WebDatabase:
   def getArtifactRefs(groupId: Artifact.GroupId): Future[Seq[Artifact.Reference]]
   def getArtifactRefs(groupId: Artifact.GroupId, limit: Int, offset: Int): Future[Seq[Artifact.Reference]]
   def updateLatestVersion(ref: Project.Reference, artifact: Artifact.Reference): Future[Unit]
+
+  // maven central namespace discovery
+  def insertDiscoveredGroupIds(discovered: Seq[DiscoveredGroupId]): Future[Int]
+  def getAllDiscoveredGroupIds(): Future[Seq[DiscoveredGroupId]]
+  def getDiscoveredGroupIds(status: DiscoveredGroupId.Status): Future[Seq[DiscoveredGroupId]]
+
+  /** Pending, not yet synced, oldest first — the sync queue. */
+  def getPendingDiscoveredGroupIdsToSync(limit: Int): Future[Seq[DiscoveredGroupId]]
+
+  /** Pending (synced or not), newest first, bounded — the admin review queue. */
+  def getPendingDiscoveredGroupIdsToReview(limit: Int): Future[Seq[DiscoveredGroupId]]
+  def updateDiscoveredGroupIdSync(
+      groupId: Artifact.GroupId,
+      lastSyncedAt: Instant,
+      syncSummary: String,
+      projectRefs: Seq[Project.Reference]
+  ): Future[Unit]
+
+  /** Record a failed sync attempt without setting last_synced_at, so it is retried. */
+  def updateDiscoveredGroupIdError(groupId: Artifact.GroupId, syncSummary: String): Future[Unit]
+  def updateDiscoveredGroupIdStatus(
+      groupId: Artifact.GroupId,
+      status: DiscoveredGroupId.Status,
+      reviewedBy: String,
+      reviewedAt: Instant
+  ): Future[Unit]
+  def getMavenIndexCursor(): Future[Option[IndexCursor]]
+  def setMavenIndexCursor(cursor: IndexCursor): Future[Unit]
+  def getProjectRefsByGroupId(groupId: Artifact.GroupId): Future[Seq[Project.Reference]]
 end SchedulerDatabase

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -164,7 +164,8 @@ class InMemoryDatabase extends SchedulerDatabase:
     Future.successful(0)
 
   override def updateArtifacts(allArtifacts: Seq[Artifact.Reference], newRef: Project.Reference): Future[Int] = ???
-  override def getGroupIds(): Future[Seq[Artifact.GroupId]] = ???
+  override def getGroupIds(): Future[Seq[Artifact.GroupId]] =
+    Future.successful(allArtifacts.values.map(_.groupId).toSeq.distinct)
   override def getGroupIds(limit: Int, offset: Int): Future[Seq[Artifact.GroupId]] = ???
   override def getArtifactRefs(): Future[Seq[Artifact.Reference]] = ???
   override def getArtifactRefs(groupId: Artifact.GroupId): Future[Seq[Artifact.Reference]] = ???
@@ -227,6 +228,69 @@ class InMemoryDatabase extends SchedulerDatabase:
 
   override def updateLatestVersion(ref: Project.Reference, artifact: Artifact.Reference): Future[Unit] =
     latestArtifacts += (ref, artifact.groupId, artifact.artifactId) -> artifact
+    Future.unit
+
+  private val discoveredGroupIds = TrieMap[Artifact.GroupId, DiscoveredGroupId]()
+  private var mavenIndexCursor = Option.empty[IndexCursor]
+
+  override def insertDiscoveredGroupIds(discovered: Seq[DiscoveredGroupId]): Future[Int] = Future.successful:
+    discovered.count(d => discoveredGroupIds.putIfAbsent(d.groupId, d).isEmpty)
+
+  override def getAllDiscoveredGroupIds(): Future[Seq[DiscoveredGroupId]] =
+    Future.successful(discoveredGroupIds.values.toSeq)
+
+  override def getDiscoveredGroupIds(status: DiscoveredGroupId.Status): Future[Seq[DiscoveredGroupId]] =
+    Future.successful(discoveredGroupIds.values.filter(_.status == status).toSeq)
+
+  override def getPendingDiscoveredGroupIdsToSync(limit: Int): Future[Seq[DiscoveredGroupId]] = Future.successful:
+    discoveredGroupIds.values
+      .filter(d => d.status == DiscoveredGroupId.Status.Pending && d.lastSyncedAt.isEmpty)
+      .toSeq
+      .sortBy(_.discoveredAt.toEpochMilli)
+      .take(limit)
+
+  override def getPendingDiscoveredGroupIdsToReview(limit: Int): Future[Seq[DiscoveredGroupId]] = Future.successful:
+    discoveredGroupIds.values
+      .filter(_.status == DiscoveredGroupId.Status.Pending)
+      .toSeq
+      .sortBy(-_.discoveredAt.toEpochMilli)
+      .take(limit)
+
+  override def updateDiscoveredGroupIdError(groupId: Artifact.GroupId, syncSummary: String): Future[Unit] =
+    discoveredGroupIds.updateWith(groupId)(_.map(_.copy(syncSummary = Some(syncSummary))))
+    Future.unit
+
+  override def updateDiscoveredGroupIdSync(
+      groupId: Artifact.GroupId,
+      lastSyncedAt: Instant,
+      syncSummary: String,
+      projectRefs: Seq[Project.Reference]
+  ): Future[Unit] =
+    discoveredGroupIds.updateWith(groupId)(
+      _.map(_.copy(lastSyncedAt = Some(lastSyncedAt), syncSummary = Some(syncSummary), projectRefs = projectRefs))
+    )
+    Future.unit
+  end updateDiscoveredGroupIdSync
+
+  override def updateDiscoveredGroupIdStatus(
+      groupId: Artifact.GroupId,
+      status: DiscoveredGroupId.Status,
+      reviewedBy: String,
+      reviewedAt: Instant
+  ): Future[Unit] =
+    discoveredGroupIds.updateWith(groupId)(
+      _.map(_.copy(status = status, reviewedBy = Some(reviewedBy), reviewedAt = Some(reviewedAt)))
+    )
+    Future.unit
+  end updateDiscoveredGroupIdStatus
+
+  override def getProjectRefsByGroupId(groupId: Artifact.GroupId): Future[Seq[Project.Reference]] =
+    Future.successful(allArtifacts.values.filter(_.groupId == groupId).map(_.projectRef).toSeq.distinct)
+
+  override def getMavenIndexCursor(): Future[Option[IndexCursor]] = Future.successful(mavenIndexCursor)
+
+  override def setMavenIndexCursor(cursor: IndexCursor): Future[Unit] =
+    mavenIndexCursor = Some(cursor)
     Future.unit
 
   override def getArtifactVersions(

--- a/modules/infra/src/main/resources/migrations/V29__add_discovered_group_id.sql
+++ b/modules/infra/src/main/resources/migrations/V29__add_discovered_group_id.sql
@@ -1,0 +1,20 @@
+CREATE TABLE discovered_group_id(
+    group_id         VARCHAR      NOT NULL,
+    source           VARCHAR      NOT NULL,
+    discovered_at    TIMESTAMPTZ  NOT NULL,
+    last_synced_at   TIMESTAMPTZ,
+    sync_summary     VARCHAR,
+    project_refs     VARCHAR,
+    status           VARCHAR      NOT NULL DEFAULT 'Pending',
+    reviewed_by      VARCHAR,
+    reviewed_at      TIMESTAMPTZ,
+    PRIMARY KEY (group_id)
+);
+
+CREATE TABLE discovered_index_cursor(
+    id               INT          NOT NULL DEFAULT 1 CHECK (id = 1),
+    chain_id         VARCHAR      NOT NULL,
+    last_incremental INT          NOT NULL,
+    updated_at       TIMESTAMPTZ  NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralIndexClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralIndexClientImpl.scala
@@ -1,0 +1,163 @@
+package scaladex.infra
+
+import java.io.ByteArrayInputStream
+import java.io.DataInputStream
+import java.io.EOFException
+import java.util.zip.GZIPInputStream
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scaladex.core.model.IndexCursor
+import scaladex.core.service.MavenCentralIndexClient
+import scaladex.core.service.MavenCentralIndexClient.Record
+import scaladex.core.service.MavenCentralIndexClient.Result
+import scaladex.infra.config.HttpClientConfig
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
+
+/** Reads the Maven Central nexus index. The chunk binary format (`doc/dev/maven-central-discovery.md` §2.5.2) is
+  * trivial enough to parse without `maven-indexer` / Lucene.
+  */
+class MavenCentralIndexClientImpl(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
+    extends CommonAkkaHttpClient(config)
+    with MavenCentralIndexClient
+    with LazyLogging:
+  private given ExecutionContextExecutor = system.dispatcher
+  private val host = "repo1.maven.org"
+  private val baseUri = s"https://$host/maven2/.index"
+  private val filePrefix = "nexus-maven-repository-index"
+
+  override def initPoolClientFlow: Flow[
+    (HttpRequest, Promise[HttpResponse]),
+    (Try[HttpResponse], Promise[HttpResponse]),
+    Http.HostConnectionPool
+  ] = Http().cachedHostConnectionPoolHttps[Promise[HttpResponse]](
+    host,
+    settings = ConnectionPoolSettings("max-open-requests = 4")
+  )
+
+  def fetchRemoteCursor(): Future[IndexCursor] = for
+    response <- queueRequestWithRetry(HttpRequest(uri = s"$baseUri/$filePrefix.properties"))
+    body <- Unmarshaller.stringUnmarshaller(response.entity)
+    props = body.linesIterator
+      .filterNot(_.startsWith("#"))
+      .map(_.split("=", 2))
+      .flatMap {
+        case Array(k, v) => Some((k.trim, v.trim))
+        case _ => None
+      }
+      .toMap
+    chainId = props.getOrElse("nexus.index.chain-id", sys.error("missing nexus.index.chain-id"))
+    lastIncremental = props
+      .get("nexus.index.last-incremental")
+      .flatMap(_.toIntOption)
+      .getOrElse(sys.error("missing last-incremental"))
+  yield IndexCursor(chainId, lastIncremental)
+
+  def recordsSince(from: IndexCursor, to: IndexCursor, maxChunks: Int)(
+      keep: Record => Boolean
+  ): Future[Result] =
+    val chunks = ((from.lastIncremental + 1) to to.lastIncremental).take(maxChunks).toList
+    // stop at the first chunk that fails so the caller's cursor never advances past unread records
+    def loop(remaining: List[Int], acc: Vector[Record], reached: Int): Future[Result] = remaining match
+      case Nil => Future.successful(Result(acc, reached))
+      case n :: rest =>
+        fetchChunk(n, keep).transformWith:
+          case Success(records) => loop(rest, acc ++ records, n)
+          case Failure(NonFatal(e)) =>
+            logger.warn(s"Stopping index scan at chunk $n (cursor stays at $reached): ${e.getMessage}")
+            Future.successful(Result(acc, reached))
+          case Failure(e) => Future.failed(e)
+    loop(chunks, Vector.empty, from.lastIncremental)
+  end recordsSince
+
+  private def fetchChunk(n: Int, keep: Record => Boolean): Future[Seq[Record]] =
+    val uri = s"$baseUri/$filePrefix.$n.gz"
+    for
+      response <- queueRequestWithRetry(HttpRequest(uri = uri))
+      records <-
+        if response.status != StatusCodes.OK then
+          response.discardEntityBytes()
+          Future.failed(new RuntimeException(s"$uri returned ${response.status}"))
+        else
+          response.entity
+            .withoutSizeLimit()
+            .dataBytes
+            .runFold(ByteString.empty)(_ ++ _)
+            .map(bytes => MavenCentralIndexParser.parseChunk(bytes.toArray, keep))
+    yield records
+    end for
+  end fetchChunk
+
+end MavenCentralIndexClientImpl
+
+/** Parser for one `nexus-maven-repository-index.<n>.gz` chunk. The binary framing (`doc/dev/maven-central-discovery.md`
+  * §2.5.2): after gunzip, a `byte` version and `long` timestamp, then repeated records of `int fieldCount` followed by
+  * `{byte flags, modified-UTF-8 name, int len, value bytes}`. We only care about the `u` (add) and `del` (remove)
+  * fields, both `groupId|artifactId|version|classifier[|ext]`.
+  */
+object MavenCentralIndexParser:
+  def parseChunk(
+      gzBytes: Array[Byte],
+      keep: MavenCentralIndexClient.Record => Boolean
+  ): Seq[MavenCentralIndexClient.Record] =
+    val in = new DataInputStream(new GZIPInputStream(new ByteArrayInputStream(gzBytes), 8192))
+    try
+      in.readByte() // format version (always 1)
+      in.readLong() // chunk timestamp
+      val out = Vector.newBuilder[MavenCentralIndexClient.Record]
+      var continue = true
+      while continue do
+        // EOF here is the legitimate end of the chunk; EOF anywhere deeper means a truncated
+        // download and is left to propagate so the caller retries the chunk instead of losing records
+        val fieldCount =
+          try in.readInt()
+          catch case _: EOFException => -1
+        if fieldCount < 0 then continue = false
+        else
+          var uinfo: String = null
+          var deleted = false
+          var i = 0
+          while i < fieldCount do
+            in.readByte() // flags, ignored
+            in.readUTF() match // field name
+              case "u" => uinfo = readValue(in)
+              case "del" =>
+                uinfo = readValue(in)
+                deleted = true
+              case _ => readValue(in)
+            i += 1
+          if uinfo != null then
+            uinfo.split('|') match
+              case Array(g, a, v, _*) =>
+                val record = MavenCentralIndexClient.Record(g, a, v, deleted)
+                if keep(record) then out += record
+              case _ => ()
+        end if
+      end while
+      out.result()
+    finally in.close()
+    end try
+  end parseChunk
+
+  private def readValue(in: DataInputStream): String =
+    val len = in.readInt()
+    val bytes = new Array[Byte](len)
+    in.readFully(bytes)
+    new String(bytes, "UTF-8")
+end MavenCentralIndexParser

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -371,6 +371,49 @@ class SqlDatabase(
   def updateGithubStatus(ref: Project.Reference, githubStatus: GithubStatus): Future[Unit] =
     run(ProjectTable.updateGithubStatus.run(githubStatus, ref)).map(_ => invalidateProject(ref))
 
+  override def insertDiscoveredGroupIds(discovered: Seq[DiscoveredGroupId]): Future[Int] =
+    run(DiscoveredGroupIdTable.insertIfNotExists.updateMany(discovered.toList))
+
+  override def getAllDiscoveredGroupIds(): Future[Seq[DiscoveredGroupId]] =
+    run(DiscoveredGroupIdTable.selectAll.to[Seq])
+
+  override def getDiscoveredGroupIds(status: DiscoveredGroupId.Status): Future[Seq[DiscoveredGroupId]] =
+    run(DiscoveredGroupIdTable.selectByStatus.to[Seq](status))
+
+  override def getPendingDiscoveredGroupIdsToSync(limit: Int): Future[Seq[DiscoveredGroupId]] =
+    run(DiscoveredGroupIdTable.selectPendingToSync.to[Seq](limit.toLong))
+
+  override def getPendingDiscoveredGroupIdsToReview(limit: Int): Future[Seq[DiscoveredGroupId]] =
+    run(DiscoveredGroupIdTable.selectPendingToReview.to[Seq](limit.toLong))
+
+  override def updateDiscoveredGroupIdError(groupId: Artifact.GroupId, syncSummary: String): Future[Unit] =
+    run(DiscoveredGroupIdTable.updateError.run((syncSummary, groupId))).map(_ => ())
+
+  override def updateDiscoveredGroupIdSync(
+      groupId: Artifact.GroupId,
+      lastSyncedAt: Instant,
+      syncSummary: String,
+      projectRefs: Seq[Project.Reference]
+  ): Future[Unit] =
+    run(DiscoveredGroupIdTable.updateSync.run((lastSyncedAt, syncSummary, projectRefs, groupId))).map(_ => ())
+
+  override def updateDiscoveredGroupIdStatus(
+      groupId: Artifact.GroupId,
+      status: DiscoveredGroupId.Status,
+      reviewedBy: String,
+      reviewedAt: Instant
+  ): Future[Unit] =
+    run(DiscoveredGroupIdTable.updateStatus.run((status, reviewedBy, reviewedAt, groupId))).map(_ => ())
+
+  override def getProjectRefsByGroupId(groupId: Artifact.GroupId): Future[Seq[Project.Reference]] =
+    run(ArtifactTable.selectProjectRefsByGroupId.to[Seq](groupId))
+
+  override def getMavenIndexCursor(): Future[Option[IndexCursor]] =
+    run(DiscoveredIndexCursorTable.select.option)
+
+  override def setMavenIndexCursor(cursor: IndexCursor): Future[Unit] =
+    run(DiscoveredIndexCursorTable.upsert.run((cursor.chainId, cursor.lastIncremental, Instant.now))).map(_ => ())
+
   private def run[A](v: doobie.ConnectionIO[A]): Future[A] =
     queryPermits match
       case None => v.transact(xa).unsafeToFuture()

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ArtifactTable.scala
@@ -163,6 +163,9 @@ object ArtifactTable:
   val selectReferencesByProject: Query[Project.Reference, Reference] =
     selectRequest(table, Seq("DISTINCT group_id", "artifact_id", "\"version\""), keys = projectReferenceFields)
 
+  val selectProjectRefsByGroupId: Query[GroupId, Project.Reference] =
+    selectRequest1(table, Seq("DISTINCT organization", "repository"), keys = Seq("group_id"))
+
   val selectMavenReferenceWithNoReleaseDate: Query0[Reference] =
     selectRequest(table, Seq("group_id", "artifact_id", "\"version\""), where = Seq("release_date is NULL"))
 

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DiscoveredGroupIdTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DiscoveredGroupIdTable.scala
@@ -1,0 +1,57 @@
+package scaladex.infra.sql
+
+import java.time.Instant
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.DiscoveredGroupId
+import scaladex.core.model.Project
+import scaladex.infra.sql.DoobieMappings.given
+import scaladex.infra.sql.DoobieUtils.*
+
+import doobie.*
+
+object DiscoveredGroupIdTable:
+  private[sql] val table = "discovered_group_id"
+  private val fields = Seq(
+    "group_id",
+    "source",
+    "discovered_at",
+    "last_synced_at",
+    "sync_summary",
+    "project_refs",
+    "status",
+    "reviewed_by",
+    "reviewed_at"
+  )
+
+  // insert new rows only: an already-known group ID keeps its current status (incl. 'rejected')
+  val insertIfNotExists: Update[DiscoveredGroupId] =
+    insertOrUpdateRequest(table, fields, Seq("group_id"))
+
+  val selectAll: Query0[DiscoveredGroupId] =
+    selectRequest(table, fields, orderBy = Some("discovered_at DESC"))
+
+  val selectByStatus: Query[DiscoveredGroupId.Status, DiscoveredGroupId] =
+    selectRequest1(table, fields, keys = Seq("status"), orderBy = Some("discovered_at DESC"))
+
+  private val fieldsStr = fields.mkString(", ")
+
+  // sync queue: pending + never synced, oldest first, bounded (param = limit)
+  val selectPendingToSync: Query[Long, DiscoveredGroupId] = Query(
+    s"SELECT $fieldsStr FROM $table WHERE status = 'Pending' AND last_synced_at IS NULL " +
+      "ORDER BY discovered_at ASC LIMIT ?"
+  )
+
+  // review queue: all pending, newest first, bounded (param = limit)
+  val selectPendingToReview: Query[Long, DiscoveredGroupId] =
+    Query(s"SELECT $fieldsStr FROM $table WHERE status = 'Pending' ORDER BY discovered_at DESC LIMIT ?")
+
+  val updateSync: Update[(Instant, String, Seq[Project.Reference], Artifact.GroupId)] =
+    updateRequest(table, Seq("last_synced_at", "sync_summary", "project_refs"), Seq("group_id"))
+
+  val updateError: Update[(String, Artifact.GroupId)] =
+    updateRequest(table, Seq("sync_summary"), Seq("group_id"))
+
+  val updateStatus: Update[(DiscoveredGroupId.Status, String, Instant, Artifact.GroupId)] =
+    updateRequest(table, Seq("status", "reviewed_by", "reviewed_at"), Seq("group_id"))
+end DiscoveredGroupIdTable

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DiscoveredIndexCursorTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DiscoveredIndexCursorTable.scala
@@ -1,0 +1,22 @@
+package scaladex.infra.sql
+
+import java.time.Instant
+
+import scaladex.core.model.IndexCursor
+import scaladex.infra.sql.DoobieMappings.given
+import scaladex.infra.sql.DoobieUtils.*
+
+import doobie.*
+
+object DiscoveredIndexCursorTable:
+  private[sql] val table = "discovered_index_cursor"
+
+  val select: Query0[IndexCursor] =
+    selectRequest(table, Seq("chain_id", "last_incremental"))
+
+  val upsert: Update[(String, Int, Instant)] = Update(
+    s"INSERT INTO $table (id, chain_id, last_incremental, updated_at) VALUES (1, ?, ?, ?) " +
+      "ON CONFLICT (id) DO UPDATE SET " +
+      "chain_id = EXCLUDED.chain_id, last_incremental = EXCLUDED.last_incremental, updated_at = EXCLUDED.updated_at"
+  )
+end DiscoveredIndexCursorTable

--- a/modules/infra/src/main/scala/scaladex/infra/sql/DoobieMappings.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/DoobieMappings.scala
@@ -61,6 +61,13 @@ object DoobieMappings extends Instances with JavaTimeInstances:
     Meta[String].timap(_.split(",").filter(_.nonEmpty).map(Project.Reference.unsafe).toSet)(_.mkString(","))
   given given_Meta_Set_Project_Organization: Meta[Set[Project.Organization]] =
     Meta[String].timap(_.split(",").filter(_.nonEmpty).map(Project.Organization.apply).toSet)(_.mkString(","))
+  given given_Meta_Seq_Project_Reference: Meta[Seq[Project.Reference]] =
+    Meta[String]
+      .timap(_.split(",").filter(_.nonEmpty).map(Project.Reference.unsafe).toSeq)(_.map(_.toString).mkString(","))
+  given Meta[DiscoveredGroupId.Source] =
+    Meta[String].timap(DiscoveredGroupId.Source.valueOf)(_.toString)
+  given Meta[DiscoveredGroupId.Status] =
+    Meta[String].timap(DiscoveredGroupId.Status.valueOf)(_.toString)
   given Meta[Category] = Meta[String].timap(Category.byLabel)(_.label)
 
   given Read[Project.Reference] =
@@ -125,6 +132,50 @@ object DoobieMappings extends Instances with JavaTimeInstances:
     }
   // not strictly needed, but keeping it to speed compilation up
   given Read[Artifact] = Read.given_Read_P
+
+  private type DiscoveredGroupIdRow = (
+      Artifact.GroupId,
+      DiscoveredGroupId.Source,
+      Instant,
+      Option[Instant],
+      Option[String],
+      Option[Seq[Project.Reference]],
+      DiscoveredGroupId.Status,
+      Option[String],
+      Option[Instant]
+  )
+  given Write[DiscoveredGroupId] =
+    Write[DiscoveredGroupIdRow].contramap { d =>
+      (
+        d.groupId,
+        d.source,
+        d.discoveredAt,
+        d.lastSyncedAt,
+        d.syncSummary,
+        Option.when(d.projectRefs.nonEmpty)(d.projectRefs),
+        d.status,
+        d.reviewedBy,
+        d.reviewedAt
+      )
+    }
+  given Read[IndexCursor] =
+    Read[(String, Int)].map { case (chainId, lastIncremental) => IndexCursor(chainId, lastIncremental) }
+
+  given Read[DiscoveredGroupId] =
+    Read[DiscoveredGroupIdRow].map {
+      case (groupId, source, discoveredAt, lastSyncedAt, syncSummary, projectRefs, status, reviewedBy, reviewedAt) =>
+        DiscoveredGroupId(
+          groupId,
+          source,
+          discoveredAt,
+          lastSyncedAt,
+          syncSummary,
+          projectRefs.getOrElse(Nil),
+          status,
+          reviewedBy,
+          reviewedAt
+        )
+    }
 
   private def toJson[A](v: A)(using Encoder[A]): String =
     Encoder[A].apply(v).noSpaces

--- a/modules/infra/src/test/scala/scaladex/infra/MavenCentralIndexParserTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/MavenCentralIndexParserTests.scala
@@ -1,0 +1,63 @@
+package scaladex.infra
+
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.util.zip.GZIPOutputStream
+
+import scaladex.core.service.MavenCentralIndexClient.Record
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class MavenCentralIndexParserTests extends AnyFunSpec with Matchers:
+  /** Writes a chunk in the maven-indexer transport format. */
+  private def chunk(records: Seq[Map[String, String]]): Array[Byte] =
+    val raw = new ByteArrayOutputStream()
+    val gz = new GZIPOutputStream(raw)
+    val out = new DataOutputStream(gz)
+    out.writeByte(1) // version
+    out.writeLong(0L) // timestamp
+    records.foreach { fields =>
+      out.writeInt(fields.size)
+      fields.foreach {
+        case (name, value) =>
+          out.writeByte(0) // flags
+          out.writeUTF(name)
+          val bytes = value.getBytes("UTF-8")
+          out.writeInt(bytes.length)
+          out.write(bytes)
+      }
+    }
+    out.close()
+    raw.toByteArray
+  end chunk
+
+  it("parses added and deleted artifact records, skipping others") {
+    val bytes = chunk(
+      Seq(
+        Map("u" -> "com.example|lib_3|1.0.0|NA", "i" -> "jar|123|456|1|1|1|jar", "n" -> "lib"),
+        Map("u" -> "com.example|lib_sjs1_3|1.0.0|sources|jar"),
+        Map("del" -> "org.old|gone_2.13|0.1.0|NA", "m" -> "123"),
+        Map("allGroups" -> "allGroups", "allGroupsList" -> ""),
+        Map("DESCRIPTOR" -> "NexusIndex", "IDXINFO" -> "1.0|central")
+      )
+    )
+    val records = MavenCentralIndexParser.parseChunk(bytes, _ => true)
+    records shouldBe Seq(
+      Record("com.example", "lib_3", "1.0.0", deleted = false),
+      Record("com.example", "lib_sjs1_3", "1.0.0", deleted = false),
+      Record("org.old", "gone_2.13", "0.1.0", deleted = true)
+    )
+  }
+
+  it("applies the keep predicate during the scan") {
+    val bytes = chunk(
+      Seq(
+        Map("u" -> "com.example|lib_3|1.0.0|NA"),
+        Map("u" -> "com.example|tool|1.0.0|NA")
+      )
+    )
+    MavenCentralIndexParser.parseChunk(bytes, _.artifactId.endsWith("_3")) shouldBe
+      Seq(Record("com.example", "lib_3", "1.0.0", deleted = false))
+  }
+end MavenCentralIndexParserTests

--- a/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/SqlDatabaseTests.scala
@@ -313,4 +313,77 @@ class SqlDatabaseTests extends AsyncFunSpec with BaseDatabaseSuite with Matchers
       obtained1 should contain theSameElementsAs Seq(Cats.`core_3:2.6.1`)
       obtained2 should contain theSameElementsAs Seq(Cats.`core_2.13:2.5.0`)
   }
+
+  it("insert, list by status and review discovered group ids") {
+    val now = java.time.Instant.now
+    val newGroup = DiscoveredGroupId.pending(DiscoveredGroupId.Source.MavenIndex, Artifact.GroupId("dev.new"), now)
+    val rejected = DiscoveredGroupId
+      .pending(DiscoveredGroupId.Source.Manual, Artifact.GroupId("dev.spam"), now)
+      .copy(status = DiscoveredGroupId.Status.Rejected)
+    for
+      inserted <- database.insertDiscoveredGroupIds(Seq(newGroup, rejected))
+      // re-inserting must not overwrite the rejected status
+      reinserted <- database.insertDiscoveredGroupIds(
+        Seq(DiscoveredGroupId.pending(DiscoveredGroupId.Source.MavenIndex, Artifact.GroupId("dev.spam"), now))
+      )
+      _ <- database.updateDiscoveredGroupIdSync(
+        Artifact.GroupId("dev.new"),
+        now,
+        "Inserted 3 poms",
+        Seq(Cats.reference)
+      )
+      pending <- database.getDiscoveredGroupIds(DiscoveredGroupId.Status.Pending)
+      _ <- database.updateDiscoveredGroupIdStatus(
+        Artifact.GroupId("dev.new"),
+        DiscoveredGroupId.Status.Reviewed,
+        "admin",
+        now
+      )
+      afterReview <- database.getDiscoveredGroupIds(DiscoveredGroupId.Status.Pending)
+      all <- database.getAllDiscoveredGroupIds()
+    yield
+      inserted shouldBe 2
+      reinserted shouldBe 0
+      pending.map(_.groupId.value) shouldBe Seq("dev.new")
+      pending.head.syncSummary shouldBe Some("Inserted 3 poms")
+      pending.head.projectRefs shouldBe Seq(Cats.reference)
+      afterReview shouldBe empty
+      all.map(_.groupId.value).sorted shouldBe Seq("dev.new", "dev.spam")
+    end for
+  }
+
+  it("sync queue is FIFO and an error keeps a group retryable") {
+    val t0 = java.time.Instant.parse("2026-01-01T00:00:00Z")
+    val older = DiscoveredGroupId.pending(DiscoveredGroupId.Source.MavenIndex, Artifact.GroupId("dev.older"), t0)
+    val newer = DiscoveredGroupId.pending(
+      DiscoveredGroupId.Source.MavenIndex,
+      Artifact.GroupId("dev.newer"),
+      t0.plusSeconds(3600)
+    )
+    for
+      _ <- database.insertDiscoveredGroupIds(Seq(newer, older))
+      toSync <- database.getPendingDiscoveredGroupIdsToSync(10)
+      _ <- database.updateDiscoveredGroupIdError(Artifact.GroupId("dev.older"), "error: boom")
+      stillQueued <- database.getPendingDiscoveredGroupIdsToSync(10)
+      _ <- database.updateDiscoveredGroupIdSync(Artifact.GroupId("dev.newer"), t0, "Inserted 0 poms", Nil)
+      afterOneSynced <- database.getPendingDiscoveredGroupIdsToSync(10)
+    yield
+      toSync.map(_.groupId.value) shouldBe Seq("dev.older", "dev.newer") // oldest first
+      stillQueued.map(_.groupId.value) shouldBe Seq("dev.older", "dev.newer") // error did not set last_synced_at
+      afterOneSynced.map(_.groupId.value) shouldBe Seq("dev.older") // dev.newer left the queue
+    end for
+  }
+
+  it("stores and reads back the maven index cursor") {
+    for
+      empty <- database.getMavenIndexCursor()
+      _ <- database.setMavenIndexCursor(IndexCursor("chain-1", 900))
+      first <- database.getMavenIndexCursor()
+      _ <- database.setMavenIndexCursor(IndexCursor("chain-1", 912))
+      second <- database.getMavenIndexCursor()
+    yield
+      empty shouldBe None
+      first shouldBe Some(IndexCursor("chain-1", 900))
+      second shouldBe Some(IndexCursor("chain-1", 912))
+  }
 end SqlDatabaseTests

--- a/modules/infra/src/test/scala/scaladex/infra/sql/DiscoveredGroupIdTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/DiscoveredGroupIdTableTests.scala
@@ -1,0 +1,19 @@
+package scaladex.infra.sql
+
+import scaladex.infra.BaseDatabaseSuite
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiscoveredGroupIdTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers:
+  it("check insertIfNotExists")(check(DiscoveredGroupIdTable.insertIfNotExists))
+  it("check selectAll")(check(DiscoveredGroupIdTable.selectAll))
+  it("check selectByStatus")(check(DiscoveredGroupIdTable.selectByStatus))
+  it("check selectPendingToSync")(check(DiscoveredGroupIdTable.selectPendingToSync))
+  it("check selectPendingToReview")(check(DiscoveredGroupIdTable.selectPendingToReview))
+  it("check updateSync")(check(DiscoveredGroupIdTable.updateSync))
+  it("check updateError")(check(DiscoveredGroupIdTable.updateError))
+  it("check updateStatus")(check(DiscoveredGroupIdTable.updateStatus))
+  it("check cursor select")(check(DiscoveredIndexCursorTable.select))
+  it("check cursor upsert")(check(DiscoveredIndexCursorTable.upsert))
+end DiscoveredGroupIdTableTests

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -14,6 +14,7 @@ import scaladex.infra.ElasticsearchEngine
 import scaladex.infra.FilesystemStorage
 import scaladex.infra.GithubClientImpl
 import scaladex.infra.MavenCentralClientImpl
+import scaladex.infra.MavenCentralIndexClientImpl
 import scaladex.infra.SqlDatabase
 import scaladex.infra.sql.DoobieUtils
 import scaladex.server.config.ServerConfig
@@ -77,13 +78,20 @@ object Server extends LazyLogging:
             val schedulerPublishProcess =
               PublishProcess(paths, filesystem, schedulerDatabase, config.env)(using publishPool, system)
             val mavenCentralClient = new MavenCentralClientImpl(config.mavenCentral.httpClient)
+            val mavenCentralIndexClient = new MavenCentralIndexClientImpl(config.mavenCentral.httpClient)
             val mavenCentralService =
               new MavenCentralService(paths, schedulerDatabase, mavenCentralClient, schedulerPublishProcess)(
                 using system.dispatcher,
                 system
               )
-            val adminService =
-              new AdminService(config.env, schedulerDatabase, searchEngine, githubClient, mavenCentralService)
+            val adminService = new AdminService(
+              env = config.env,
+              database = schedulerDatabase,
+              searchEngine = searchEngine,
+              githubClientOpt = githubClient,
+              mavenCentralService = mavenCentralService,
+              mavenCentralIndexClient = mavenCentralIndexClient
+            )
 
             for
               _ <- init(flyway, adminService, searchEngine, config.elasticsearch.reset)

--- a/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
@@ -23,8 +23,9 @@ class AdminPage(env: Env, adminService: AdminService):
             pathEnd {
               val jobs = adminService.allJobStatuses
               val tasks = adminService.allTaskStatuses
-              val html = view.admin.html.admin(env, user, jobs, tasks)
-              complete(html)
+              onSuccess(adminService.discoveredProjectsToReview()) { discovered =>
+                complete(view.admin.html.admin(env, user, jobs, tasks, discovered))
+              }
             }
           } ~
             post {
@@ -71,6 +72,15 @@ class AdminPage(env: Env, adminService: AdminService):
               path("tasks" / Task.republishArtifacts.name) {
                 adminService.republishArtifacts(user)
                 redirect(Uri("/admin"), StatusCodes.SeeOther)
+              }
+            } ~
+            post {
+              path("discovered" / Segment / "review") { rawGroupId =>
+                formField("decision") { decision =>
+                  onSuccess(adminService.reviewDiscoveredGroupId(Artifact.GroupId(rawGroupId), decision, user)) {
+                    redirect(Uri("/admin"), StatusCodes.SeeOther)
+                  }
+                }
               }
             }
 

--- a/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/AdminPage.scala
@@ -75,6 +75,14 @@ class AdminPage(env: Env, adminService: AdminService):
               }
             } ~
             post {
+              path("tasks" / Task.rewindDiscoveryCursor.name) {
+                formField("chunks-back") { raw =>
+                  adminService.rewindDiscoveryCursor(raw.toIntOption.getOrElse(8), user)
+                  redirect(Uri("/admin"), StatusCodes.SeeOther)
+                }
+              }
+            } ~
+            post {
               path("discovered" / Segment / "review") { rawGroupId =>
                 formField("decision") { decision =>
                   onSuccess(adminService.reviewDiscoveredGroupId(Artifact.GroupId(rawGroupId), decision, user)) {

--- a/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
@@ -180,6 +180,13 @@ class AdminService(
     }
     tasks = tasks :+ task
 
+  def rewindDiscoveryCursor(chunksBack: Int, user: UserState): Unit =
+    val input = Seq("Chunks back" -> chunksBack.toString)
+    val task = TaskRunner.run(Task.rewindDiscoveryCursor, user.info.login, input) { () =>
+      discoveryService.rewindCursor(chunksBack)
+    }
+    tasks = tasks :+ task
+
   private def updateProjectCreationDate(): Future[String] =
     for
       creationDates <- database.computeProjectsCreationDates()

--- a/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
@@ -1,8 +1,12 @@
 package scaladex.server.service
+import java.time.Instant
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 import scaladex.core.model.Artifact
+import scaladex.core.model.DiscoveredGroupId
 import scaladex.core.model.Env
 import scaladex.core.model.GithubResponse
 import scaladex.core.model.GithubStatus
@@ -10,6 +14,7 @@ import scaladex.core.model.Project
 import scaladex.core.model.Project.Settings
 import scaladex.core.model.UserState
 import scaladex.core.service.GithubClient
+import scaladex.core.service.MavenCentralIndexClient
 import scaladex.core.service.ProjectService
 import scaladex.core.service.SchedulerDatabase
 import scaladex.core.service.SearchEngine
@@ -25,10 +30,14 @@ class AdminService(
     database: SchedulerDatabase,
     searchEngine: SearchEngine,
     githubClientOpt: Option[GithubClient],
-    mavenCentralService: MavenCentralService
+    mavenCentralService: MavenCentralService,
+    mavenCentralIndexClient: MavenCentralIndexClient
 )(using system: ActorSystem)
     extends LazyLogging:
   private given ExecutionContext = system.dispatcher
+
+  private val discoveryService =
+    new DiscoveryService(database, mavenCentralIndexClient, mavenCentralService.syncOne(_, None))
 
   val projectService = new ProjectService(database, searchEngine)
   val searchSynchronizer = new SearchSynchronizer(database, projectService, searchEngine)
@@ -53,7 +62,8 @@ class AdminService(
         if !env.isLocal then
           Seq(
             new JobScheduler(Job.missingMavenArtifacts, mavenCentralService.findMissing),
-            new JobScheduler(Job.nonStandardArtifacts, mavenCentralService.findNonStandard)
+            new JobScheduler(Job.nonStandardArtifacts, mavenCentralService.findNonStandard),
+            new JobScheduler(Job.discoverMavenNamespaces, discoveryService.discover)
           )
         else Seq.empty
       )
@@ -73,6 +83,34 @@ class AdminService(
 
   def allJobStatuses: Seq[(Job, Job.Status)] =
     jobs.values.map(s => s.job -> s.status).toSeq
+
+  private val discoveredReviewLimit = 100
+
+  /** The review queue: group IDs found by discovery that no admin has yet accepted or rejected, newest first, joined to
+    * the projects they produced. Bounded, and degrades to an empty list rather than failing the whole admin page.
+    */
+  def discoveredProjectsToReview(): Future[Seq[DiscoveredGroupId.View]] =
+    database
+      .getPendingDiscoveredGroupIdsToReview(discoveredReviewLimit)
+      .flatMap: pending =>
+        pending.mapSync: discovered =>
+          discovered.projectRefs
+            .mapSync(database.getProject)
+            .map(projects => DiscoveredGroupId.View(discovered, projects.flatten))
+      .recover:
+        case NonFatal(e) =>
+          logger.warn(s"Could not load discovered projects for review: ${e.getMessage}")
+          Nil
+
+  def reviewDiscoveredGroupId(groupId: Artifact.GroupId, decision: String, user: UserState): Future[Unit] =
+    decision match
+      case "reviewed" =>
+        database.updateDiscoveredGroupIdStatus(groupId, DiscoveredGroupId.Status.Reviewed, user.info.login, Instant.now)
+      case "reject" | "rejected" =>
+        database.updateDiscoveredGroupIdStatus(groupId, DiscoveredGroupId.Status.Rejected, user.info.login, Instant.now)
+      case other =>
+        logger.warn(s"Ignoring unknown discovered-group review decision '$other' for ${groupId.value}")
+        Future.unit
 
   def findMissingArtifacts(
       groupId: Artifact.GroupId,

--- a/modules/server/src/main/scala/scaladex/server/service/DiscoveryService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/DiscoveryService.scala
@@ -1,0 +1,93 @@
+package scaladex.server.service
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.DiscoveredGroupId
+import scaladex.core.model.IndexCursor
+import scaladex.core.service.MavenCentralIndexClient
+import scaladex.core.service.SchedulerDatabase
+import scaladex.core.util.ScalaExtensions.*
+
+import com.typesafe.scalalogging.LazyLogging
+
+/** Finds Scala group IDs newly published to Maven Central by reading the nexus incremental index, then auto-indexes
+  * each one through the existing `MavenCentralService.syncOne`. Every discovered group ID is recorded in
+  * `discovered_group_id` for the admin review queue. See `doc/dev/maven-central-discovery.md`.
+  */
+class DiscoveryService(
+    database: SchedulerDatabase,
+    indexClient: MavenCentralIndexClient,
+    syncGroupId: Artifact.GroupId => Future[String]
+)(using ExecutionContext)
+    extends LazyLogging:
+
+  // never pull more than this many ~40 MB chunks in one run (a long outage would otherwise be multi-GB)
+  private val maxChunksPerRun = 8
+  // cap how many freshly-discovered group IDs we sync per run, so a burst can't hammer Maven Central
+  private val syncBatchSize = 10
+
+  def discover(): Future[String] = for
+    remote <- indexClient.fetchRemoteCursor()
+    localOpt <- database.getMavenIndexCursor()
+    from = resolveFrom(localOpt, remote)
+    result <-
+      if from.lastIncremental >= remote.lastIncremental then
+        Future.successful(MavenCentralIndexClient.Result(Nil, from.lastIncremental))
+      else indexClient.recordsSince(from, remote, maxChunksPerRun)(r => isScalaArtifact(r.artifactId))
+    newGroupIds <- selectNewGroupIds(result.records)
+    now = Instant.now
+    inserted <- database.insertDiscoveredGroupIds(
+      newGroupIds.map(g => DiscoveredGroupId.pending(DiscoveredGroupId.Source.MavenIndex, g, now))
+    )
+    // advance only to the last chunk actually read; a failed chunk keeps its records in scope for the next run
+    _ <- database.setMavenIndexCursor(IndexCursor(remote.chainId, result.reachedIncremental))
+    synced <- syncPending()
+  yield s"Discovered $inserted new group IDs from ${result.records.size} Scala records; synced $synced"
+
+  /** If the remote chain was rebuilt, or we have no cursor yet, start from "now" (remote.lastIncremental - 1) rather
+    * than downloading the 3.2 GB full index.
+    */
+  private def resolveFrom(localOpt: Option[IndexCursor], remote: IndexCursor): IndexCursor = localOpt match
+    case Some(local) if local.chainId == remote.chainId => local
+    case Some(local) =>
+      logger.warn(s"Maven index chain changed (${local.chainId} -> ${remote.chainId}); skipping the gap")
+      IndexCursor(remote.chainId, remote.lastIncremental - 1)
+    case None =>
+      logger.info("No Maven index cursor yet; starting from the latest chunk")
+      IndexCursor(remote.chainId, remote.lastIncremental - 1)
+
+  private def isScalaArtifact(artifactId: String): Boolean =
+    val parsed = Artifact.ArtifactId(artifactId)
+    parsed.isScala && parsed.binaryVersion.isValid
+
+  private def selectNewGroupIds(records: Seq[MavenCentralIndexClient.Record]): Future[Seq[Artifact.GroupId]] =
+    val candidates = records.iterator.filterNot(_.deleted).map(_.groupId).distinct.map(Artifact.GroupId.apply).toSeq
+    for
+      known <- database.getGroupIds().map(_.toSet)
+      recorded <- database.getAllDiscoveredGroupIds().map(_.map(_.groupId).toSet)
+    yield candidates.filterNot(known).filterNot(recorded)
+
+  // oldest first, so a backlog drains in publish order instead of starving early entries
+  private def syncPending(): Future[Int] = for
+    pending <- database.getPendingDiscoveredGroupIdsToSync(syncBatchSize)
+    _ <- pending.mapSync(syncAndRecord)
+  yield pending.size
+
+  private def syncAndRecord(discovered: DiscoveredGroupId): Future[Unit] =
+    val synced = for
+      summary <- syncGroupId(discovered.groupId)
+      refs <- database.getProjectRefsByGroupId(discovered.groupId)
+      _ <- database.updateDiscoveredGroupIdSync(discovered.groupId, Instant.now, summary, refs)
+    yield ()
+    synced.recoverWith:
+      case NonFatal(e) =>
+        // record the error but leave last_synced_at unset so the next run retries this group
+        logger.warn(s"Failed to sync discovered group ${discovered.groupId.value}, will retry: ${e.getMessage}")
+        database.updateDiscoveredGroupIdError(discovered.groupId, s"error: ${e.getMessage}")
+  end syncAndRecord
+end DiscoveryService

--- a/modules/server/src/main/scala/scaladex/server/service/DiscoveryService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/DiscoveryService.scala
@@ -49,6 +49,20 @@ class DiscoveryService(
     synced <- syncPending()
   yield s"Discovered $inserted new group IDs from ${result.records.size} Scala records; synced $synced"
 
+  /** Rewind the cursor so the next `discover()` re-scans the last `chunksBack` chunks (capped at `maxChunksPerRun`).
+    * Admin action for backfilling after a deploy or a missed chunk.
+    */
+  def rewindCursor(chunksBack: Int): Future[String] =
+    indexClient
+      .fetchRemoteCursor()
+      .flatMap: remote =>
+        val target = IndexCursor(remote.chainId, math.max(0, remote.lastIncremental - chunksBack))
+        database
+          .setMavenIndexCursor(target)
+          .map: _ =>
+            s"Cursor set to chunk ${target.lastIncremental} (remote is ${remote.lastIncremental}); " +
+              s"the next discovery run will re-scan up to $maxChunksPerRun chunks"
+
   /** If the remote chain was rebuilt, or we have no cursor yet, start from "now" (remote.lastIncremental - 1) rather
     * than downloading the 3.2 GB full index.
     */

--- a/modules/server/src/test/scala/scaladex/server/route/AdminPagePreview.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/AdminPagePreview.scala
@@ -1,0 +1,75 @@
+package scaladex.server.route
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.DiscoveredGroupId
+import scaladex.core.model.Env
+import scaladex.core.model.GithubInfo
+import scaladex.core.model.Project
+import scaladex.core.test.MockGithubAuth
+
+import org.scalatest.funspec.AnyFunSpec
+
+/** Not a real test: renders the admin page with synthetic discovery data to an HTML file so the panel can be eyeballed
+  * without the full stack. Set `-Dscaladex.admin.preview=/path/to/out.html`.
+  */
+class AdminPagePreview extends AnyFunSpec:
+  it("renders the admin page to an html file") {
+    // opt-in only: skipped in CI, run with `-Dscaladex.admin.preview=/path/out.html`
+    val out = sys.props.getOrElse("scaladex.admin.preview", cancel("set -Dscaladex.admin.preview to render"))
+
+    def project(org: String, repo: String, stars: Int, scalaPct: Int): Project =
+      Project.default(
+        Project.Reference.from(org, repo),
+        githubInfo = Some(GithubInfo.empty.copy(stars = Some(stars), scalaPercentage = Some(scalaPct)))
+      )
+
+    val now = Instant.now
+    def discovered(
+        groupId: String,
+        ageHours: Long,
+        summary: Option[String],
+        projects: Seq[Project]
+    ): DiscoveredGroupId.View =
+      val d = DiscoveredGroupId
+        .pending(DiscoveredGroupId.Source.MavenIndex, Artifact.GroupId(groupId), now.minus(ageHours, ChronoUnit.HOURS))
+        .copy(
+          lastSyncedAt = summary.map(_ => now.minus(ageHours - 1, ChronoUnit.HOURS)),
+          syncSummary = summary,
+          projectRefs = projects.map(_.reference)
+        )
+      DiscoveredGroupId.View(d, projects)
+    end discovered
+
+    val views = Seq(
+      discovered(
+        "dev.valentiay",
+        6,
+        Some("Inserted 29 poms"),
+        Seq(project("valentiay", "phobos", 41, 96))
+      ),
+      discovered(
+        "com.softwaremill.sttp.ai",
+        14,
+        Some("Inserted 12 poms"),
+        Seq(project("softwaremill", "sttp-ai", 73, 99))
+      ),
+      discovered("io.github.zyblw", 20, Some("github repository not found"), Nil),
+      discovered("org.mongo4s", 30, None, Nil)
+    )
+
+    val html = scaladex.view.admin.html.admin(
+      Env.Local,
+      MockGithubAuth.Admin.userState,
+      jobs = Nil,
+      tasks = Nil,
+      discovered = views
+    )
+    Files.writeString(Paths.get(out), html.body)
+    info(s"wrote $out")
+  }
+end AdminPagePreview

--- a/modules/server/src/test/scala/scaladex/server/service/DiscoveryServiceTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/service/DiscoveryServiceTests.scala
@@ -1,0 +1,120 @@
+package scaladex.server.service
+
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.DiscoveredGroupId
+import scaladex.core.model.IndexCursor
+import scaladex.core.service.MavenCentralIndexClient
+import scaladex.core.service.MavenCentralIndexClient.Record
+import scaladex.core.service.MavenCentralIndexClient.Result
+import scaladex.core.test.InMemoryDatabase
+import scaladex.core.test.Values
+
+import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiscoveryServiceTests extends AsyncFunSpec with Matchers:
+  given ExecutionContext = ExecutionContext.global
+
+  class StubIndexClient(remote: IndexCursor, records: Seq[Record], reached: Option[Int] = None)
+      extends MavenCentralIndexClient:
+    def fetchRemoteCursor(): Future[IndexCursor] = Future.successful(remote)
+    def recordsSince(from: IndexCursor, to: IndexCursor, maxChunks: Int)(keep: Record => Boolean): Future[Result] =
+      Future.successful(Result(records.filter(keep), reached.getOrElse(to.lastIncremental)))
+
+  private def service(
+      db: InMemoryDatabase,
+      client: MavenCentralIndexClient,
+      synced: collection.mutable.Buffer[String]
+  ) =
+    new DiscoveryService(
+      db,
+      client,
+      groupId =>
+        synced += groupId.value
+        Future.successful(s"Inserted 1 poms")
+    )
+
+  it("records and syncs only unknown Scala group IDs") {
+    val db = new InMemoryDatabase
+    db.insertArtifacts(Seq(Values.Scalafix.artifact)) // ch.epfl.scala already indexed
+
+    val client = new StubIndexClient(
+      IndexCursor("chain-1", 100),
+      Seq(
+        Record("ch.epfl.scala", "scalafix-core_2.13", "0.9.31", deleted = false), // known group
+        Record("dev.new", "lib_3", "1.0.0", deleted = false), // new, Scala
+        Record("dev.new", "lib_sjs1_3", "1.0.0", deleted = false), // same new group
+        Record("com.java", "tool", "1.0.0", deleted = false), // not Scala
+        Record("dev.deleted", "gone_3", "1.0.0", deleted = true) // deleted -> ignored
+      )
+    )
+    val synced = collection.mutable.Buffer.empty[String]
+
+    for
+      message <- service(db, client, synced).discover()
+      discovered <- db.getAllDiscoveredGroupIds()
+      cursor <- db.getMavenIndexCursor()
+    yield
+      discovered.map(_.groupId.value) shouldBe Seq("dev.new")
+      synced.toSeq shouldBe Seq("dev.new")
+      discovered.head.syncSummary shouldBe Some("Inserted 1 poms")
+      discovered.head.lastSyncedAt shouldBe defined
+      cursor.map(_.chainId) shouldBe Some("chain-1")
+      message should include("Discovered 1")
+    end for
+  }
+
+  it("does not re-surface a rejected group ID") {
+    val db = new InMemoryDatabase
+    val rejected = DiscoveredGroupId
+      .pending(DiscoveredGroupId.Source.MavenIndex, Artifact.GroupId("dev.rejected"), Instant.now)
+      .copy(status = DiscoveredGroupId.Status.Rejected)
+    db.insertDiscoveredGroupIds(Seq(rejected))
+
+    val client = new StubIndexClient(
+      IndexCursor("chain-1", 50),
+      Seq(Record("dev.rejected", "lib_3", "2.0.0", deleted = false))
+    )
+    val synced = collection.mutable.Buffer.empty[String]
+
+    for _ <- service(db, client, synced).discover()
+    yield synced shouldBe empty
+  }
+
+  it("advances the cursor only to the last chunk actually read") {
+    val db = new InMemoryDatabase
+    // remote is at 100, but the client only got through chunk 96 before a chunk failed
+    val client = new StubIndexClient(
+      IndexCursor("chain-1", 100),
+      Seq(Record("dev.partial", "lib_3", "1.0.0", deleted = false)),
+      reached = Some(96)
+    )
+    for
+      _ <- service(db, client, collection.mutable.Buffer.empty[String]).discover()
+      cursor <- db.getMavenIndexCursor()
+    yield cursor shouldBe Some(IndexCursor("chain-1", 96))
+  }
+
+  it("keeps a group retryable when its sync fails") {
+    val db = new InMemoryDatabase
+    val client = new StubIndexClient(
+      IndexCursor("chain-1", 10),
+      Seq(Record("dev.flaky", "lib_3", "1.0.0", deleted = false))
+    )
+    val failing = new DiscoveryService(db, client, _ => Future.failed(new RuntimeException("503 rate limited")))
+    for
+      _ <- failing.discover()
+      discovered <- db.getAllDiscoveredGroupIds()
+      pending <- db.getPendingDiscoveredGroupIdsToSync(10)
+    yield
+      discovered.head.lastSyncedAt shouldBe None
+      discovered.head.syncSummary.getOrElse("") should include("503")
+      discovered.head.status shouldBe DiscoveredGroupId.Status.Pending
+      pending.map(_.groupId.value) shouldBe Seq("dev.flaky") // still in the sync queue
+  }
+end DiscoveryServiceTests

--- a/modules/server/src/test/scala/scaladex/server/service/DiscoveryServiceTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/service/DiscoveryServiceTests.scala
@@ -117,4 +117,18 @@ class DiscoveryServiceTests extends AsyncFunSpec with Matchers:
       discovered.head.status shouldBe DiscoveredGroupId.Status.Pending
       pending.map(_.groupId.value) shouldBe Seq("dev.flaky") // still in the sync queue
   }
+
+  it("rewindCursor sets the cursor back by N chunks (clamped at 0)") {
+    val db = new InMemoryDatabase
+    val client = new StubIndexClient(IndexCursor("chain-1", 100), Nil)
+    val svc = service(db, client, collection.mutable.Buffer.empty[String])
+    for
+      _ <- svc.rewindCursor(8)
+      after8 <- db.getMavenIndexCursor()
+      _ <- svc.rewindCursor(500)
+      afterClamp <- db.getMavenIndexCursor()
+    yield
+      after8 shouldBe Some(IndexCursor("chain-1", 92))
+      afterClamp shouldBe Some(IndexCursor("chain-1", 0))
+  }
 end DiscoveryServiceTests

--- a/modules/template/src/main/scala/scaladex/view/Job.scala
+++ b/modules/template/src/main/scala/scaladex/view/Job.scala
@@ -49,6 +49,12 @@ object Job:
     "Find missing non-standard artifacts from Maven Central",
     2.hours
   )
+
+  val discoverMavenNamespaces: Job = Job(
+    "discover-maven-namespaces",
+    "Find new Scala group IDs on Maven Central via the nexus index, then auto-index them.",
+    12.hours
+  )
   val latestArtifacts: Job = Job(
     "latest-artifacts",
     "Update latest version of artifacts",

--- a/modules/template/src/main/scala/scaladex/view/Task.scala
+++ b/modules/template/src/main/scala/scaladex/view/Task.scala
@@ -29,6 +29,11 @@ object Task:
     "Re-download pom files of known artifacts to extract new fields"
   )
 
+  val rewindDiscoveryCursor: Task = Task(
+    "rewind-discovery-cursor",
+    "Rewind the Maven Central index cursor so the next discovery run re-scans the last N chunks."
+  )
+
   case class Status(name: String, user: String, start: Instant, input: Seq[(String, String)], state: State):
     def fromNow: FiniteDuration = TimeUtils.toFiniteDuration(start, Instant.now())
 

--- a/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
@@ -131,6 +131,21 @@
             <td><button type="submit" class="btn btn-primary">Submit</button></td>
           </form>
         </tr>
+        <tr>
+          <td>
+            <h5>@Task.rewindDiscoveryCursor.name</h5>
+            <p>@Task.rewindDiscoveryCursor.description</p>
+          </td>
+          <form action="/admin/tasks/@Task.rewindDiscoveryCursor.name" method="POST">
+            <td>
+              <div class="input-group">
+                <span class="input-group-addon" id="chunks-back">Chunks back</span>
+                <input type="number" class="form-control" name="chunks-back" min="0" max="8" value="8">
+              </div>
+            </td>
+            <td><button type="submit" class="btn btn-primary">Submit</button></td>
+          </form>
+        </tr>
       </tbody>
     </table>
     <h2>Discovered projects (review queue)</h2>

--- a/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/admin/admin.scala.html
@@ -3,9 +3,10 @@
 @import scaladex.view.html._
 @import scaladex.core.model.UserState
 @import scaladex.core.model.Env
+@import scaladex.core.model.DiscoveredGroupId
 @import scaladex.core.util.ScalaExtensions._
 
-@(env: Env, user: UserState, jobs: Seq[(Job, Job.Status)], tasks: Seq[Task.Status])
+@(env: Env, user: UserState, jobs: Seq[(Job, Job.Status)], tasks: Seq[Task.Status], discovered: Seq[DiscoveredGroupId.View])
 @main(env, title = "Admin page", Some(user)) {
   <div class="container admin-content">
     <h2>Background jobs</h2>
@@ -132,6 +133,69 @@
         </tr>
       </tbody>
     </table>
+    <h2>Discovered projects (review queue)</h2>
+    <p>
+      Group IDs found on Maven Central by the <code>discover-maven-namespaces</code> job and auto-indexed.
+      Nothing is filtered out &mdash; use this list to sanity-check what came in.
+      <strong>Reviewed</strong> just clears the row; <strong>Reject</strong> also stops the group ID from being surfaced again.
+    </p>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Group ID</th>
+          <th scope="col">Discovered</th>
+          <th scope="col">Sync result</th>
+          <th scope="col">Projects</th>
+          <th scope="col">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        @if(discovered.isEmpty) {
+          <tr><td colspan="5"><em>Nothing to review.</em></td></tr>
+        }
+        @discovered.map { view =>
+          <tr>
+            <td>
+              <a href="https://central.sonatype.com/namespace/@view.discovered.groupId.value" target="_blank" rel="noopener">
+                @view.discovered.groupId.value
+              </a>
+              <br/><small>via @view.discovered.source</small>
+            </td>
+            <td><small>@view.discovered.discoveredAt.toString</small></td>
+            <td>
+              <small>@view.discovered.syncSummary.getOrElse("not synced yet")</small>
+            </td>
+            <td>
+              @if(view.projects.isEmpty) {
+                <small>&mdash;</small>
+              }
+              @view.projects.map { project =>
+                <div>
+                  <a href="/@project.reference.organization/@project.reference.repository">@project.reference</a>
+                  @project.githubInfo.map { gh =>
+                    <small>
+                      &#9733; @gh.stars.getOrElse(0)
+                      @gh.scalaPercentage.map(p => s"· Scala $p%").getOrElse("")
+                    </small>
+                  }
+                </div>
+              }
+            </td>
+            <td>
+              <form action="/admin/discovered/@view.discovered.groupId.value/review" method="post" style="display:inline">
+                <input type="hidden" name="decision" value="reviewed"/>
+                <button type="submit" class="btn btn-success btn-sm">Reviewed</button>
+              </form>
+              <form action="/admin/discovered/@view.discovered.groupId.value/review" method="post" style="display:inline">
+                <input type="hidden" name="decision" value="reject"/>
+                <button type="submit" class="btn btn-danger btn-sm">Reject</button>
+              </form>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
     <h2>Task History</h2>
     <table class="table">
       <thead>


### PR DESCRIPTION
Scaladex had no way to find group IDs newly published to Maven Central: the periodic jobs only re-scan group IDs already in the artifacts table, and the old Sonatype post-deploy webhook no longer fires for Central Portal publishers (new namespace registration moved off it from 2024-02-01; e.g. com.halotukozak never appeared).

Adds a discovery stage that reads the Maven Central nexus incremental index (`.index/*.N.gz`), keeps a cursor, filters for Scala binary versions, and auto-indexes each new namespace through the existing `MavenCentralService.syncOne` (no filtering, matching the old publish-webhook behaviour).

- Starts from chunk 0 (the chain goes back to 2012-06-15) rather than only "from now on", so the gap left by the OSSRH→Central Portal migration gets backfilled too.
- No per-run cap on chunks or groups synced — a run pulls everything currently available. Pacing is entirely the shared, cross-client throttle on `CommonAkkaHttpClient` (same instance now used by both Maven Central clients), so a large backlog drains at the throttled request rate instead of trickling in over many scheduled runs.
- `discovered_group_id` tracks dedup + sync-retry bookkeeping only — there's no admin review queue. It never actually gated indexing (a group auto-syncs in the same run it's discovered, before any human could act on it), so it was pure maintenance with no real control; removed per review feedback rather than trying to make it cheaper to operate.
- New job `discover-maven-namespaces`, 12h frequency.