### PR TITLE
extend REST API v1 with search, dependencies and project settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val infra = project
       "com.github.pjfanning" %% "pekko-http-circe" % "3.9.2",
       ("io.get-coursier" %% "coursier" % V.coursier).cross(CrossVersion.for3Use2_13),
       ("io.get-coursier" %% "coursier-sbt-maven-repository" % V.coursier).cross(CrossVersion.for3Use2_13),
-      "com.github.blemale" %% "scaffeine" % "5.3.0",
+      "com.github.blemale" %% "scaffeine" % V.scaffeine,
       "org.tpolecat" %% "doobie-core" % V.doobie,
       "org.tpolecat" %% "doobie-h2" % V.doobie,
       "org.tpolecat" %% "doobie-postgres" % V.doobie,
@@ -164,7 +164,7 @@ lazy val server = project
       "org.apache.pekko" %% "pekko-http-testkit" % V.pekkoHttp % Test,
       "org.apache.pekko" %% "pekko-http-cors" % V.pekkoHttp,
       "com.softwaremill.pekko-http-session" %% "core" % "0.7.1",
-      "com.github.blemale" %% "scaffeine" % "5.3.0",
+      "com.github.blemale" %% "scaffeine" % V.scaffeine,
       "org.apache.pekko" %% "pekko-http" % V.pekkoHttp,
       "org.endpoints4s" %% "pekko-http-server" % "2.0.1",
       "org.webjars" % "bootstrap-sass" % "3.4.1",
@@ -257,4 +257,5 @@ lazy val V = new {
   val json4s = "4.1.1"
   val coursier = "2.1.24"
   val gatling = "3.15.1"
+  val scaffeine = "5.3.0"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -164,6 +164,7 @@ lazy val server = project
       "org.apache.pekko" %% "pekko-http-testkit" % V.pekkoHttp % Test,
       "org.apache.pekko" %% "pekko-http-cors" % V.pekkoHttp,
       "com.softwaremill.pekko-http-session" %% "core" % "0.7.1",
+      "com.github.blemale" %% "scaffeine" % "5.3.0",
       "org.apache.pekko" %% "pekko-http" % V.pekkoHttp,
       "org.endpoints4s" %% "pekko-http-server" % "2.0.1",
       "org.webjars" % "bootstrap-sass" % "3.4.1",

--- a/modules/core/shared/src/main/scala/scaladex/core/api/Endpoints.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/Endpoints.scala
@@ -1,10 +1,18 @@
 package scaladex.core.api
 
 import scaladex.core.model.*
+import scaladex.core.model.search.Page
+import scaladex.core.model.search.PageParams
 
 import endpoints4s.Validated
+import endpoints4s.algebra.BasicAuthentication
+import endpoints4s.algebra.BasicAuthentication.Credentials
 
-trait Endpoints extends JsonSchemas with endpoints4s.algebra.Endpoints with endpoints4s.algebra.JsonEntitiesFromSchemas:
+trait Endpoints
+    extends JsonSchemas
+    with endpoints4s.algebra.Endpoints
+    with endpoints4s.algebra.JsonEntitiesFromSchemas
+    with BasicAuthentication:
 
   val v0 = None
   val v1: Some[String] = Some("v1")
@@ -30,11 +38,16 @@ trait Endpoints extends JsonSchemas with endpoints4s.algebra.Endpoints with endp
 
   private val projectVersionsPath: Path[Project.Reference] = projectPath / "versions"
   private val projectArtifactsPath: Path[Project.Reference] = projectPath / "artifacts"
+  private val projectSettingsPath: Path[Project.Reference] = projectPath / "settings"
+  private val projectDependenciesPath: Path[Project.Reference] = projectPath / "dependencies"
+  private val projectDependentsPath: Path[Project.Reference] = projectPath / "dependents"
+  private val usersPath: Path[Unit] = staticPathSegment("users")
 
   private val artifactPath: Path[Artifact.Reference] =
     (artifactsPath / groupIdSegment / artifactIdSegment / versionSegment)
       .xmap((Artifact.Reference.apply _).tupled)(Tuple.fromProductTyped)
 
+  private given QueryStringParam[Version] = stringQueryString.xmap(Version(_))(_.value)
   private given QueryStringParam[Platform] = stringQueryString
     .xmapPartial(v => Validated.fromOption(Platform.parse(v))(s"Cannot parse $v"))(_.value)
   private given QueryStringParam[Language] = stringQueryString
@@ -90,6 +103,24 @@ trait Endpoints extends JsonSchemas with endpoints4s.algebra.Endpoints with endp
     (binaryVersionFilter & artifactNameFilter & stableOnlyFilter)
       .xmap((ProjectArtifactsParams.apply _).tupled)(Tuple.fromProductTyped)
 
+  private val versionFilter: QueryString[Option[Version]] =
+    qs[Option[Version]]("version", Some("Version of the project to resolve dependencies for. Default is the latest."))
+
+  private val pageParams: QueryString[PageParams] =
+    (qs[Option[Int]]("page", Some("Page number, starting at 1. (Default is 1)")) &
+      qs[Option[Int]]("size", Some(s"Number of items per page, 1 to ${PageParams.MaxSize}. (Default is 20)")))
+      .xmap { case (page, size) => PageParams.bounded(page.getOrElse(1), size.getOrElse(20)) } { params =>
+        (Some(params.page), Some(params.size))
+      }
+
+  private val projectSearchParams: QueryString[ProjectSearchParams] = (
+    qs[Option[String]]("q", Some("Main query (e.g., 'json', 'testing', etc.)")).xmap(_.getOrElse("*"))(Some(_)) &
+      qs[Seq[String]]("topic", Some("Filter on Github topics")) &
+      languageFilters &
+      platformFilters &
+      qs[Option[String]]("sort", qsDoc("Sort results", Seq("stars", "commit-activity", "contributors", "dependent")))
+  ).xmap((ProjectSearchParams.apply _).tupled)(Tuple.fromProductTyped)
+
   private val autocompletionParams: QueryString[AutocompletionParams] = (
     qs[String]("q", docs = Some("Main query (e.g., 'json', 'testing', etc.)")) &
       qs[Seq[String]]("topic", docs = Some("Filter on Github topics")) &
@@ -144,6 +175,53 @@ trait Endpoints extends JsonSchemas with endpoints4s.algebra.Endpoints with endp
 
   val autocomplete: Endpoint[AutocompletionParams, Seq[AutocompletionResponse]] =
     endpoint(get(root / "autocomplete" /? autocompletionParams), ok(jsonResponse[Seq[AutocompletionResponse]]))
+
+  val searchProjectsV1: Endpoint[(ProjectSearchParams, PageParams), Page[SearchResult]] =
+    endpoint(
+      get(api(v1) / "search" /? (projectSearchParams & pageParams)),
+      ok(jsonResponse[Page[SearchResult]])
+    )
+
+  val getProjectDependenciesV1
+      : Endpoint[(Project.Reference, Option[Version], PageParams), Option[Page[ProjectDependency]]] =
+    endpoint(
+      get(api(v1) / projectDependenciesPath /? (versionFilter & pageParams)),
+      ok(jsonResponse[Page[ProjectDependency]]).orNotFound()
+    )
+
+  val getProjectDependentsV1: Endpoint[(Project.Reference, PageParams), Option[Page[ProjectDependency]]] =
+    endpoint(
+      get(api(v1) / projectDependentsPath /? pageParams),
+      ok(jsonResponse[Page[ProjectDependency]]).orNotFound()
+    )
+
+  /** `GET /api/v1/users/me` — information about the user authenticated by the
+    * `Authorization: Basic token:<github-token>` header. Returns 401 if no credentials are provided, 403 if the token
+    * is invalid.
+    */
+  val getAuthenticatedUserV1: Endpoint[Credentials, Option[UserResponse]] =
+    authenticatedEndpoint(Get, api(v1) / usersPath / "me", ok(jsonResponse[UserResponse]))
+
+  /** `GET /api/v1/projects/{org}/{repo}/settings` — current settings of the project. Requires edit permission on the
+    * project (403 otherwise), 404 if the project is unknown.
+    */
+  val getProjectSettingsV1: Endpoint[(Project.Reference, Credentials), Option[Option[Project.Settings]]] =
+    authenticatedEndpoint(Get, api(v1) / projectSettingsPath, ok(jsonResponse[Project.Settings]).orNotFound())
+
+  /** `PATCH /api/v1/projects/{org}/{repo}/settings` — partial update of the project settings. Requires edit permission
+    * on the project (403 otherwise), 404 if the project is unknown.
+    *
+    * The update is read-modify-write with no optimistic locking, so two patches racing on the same project can lose an
+    * update. This matches the web settings form and is acceptable given how rarely a single project is edited
+    * concurrently.
+    */
+  val patchProjectSettingsV1: Endpoint[(Project.Reference, ProjectSettingsPatch, Credentials), Option[Option[Unit]]] =
+    authenticatedEndpoint(
+      Patch,
+      api(v1) / projectSettingsPath,
+      ok(emptyResponse).orNotFound(),
+      requestEntity = jsonRequest[ProjectSettingsPatch]
+    )
 
   private def qsDoc(desc: String, examples: Seq[String]): Some[String] =
     Some(

--- a/modules/core/shared/src/main/scala/scaladex/core/api/Endpoints.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/Endpoints.scala
@@ -4,6 +4,8 @@ import scaladex.core.model.*
 import scaladex.core.model.search.Page
 import scaladex.core.model.search.PageParams
 
+import endpoints4s.Invalid
+import endpoints4s.Valid
 import endpoints4s.Validated
 import endpoints4s.algebra.BasicAuthentication
 import endpoints4s.algebra.BasicAuthentication.Credentials
@@ -108,10 +110,19 @@ trait Endpoints
 
   private val pageParams: QueryString[PageParams] =
     (qs[Option[Int]]("page", Some("Page number, starting at 1. (Default is 1)")) &
-      qs[Option[Int]]("size", Some(s"Number of items per page, 1 to ${PageParams.MaxSize}. (Default is 20)")))
-      .xmap { case (page, size) => PageParams.bounded(page.getOrElse(1), size.getOrElse(20)) } { params =>
-        (Some(params.page), Some(params.size))
-      }
+      qs[Option[Int]](
+        "size",
+        Some(
+          s"Number of items per page, one of ${PageParams.AllowedSizes.mkString(", ")}. (Default is ${PageParams.DefaultSize})"
+        )
+      ))
+      .xmapPartial {
+        case (page, size) =>
+          val resolvedSize = size.getOrElse(PageParams.DefaultSize)
+          if PageParams.AllowedSizes.contains(resolvedSize) then
+            Valid(PageParams(page.getOrElse(1).max(1), resolvedSize))
+          else Invalid(s"size must be one of ${PageParams.AllowedSizes.mkString(", ")}")
+      } { params => (Some(params.page), Some(params.size)) }
 
   private val projectSearchParams: QueryString[ProjectSearchParams] = (
     qs[Option[String]]("q", Some("Main query (e.g., 'json', 'testing', etc.)")).xmap(_.getOrElse("*"))(Some(_)) &
@@ -195,26 +206,14 @@ trait Endpoints
       ok(jsonResponse[Page[ProjectDependency]]).orNotFound()
     )
 
-  /** `GET /api/v1/users/me` — information about the user authenticated by the
-    * `Authorization: Basic token:<github-token>` header. Returns 401 if no credentials are provided, 403 if the token
-    * is invalid.
-    */
   val getAuthenticatedUserV1: Endpoint[Credentials, Option[UserResponse]] =
     authenticatedEndpoint(Get, api(v1) / usersPath / "me", ok(jsonResponse[UserResponse]))
 
-  /** `GET /api/v1/projects/{org}/{repo}/settings` — current settings of the project. Requires edit permission on the
-    * project (403 otherwise), 404 if the project is unknown.
-    */
   val getProjectSettingsV1: Endpoint[(Project.Reference, Credentials), Option[Option[Project.Settings]]] =
     authenticatedEndpoint(Get, api(v1) / projectSettingsPath, ok(jsonResponse[Project.Settings]).orNotFound())
 
-  /** `PATCH /api/v1/projects/{org}/{repo}/settings` — partial update of the project settings. Requires edit permission
-    * on the project (403 otherwise), 404 if the project is unknown.
-    *
-    * The update is read-modify-write with no optimistic locking, so two patches racing on the same project can lose an
-    * update. This matches the web settings form and is acceptable given how rarely a single project is edited
-    * concurrently.
-    */
+  // Read-modify-write with no optimistic locking: two patches racing on the same project can lose an update, same as
+  // the web settings form.
   val patchProjectSettingsV1: Endpoint[(Project.Reference, ProjectSettingsPatch, Credentials), Option[Option[Unit]]] =
     authenticatedEndpoint(
       Patch,

--- a/modules/core/shared/src/main/scala/scaladex/core/api/JsonSchemas.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/JsonSchemas.scala
@@ -3,7 +3,11 @@ package scaladex.core.api
 import java.time.Instant
 
 import scaladex.core.model.*
+import scaladex.core.model.search.Page
+import scaladex.core.model.search.Pagination
 
+import endpoints4s.Invalid
+import endpoints4s.Valid
 import endpoints4s.Validated
 
 /** The Json schema of the Scaladex API
@@ -38,7 +42,7 @@ trait JsonSchemas extends endpoints4s.algebra.JsonSchemas:
     field[Artifact.GroupId]("groupId")
       .zip(field[Artifact.ArtifactId]("artifactId"))
       .zip(field[Version]("version"))
-      .xmap((Artifact.Reference.apply _).tupled)(Tuple.fromProductTyped)
+      .xmap(Artifact.Reference.apply)(Tuple.fromProductTyped)
 
   given JsonSchema[DocumentationPattern] =
     field[String]("label")
@@ -65,7 +69,7 @@ trait JsonSchemas extends endpoints4s.algebra.JsonSchemas:
       .zip(field[Set[Artifact.Name]]("cliArtifacts"))
       .zip(optField[Category]("category"))
       .zip(optField[String]("chatroom"))
-      .xmap((ProjectResponse.apply _).tupled)(Tuple.fromProductTyped)
+      .xmap(ProjectResponse.apply)(Tuple.fromProductTyped)
 
   given JsonSchema[ArtifactResponse] =
     field[Artifact.GroupId]("groupId")
@@ -78,7 +82,81 @@ trait JsonSchemas extends endpoints4s.algebra.JsonSchemas:
       .zip(field[Project.Reference]("project"))
       .zip(field[Instant]("releaseDate"))
       .zip(field[Seq[License]]("licenses"))
-      .xmap((ArtifactResponse.apply _).tupled)(Tuple.fromProductTyped)
+      .xmap(ArtifactResponse.apply)(Tuple.fromProductTyped)
+
+  given JsonSchema[ArtifactDependency.Scope] =
+    stringJson.xmap(ArtifactDependency.Scope(_))(_.value)
+
+  given JsonSchema[ProjectDependency] =
+    field[Project.Reference]("source")
+      .zip(field[Version]("sourceVersion"))
+      .zip(field[Project.Reference]("target"))
+      .zip(field[Version]("targetVersion"))
+      .zip(field[ArtifactDependency.Scope]("scope"))
+      .xmap(ProjectDependency.apply)(Tuple.fromProductTyped)
+
+  given JsonSchema[Pagination] =
+    field[Int]("current")
+      .zip(field[Int]("pageCount"))
+      .zip(field[Long]("totalSize"))
+      .xmap(Pagination.apply)(Tuple.fromProductTyped)
+
+  given pageJsonSchema[A](using JsonSchema[A]): JsonSchema[Page[A]] =
+    field[Pagination]("pagination")
+      .zip(field[Seq[A]]("items"))
+      .xmap { case (pagination, items) => Page(pagination, items) }(page => (page.pagination, page.items))
+
+  given JsonSchema[Project.Settings] =
+    field[Boolean]("preferStableVersion")
+      .zip(optField[Artifact.Name]("defaultArtifact"))
+      .zip(optField[String]("customScalaDoc"))
+      .zip(field[Seq[DocumentationPattern]]("documentationLinks"))
+      .zip(field[Boolean]("contributorsWanted"))
+      .zip(field[Set[Artifact.Name]]("deprecatedArtifacts"))
+      .zip(field[Set[Artifact.Name]]("cliArtifacts"))
+      .zip(optField[Category]("category"))
+      .zip(optField[String]("chatroom"))
+      .xmap(Project.Settings.apply)(Tuple.fromProductTyped)
+
+  given JsonSchema[ProjectSettingsPatch] =
+    optField[Boolean]("preferStableVersion")
+      .zip(optField[String]("defaultArtifact"))
+      .zip(optField[String]("customScalaDoc"))
+      .zip(optField[Seq[DocumentationPattern]]("documentationLinks"))
+      .zip(optField[Boolean]("contributorsWanted"))
+      .zip(optField[Seq[Artifact.Name]]("deprecatedArtifacts"))
+      .zip(optField[Seq[Artifact.Name]]("cliArtifacts"))
+      .zip(optField[String]("category"))
+      .zip(optField[String]("chatroom"))
+      .xmapPartial { tuple =>
+        val patch = ProjectSettingsPatch.apply.tupled(tuple)
+        ProjectSettingsPatch.invalidCategory(patch.category) match
+          case Some(label) => Invalid(s"Unknown category $label")
+          case None => Valid(patch)
+      }(Tuple.fromProductTyped)
+
+  given JsonSchema[UserResponse] =
+    field[String]("login")
+      .zip(optField[String]("name"))
+      .zip(field[String]("avatarUrl"))
+      .zip(field[Boolean]("isAdmin"))
+      .zip(field[Seq[Project.Organization]]("organizations"))
+      .zip(field[Seq[Project.Reference]]("repositories"))
+      .xmap(UserResponse.apply)(Tuple.fromProductTyped)
+
+  given JsonSchema[SearchResult] =
+    field[Project.Organization]("organization")
+      .zip(field[Project.Repository]("repository"))
+      .zip(optField[String]("description"))
+      .zip(optField[Int]("stars"))
+      .zip(optField[Int]("forks"))
+      .zip(field[Seq[String]]("topics"))
+      .zip(field[Seq[Language]]("languages"))
+      .zip(field[Seq[Platform]]("platforms"))
+      .zip(optField[Version]("latestVersion"))
+      .zip(field[Long]("dependents"))
+      .zip(optField[String]("category"))
+      .xmap(SearchResult.apply)(Tuple.fromProductTyped)
 
   given JsonSchema[AutocompletionResponse] =
     field[String]("organization")

--- a/modules/core/shared/src/main/scala/scaladex/core/api/ProjectSearchParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/ProjectSearchParams.scala
@@ -1,0 +1,22 @@
+package scaladex.core.api
+
+import scaladex.core.model.Language
+import scaladex.core.model.Platform
+import scaladex.core.model.search.SearchParams
+import scaladex.core.model.search.Sorting
+
+case class ProjectSearchParams(
+    query: String,
+    topics: Seq[String],
+    languages: Seq[Language],
+    platforms: Seq[Platform],
+    sort: Option[String]
+):
+  def toSearchParams: SearchParams = SearchParams(
+    queryString = query,
+    sorting = sort.flatMap(Sorting.byLabel.get).getOrElse(Sorting.Stars),
+    topics = topics,
+    languages = languages,
+    platforms = platforms
+  )
+end ProjectSearchParams

--- a/modules/core/shared/src/main/scala/scaladex/core/api/ProjectSettingsPatch.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/ProjectSettingsPatch.scala
@@ -1,0 +1,57 @@
+package scaladex.core.api
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.Category
+import scaladex.core.model.DocumentationPattern
+import scaladex.core.model.Project
+
+/** A partial update of [[Project.Settings]].
+  *
+  * Every field is optional: a field that is absent from the request is left unchanged. For the nullable fields
+  * (`defaultArtifact`, `customScalaDoc`, `category`, `chatroom`) an empty string clears the current value, mirroring
+  * the behaviour of the web settings form. A non-empty `category` must be a known category label (validated when the
+  * request is decoded).
+  */
+case class ProjectSettingsPatch(
+    preferStableVersion: Option[Boolean],
+    defaultArtifact: Option[String],
+    customScalaDoc: Option[String],
+    documentationLinks: Option[Seq[DocumentationPattern]],
+    contributorsWanted: Option[Boolean],
+    deprecatedArtifacts: Option[Seq[Artifact.Name]],
+    cliArtifacts: Option[Seq[Artifact.Name]],
+    category: Option[String],
+    chatroom: Option[String]
+):
+  def applyTo(settings: Project.Settings): Project.Settings =
+
+    settings.copy(
+      preferStableVersion = preferStableVersion.getOrElse(settings.preferStableVersion),
+      defaultArtifact = defaultArtifact match
+        case Some("") => None
+        case Some(name) => Some(Artifact.Name.apply(name))
+        case None => settings.defaultArtifact,
+      customScalaDoc = customScalaDoc match
+        case Some("") => None
+        case some: Some[String] => some
+        case None => settings.customScalaDoc,
+      documentationLinks = documentationLinks.getOrElse(settings.documentationLinks),
+      contributorsWanted = contributorsWanted.getOrElse(settings.contributorsWanted),
+      deprecatedArtifacts = deprecatedArtifacts.map(_.toSet).getOrElse(settings.deprecatedArtifacts),
+      cliArtifacts = cliArtifacts.map(_.toSet).getOrElse(settings.cliArtifacts),
+      category = category match
+        case Some("") => None
+        case Some(name) => Category.byLabel.get(name).orElse(settings.category)
+        case None => settings.category,
+      chatroom = chatroom match
+        case Some("") => None
+        case some: Some[String] => some
+        case None => settings.chatroom
+    )
+  end applyTo
+end ProjectSettingsPatch
+
+object ProjectSettingsPatch:
+  /** Returns the invalid category label, if `category` is present, non-empty and unknown. */
+  def invalidCategory(category: Option[String]): Option[String] =
+    category.filter(label => label.nonEmpty && !Category.byLabel.contains(label))

--- a/modules/core/shared/src/main/scala/scaladex/core/api/SearchResult.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/SearchResult.scala
@@ -1,0 +1,21 @@
+package scaladex.core.api
+
+import scaladex.core.model.Language
+import scaladex.core.model.Platform
+import scaladex.core.model.Project
+import scaladex.core.model.Version
+
+/** A single project matched by the search API. */
+case class SearchResult(
+    organization: Project.Organization,
+    repository: Project.Repository,
+    description: Option[String],
+    stars: Option[Int],
+    forks: Option[Int],
+    topics: Seq[String],
+    languages: Seq[Language],
+    platforms: Seq[Platform],
+    latestVersion: Option[Version],
+    dependents: Long,
+    category: Option[String]
+)

--- a/modules/core/shared/src/main/scala/scaladex/core/api/UserResponse.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/api/UserResponse.scala
@@ -1,0 +1,13 @@
+package scaladex.core.api
+
+import scaladex.core.model.Project
+
+/** Information about the user authenticated by the token passed in the request. */
+case class UserResponse(
+    login: String,
+    name: Option[String],
+    avatarUrl: String,
+    isAdmin: Boolean,
+    organizations: Seq[Project.Organization],
+    repositories: Seq[Project.Reference]
+)

--- a/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
@@ -7,3 +7,27 @@ case class ProjectDependency(
     targetVersion: Version,
     scope: ArtifactDependency.Scope
 )
+
+object ProjectDependency:
+  /** Reduces raw dependency rows to a single representative row per project on the given side (the depended-on project
+    * for direct dependencies, the dependent project for reverse ones), keeping the lowest scope and the highest source
+    * and target versions. This keeps a paginated list aligned with the distinct-project counts.
+    */
+  def collapseByProject(
+      rows: Seq[ProjectDependency],
+      side: ProjectDependency => Project.Reference
+  ): Seq[ProjectDependency] =
+    rows
+      .groupBy(side)
+      .values
+      .map { group =>
+        group
+          .minBy(_.scope)
+          .copy(
+            sourceVersion = group.map(_.sourceVersion).max,
+            targetVersion = group.map(_.targetVersion).max
+          )
+      }
+      .toSeq
+      .sortBy(dependency => (side(dependency).organization.value, side(dependency).repository.value))
+end ProjectDependency

--- a/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ProjectDependency.scala
@@ -9,10 +9,7 @@ case class ProjectDependency(
 )
 
 object ProjectDependency:
-  /** Reduces raw dependency rows to a single representative row per project on the given side (the depended-on project
-    * for direct dependencies, the dependent project for reverse ones), keeping the lowest scope and the highest source
-    * and target versions. This keeps a paginated list aligned with the distinct-project counts.
-    */
+  /** Collapses rows to one per project on the given side, keeping the lowest scope and the highest versions. */
   def collapseByProject(
       rows: Seq[ProjectDependency],
       side: ProjectDependency => Project.Reference

--- a/modules/core/shared/src/main/scala/scaladex/core/model/search/PageParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/search/PageParams.scala
@@ -1,3 +1,13 @@
 package scaladex.core.model.search
 
 final case class PageParams(page: Int, size: Int)
+
+object PageParams:
+  val MaxSize: Int = 100
+
+  /** Builds [[PageParams]] with `page` forced to at least 1 and `size` clamped to `[1, MaxSize]`, so that callers
+    * cannot trigger negative/huge SQL `LIMIT`/`OFFSET` or nonsensical pagination metadata.
+    */
+  def bounded(page: Int, size: Int): PageParams =
+    PageParams(page.max(1), size.max(1).min(MaxSize))
+end PageParams

--- a/modules/core/shared/src/main/scala/scaladex/core/model/search/PageParams.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/search/PageParams.scala
@@ -3,11 +3,7 @@ package scaladex.core.model.search
 final case class PageParams(page: Int, size: Int)
 
 object PageParams:
-  val MaxSize: Int = 100
-
-  /** Builds [[PageParams]] with `page` forced to at least 1 and `size` clamped to `[1, MaxSize]`, so that callers
-    * cannot trigger negative/huge SQL `LIMIT`/`OFFSET` or nonsensical pagination metadata.
-    */
-  def bounded(page: Int, size: Int): PageParams =
-    PageParams(page.max(1), size.max(1).min(MaxSize))
+  // A small, fixed set of page sizes keeps the REST API cache-friendly under load.
+  val AllowedSizes: Seq[Int] = Seq(20, 50, 100)
+  val DefaultSize: Int = AllowedSizes.head
 end PageParams

--- a/modules/core/shared/src/main/scala/scaladex/core/service/ProjectService.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/ProjectService.scala
@@ -4,6 +4,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scaladex.core.model.*
+import scaladex.core.model.search.Page
+import scaladex.core.model.search.PageParams
+import scaladex.core.model.search.Pagination
 import scaladex.core.model.search.SearchParams
 
 class ProjectService(database: WebDatabase, searchEngine: SearchEngine)(using ExecutionContext):
@@ -57,6 +60,59 @@ class ProjectService(database: WebDatabase, searchEngine: SearchEngine)(using Ex
       (binaryVersions.isEmpty || binaryVersions.contains(a.binaryVersion)) &&
       (artifactNames.isEmpty || artifactNames.contains(a.name))
     }
+
+  def getSettings(ref: Project.Reference): Future[Option[Project.Settings]] =
+    database.getProject(ref).map(_.map(_.settings))
+
+  /** Direct dependencies of the project at the given version (latest release if not specified), one entry per
+    * depended-on project. Returns `None` if the project is unknown.
+    */
+  def getDependencies(
+      ref: Project.Reference,
+      version: Option[Version],
+      rawPage: PageParams
+  ): Future[Option[Page[ProjectDependency]]] =
+    val page = PageParams.bounded(rawPage.page, rawPage.size)
+    database.getProject(ref).flatMap {
+      case None => Future.successful(None)
+      case Some(project) =>
+        val resolvedVersion = version match
+          case some: Some[Version] => Future.successful(some)
+          case None => getHeader(project).map(_.map(_.latestVersion))
+        resolvedVersion.flatMap {
+          case None => Future.successful(Some(Page.empty[ProjectDependency]))
+          case Some(v) =>
+            for dependencies <- database.getProjectDependencies(ref, v)
+            yield Some(paginate(ProjectDependency.collapseByProject(dependencies, _.target), page))
+        }
+    }
+  end getDependencies
+
+  /** Reverse dependencies (dependents) of the project, one entry per dependent project. Returns `None` if the project
+    * is unknown.
+    */
+  def getDependents(ref: Project.Reference, rawPage: PageParams): Future[Option[Page[ProjectDependency]]] =
+    val page = PageParams.bounded(rawPage.page, rawPage.size)
+    database.getProject(ref).flatMap {
+      case None => Future.successful(None)
+      case Some(_) =>
+        // getProjectReverseDependencies already paginates by distinct source project at the SQL level, so the count of
+        // distinct source projects (countProjectDependents) is the right total for this page shape.
+        val offset = (page.page - 1) * page.size
+        for
+          dependents <- database.getProjectReverseDependencies(ref, limit = page.size, offset = offset)
+          total <- database.countProjectDependents(ref)
+        yield Some(Page(pagination(page, total), ProjectDependency.collapseByProject(dependents, _.source)))
+    }
+  end getDependents
+
+  private def paginate[A](items: Seq[A], page: PageParams): Page[A] =
+    val offset = (page.page - 1) * page.size
+    Page(pagination(page, items.size.toLong), items.slice(offset, offset + page.size))
+
+  private def pagination(page: PageParams, total: Long): Pagination =
+    val pageCount = math.ceil(total.toDouble / page.size).toInt.max(1)
+    Pagination(current = page.page, pageCount = pageCount, totalSize = total)
 
   def getHeader(ref: Project.Reference): Future[Option[ProjectHeader]] =
     database.getProject(ref).flatMap {

--- a/modules/core/shared/src/main/scala/scaladex/core/service/ProjectService.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/ProjectService.scala
@@ -64,40 +64,35 @@ class ProjectService(database: WebDatabase, searchEngine: SearchEngine)(using Ex
   def getSettings(ref: Project.Reference): Future[Option[Project.Settings]] =
     database.getProject(ref).map(_.map(_.settings))
 
-  /** Direct dependencies of the project at the given version (latest release if not specified), one entry per
-    * depended-on project. Returns `None` if the project is unknown.
-    */
+  /** Direct dependencies at the given version (latest release if not specified), one entry per depended-on project. */
   def getDependencies(
       ref: Project.Reference,
       version: Option[Version],
-      rawPage: PageParams
+      page: PageParams
   ): Future[Option[Page[ProjectDependency]]] =
-    val page = PageParams.bounded(rawPage.page, rawPage.size)
     database.getProject(ref).flatMap {
       case None => Future.successful(None)
       case Some(project) =>
         val resolvedVersion = version match
-          case some: Some[Version] => Future.successful(some)
+          case some @ Some(_) => Future.successful(some)
           case None => getHeader(project).map(_.map(_.latestVersion))
         resolvedVersion.flatMap {
           case None => Future.successful(Some(Page.empty[ProjectDependency]))
           case Some(v) =>
-            for dependencies <- database.getProjectDependencies(ref, v)
-            yield Some(paginate(ProjectDependency.collapseByProject(dependencies, _.target), page))
+            val offset = (page.page - 1) * page.size
+            for
+              dependencies <- database.getProjectDependencies(ref, v, page.size, offset)
+              total <- database.countProjectDependencies(ref, v)
+            yield Some(Page(pagination(page, total), ProjectDependency.collapseByProject(dependencies, _.target)))
         }
     }
   end getDependencies
 
-  /** Reverse dependencies (dependents) of the project, one entry per dependent project. Returns `None` if the project
-    * is unknown.
-    */
-  def getDependents(ref: Project.Reference, rawPage: PageParams): Future[Option[Page[ProjectDependency]]] =
-    val page = PageParams.bounded(rawPage.page, rawPage.size)
+  /** Reverse dependencies (dependents), one entry per dependent project. */
+  def getDependents(ref: Project.Reference, page: PageParams): Future[Option[Page[ProjectDependency]]] =
     database.getProject(ref).flatMap {
       case None => Future.successful(None)
       case Some(_) =>
-        // getProjectReverseDependencies already paginates by distinct source project at the SQL level, so the count of
-        // distinct source projects (countProjectDependents) is the right total for this page shape.
         val offset = (page.page - 1) * page.size
         for
           dependents <- database.getProjectReverseDependencies(ref, limit = page.size, offset = offset)
@@ -105,10 +100,6 @@ class ProjectService(database: WebDatabase, searchEngine: SearchEngine)(using Ex
         yield Some(Page(pagination(page, total), ProjectDependency.collapseByProject(dependents, _.source)))
     }
   end getDependents
-
-  private def paginate[A](items: Seq[A], page: PageParams): Page[A] =
-    val offset = (page.page - 1) * page.size
-    Page(pagination(page, items.size.toLong), items.slice(offset, offset + page.size))
 
   private def pagination(page: PageParams, total: Long): Pagination =
     val pageCount = math.ceil(total.toDouble / page.size).toInt.max(1)

--- a/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/WebDatabase.scala
@@ -64,7 +64,13 @@ trait WebDatabase:
 
   // project dependencies
   def countProjectDependents(projectRef: Project.Reference): Future[Long]
-  def getProjectDependencies(ref: Project.Reference, version: Version): Future[Seq[ProjectDependency]]
+  def getProjectDependencies(
+      ref: Project.Reference,
+      version: Version,
+      limit: Int,
+      offset: Int
+  ): Future[Seq[ProjectDependency]]
+  def countProjectDependencies(ref: Project.Reference, version: Version): Future[Long]
   def getProjectReverseDependencies(ref: Project.Reference, limit: Int, offset: Int): Future[Seq[ProjectDependency]]
 
   // users

--- a/modules/core/shared/src/test/scala/scaladex/core/api/ProjectSettingsPatchTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/api/ProjectSettingsPatchTests.scala
@@ -1,0 +1,84 @@
+package scaladex.core.api
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.Category
+import scaladex.core.model.DocumentationPattern
+import scaladex.core.model.Project
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ProjectSettingsPatchTests extends AnyFunSpec with Matchers:
+  val noChanges: ProjectSettingsPatch = ProjectSettingsPatch(None, None, None, None, None, None, None, None, None)
+
+  val current: Project.Settings = Project.Settings.empty.copy(
+    preferStableVersion = false,
+    defaultArtifact = Some(Artifact.Name("cats-core")),
+    customScalaDoc = Some("https://example.org/api"),
+    documentationLinks = List(DocumentationPattern("Guide", "https://example.org/guide")),
+    contributorsWanted = true,
+    deprecatedArtifacts = Set(Artifact.Name("cats-old")),
+    cliArtifacts = Set(Artifact.Name("cats-cli")),
+    category = Some(Category.Json),
+    chatroom = Some("#cats")
+  )
+
+  describe("applyTo") {
+    it("leaves every field unchanged when the patch is empty") {
+      noChanges.applyTo(current) shouldBe current
+    }
+
+    it("updates only the fields present in the patch") {
+      val patch = noChanges.copy(contributorsWanted = Some(false), preferStableVersion = Some(true))
+      patch.applyTo(current) shouldBe current.copy(contributorsWanted = false, preferStableVersion = true)
+    }
+
+    it("clears a nullable field when given an empty string") {
+      val patch = noChanges.copy(customScalaDoc = Some(""), chatroom = Some(""), defaultArtifact = Some(""))
+      val updated = patch.applyTo(current)
+      updated.customScalaDoc shouldBe None
+      updated.chatroom shouldBe None
+      updated.defaultArtifact shouldBe None
+    }
+
+    it("sets a nullable field when given a non-empty value") {
+      val patch = noChanges.copy(chatroom = Some("#new"), defaultArtifact = Some("cats-effect"))
+      val updated = patch.applyTo(current)
+      updated.chatroom shouldBe Some("#new")
+      updated.defaultArtifact shouldBe Some(Artifact.Name("cats-effect"))
+    }
+
+    it("replaces list fields wholesale") {
+      val patch = noChanges.copy(
+        deprecatedArtifacts = Some(Seq(Artifact.Name("a"), Artifact.Name("b"))),
+        cliArtifacts = Some(Seq.empty),
+        documentationLinks = Some(Seq.empty)
+      )
+      val updated = patch.applyTo(current)
+      updated.deprecatedArtifacts shouldBe Set(Artifact.Name("a"), Artifact.Name("b"))
+      updated.cliArtifacts shouldBe empty
+      updated.documentationLinks shouldBe empty
+    }
+
+    it("resolves a known category label and clears it on empty string") {
+      noChanges.copy(category = Some("web-frontend")).applyTo(current).category shouldBe Some(Category.WebFrontend)
+      noChanges.copy(category = Some("")).applyTo(current).category shouldBe None
+    }
+
+    it("keeps the current category when handed an unknown label") {
+      noChanges.copy(category = Some("not-a-category")).applyTo(current).category shouldBe current.category
+    }
+  }
+
+  describe("invalidCategory") {
+    it("flags an unknown non-empty category label") {
+      ProjectSettingsPatch.invalidCategory(Some("not-a-category")) shouldBe Some("not-a-category")
+    }
+
+    it("accepts a known label, an empty string and an absent value") {
+      ProjectSettingsPatch.invalidCategory(Some("json")) shouldBe None
+      ProjectSettingsPatch.invalidCategory(Some("")) shouldBe None
+      ProjectSettingsPatch.invalidCategory(None) shouldBe None
+    }
+  }
+end ProjectSettingsPatchTests

--- a/modules/core/shared/src/test/scala/scaladex/core/model/ProjectDependencyTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/ProjectDependencyTests.scala
@@ -1,0 +1,45 @@
+package scaladex.core.model
+
+import scaladex.core.model.ArtifactDependency.Scope
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ProjectDependencyTests extends AnyFunSpec with Matchers:
+  val us: Project.Reference = Project.Reference.from("typelevel", "cats")
+  def dep(org: String, repo: String, sourceV: String, targetV: String, scope: String): ProjectDependency =
+    ProjectDependency(Project.Reference.from(org, repo), Version(sourceV), us, Version(targetV), Scope(scope))
+
+  describe("collapseByProject") {
+    it("keeps one row per project on the chosen side") {
+      val rows = Seq(
+        dep("org", "a", "1.0.0", "2.0.0", "test"),
+        dep("org", "a", "1.1.0", "2.1.0", "compile"),
+        dep("org", "b", "3.0.0", "2.0.0", "compile")
+      )
+      val collapsed = ProjectDependency.collapseByProject(rows, _.source)
+      collapsed.map(_.source.repository.value) shouldBe Seq("a", "b")
+    }
+
+    it("keeps the lowest scope and the highest versions of the group") {
+      val rows = Seq(
+        dep("org", "a", "1.0.0", "2.0.0", "test"),
+        dep("org", "a", "1.2.0", "2.5.0", "compile")
+      )
+      val Seq(collapsed) = ProjectDependency.collapseByProject(rows, _.source)
+      collapsed.scope shouldBe Scope("compile")
+      collapsed.sourceVersion shouldBe Version("1.2.0")
+      collapsed.targetVersion shouldBe Version("2.5.0")
+    }
+
+    it("sorts by organization then repository") {
+      val rows = Seq(
+        dep("z-org", "a", "1.0.0", "1.0.0", "compile"),
+        dep("a-org", "z", "1.0.0", "1.0.0", "compile"),
+        dep("a-org", "a", "1.0.0", "1.0.0", "compile")
+      )
+      ProjectDependency.collapseByProject(rows, _.source).map(d => d.source.toString) shouldBe
+        Seq("a-org/a", "a-org/z", "z-org/a")
+    }
+  }
+end ProjectDependencyTests

--- a/modules/core/shared/src/test/scala/scaladex/core/model/search/PageParamsTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/search/PageParamsTests.scala
@@ -4,20 +4,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class PageParamsTests extends AnyFunSpec with Matchers:
-  describe("bounded") {
-    it("forces page to at least 1") {
-      PageParams.bounded(0, 20) shouldBe PageParams(1, 20)
-      PageParams.bounded(-3, 20) shouldBe PageParams(1, 20)
-    }
-
-    it("clamps size to [1, MaxSize]") {
-      PageParams.bounded(1, 0) shouldBe PageParams(1, 1)
-      PageParams.bounded(1, -5) shouldBe PageParams(1, 1)
-      PageParams.bounded(1, PageParams.MaxSize + 1000) shouldBe PageParams(1, PageParams.MaxSize)
-    }
-
-    it("leaves valid values untouched") {
-      PageParams.bounded(3, 25) shouldBe PageParams(3, 25)
+  describe("AllowedSizes") {
+    it("contains the default size") {
+      PageParams.AllowedSizes should contain(PageParams.DefaultSize)
     }
   }
 end PageParamsTests

--- a/modules/core/shared/src/test/scala/scaladex/core/model/search/PageParamsTests.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/model/search/PageParamsTests.scala
@@ -1,0 +1,23 @@
+package scaladex.core.model.search
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PageParamsTests extends AnyFunSpec with Matchers:
+  describe("bounded") {
+    it("forces page to at least 1") {
+      PageParams.bounded(0, 20) shouldBe PageParams(1, 20)
+      PageParams.bounded(-3, 20) shouldBe PageParams(1, 20)
+    }
+
+    it("clamps size to [1, MaxSize]") {
+      PageParams.bounded(1, 0) shouldBe PageParams(1, 1)
+      PageParams.bounded(1, -5) shouldBe PageParams(1, 1)
+      PageParams.bounded(1, PageParams.MaxSize + 1000) shouldBe PageParams(1, PageParams.MaxSize)
+    }
+
+    it("leaves valid values untouched") {
+      PageParams.bounded(3, 25) shouldBe PageParams(3, 25)
+    }
+  }
+end PageParamsTests

--- a/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
+++ b/modules/core/shared/src/test/scala/scaladex/core/test/InMemoryDatabase.scala
@@ -188,9 +188,13 @@ class InMemoryDatabase extends SchedulerDatabase:
 
   override def getProjectDependencies(
       ref: Project.Reference,
-      version: Version
+      version: Version,
+      limit: Int,
+      offset: Int
   ): Future[Seq[ProjectDependency]] =
     Future.successful(Seq.empty)
+  override def countProjectDependencies(ref: Project.Reference, version: Version): Future[Long] =
+    Future.successful(0)
   override def getProjectReverseDependencies(
       ref: Project.Reference,
       limit: Int,

--- a/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/SqlDatabase.scala
@@ -99,6 +99,13 @@ class SqlDatabase(
         run(ProjectDependenciesTable.getReverseDependenciesPage.to[Seq]((ref, limit.toLong, offset.toLong)))
     }
 
+  private val projectDependenciesPageCache
+      : AsyncLoadingCache[(Project.Reference, Version, Int, Int), Seq[ProjectDependency]] =
+    buildCache {
+      case (ref, version, limit, offset) =>
+        run(ProjectDependenciesTable.getDependenciesPage.to[Seq]((ref, version, limit.toLong, offset.toLong)))
+    }
+
   override def insertArtifact(artifact: Artifact): Future[Boolean] =
     run(ArtifactTable.insertIfNotExist.run(artifact)).map { inserted =>
       invalidateArtifactRefs(artifact)
@@ -247,9 +254,14 @@ class SqlDatabase(
 
   override def getProjectDependencies(
       ref: Project.Reference,
-      version: Version
+      version: Version,
+      limit: Int,
+      offset: Int
   ): Future[Seq[ProjectDependency]] =
-    run(ProjectDependenciesTable.getDependencies.to[Seq]((ref, version)))
+    projectDependenciesPageCache.get((ref, version, limit, offset))
+
+  override def countProjectDependencies(ref: Project.Reference, version: Version): Future[Long] =
+    run(ProjectDependenciesTable.countDependencies.unique((ref, version)))
 
   override def getFormerReferences(projectRef: Project.Reference): Future[Seq[Project.Reference]] =
     run(ProjectTable.selectByNewReference.to[Seq](projectRef))

--- a/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/sql/ProjectDependenciesTable.scala
@@ -44,8 +44,31 @@ object ProjectDependenciesTable:
     ).contramap { case (ref, limit, offset) => (ref, limit, offset, ref) }
   end getReverseDependenciesPage
 
-  val getDependencies: Query[(Project.Reference, Version), ProjectDependency] =
-    selectRequest(table, allFields, sourceFields)
+  val countDependencies: Query[(Project.Reference, Version), Long] =
+    selectRequest(
+      table,
+      Seq("COUNT(DISTINCT (target_organization, target_repository))"),
+      sourceFields
+    )
+
+  // the first N distinct target projects are selected before fetching their rows
+  val getDependenciesPage: Query[(Project.Reference, Version, Long, Long), ProjectDependency] =
+    val outFields = allFields.map(f => s"d.$f").mkString(", ")
+    Query[(Project.Reference, Version, Long, Long, Project.Reference, Version), ProjectDependency](
+      s"""|SELECT $outFields
+          |FROM (
+          |  SELECT DISTINCT target_organization, target_repository
+          |  FROM $table
+          |  WHERE source_organization = ? AND source_repository = ? AND source_version = ?
+          |  ORDER BY target_organization, target_repository
+          |  LIMIT ? OFFSET ?
+          |) t
+          |INNER JOIN $table d
+          |  ON d.target_organization = t.target_organization
+          |  AND d.target_repository = t.target_repository
+          |  AND d.source_organization = ? AND d.source_repository = ? AND d.source_version = ?""".stripMargin
+    ).contramap { case (ref, version, limit, offset) => (ref, version, limit, offset, ref, version) }
+  end getDependenciesPage
 
   val deleteBySource: Update[Project.Reference] =
     deleteRequest(table, Seq("source_organization", "source_repository"))

--- a/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/sql/ProjectDependenciesTableTests.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class ProjectDependenciesTableTests extends AnyFunSpec with BaseDatabaseSuite with Matchers:
   it("check insertOrUpdate")(check(ProjectDependenciesTable.insertOrUpdate))
   it("check deleteBySource")(check(ProjectDependenciesTable.deleteBySource))
-  it("check getDependencies")(check(ProjectDependenciesTable.getDependencies))
+  it("check getDependenciesPage")(check(ProjectDependenciesTable.getDependenciesPage))
+  it("check countDependencies")(check(ProjectDependenciesTable.countDependencies))
   it("check getReverseDependenciesPage")(check(ProjectDependenciesTable.getReverseDependenciesPage))
   it("check countDependents")(check(ProjectDependenciesTable.countDependents))

--- a/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
+++ b/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
@@ -70,9 +70,8 @@ private class GithubAuthImpl(clientId: String, clientSecret: String, redirectUri
     githubClient.getUserState().map {
       case GithubResponse.Ok(userState) => Some(userState)
       case GithubResponse.MovedPermanently(userState) => Some(userState)
-      // 401 means the token itself is invalid; any other failure (rate-limit, 5xx, network) is transient and must not be
-      // reported as "unauthenticated", otherwise callers would see a misleading 403.
-      case GithubResponse.Failed(401, errorMessage) =>
+      // Any other failure (rate-limit, 5xx, network) is transient and must not be reported as "unauthenticated".
+      case GithubResponse.Failed(StatusCodes.Unauthorized.intValue, errorMessage) =>
         logger.warn(s"Rejected invalid GitHub token: $errorMessage")
         None
       case GithubResponse.Failed(errorCode, errorMessage) =>

--- a/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
+++ b/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
@@ -70,10 +70,15 @@ private class GithubAuthImpl(clientId: String, clientSecret: String, redirectUri
     githubClient.getUserState().map {
       case GithubResponse.Ok(userState) => Some(userState)
       case GithubResponse.MovedPermanently(userState) => Some(userState)
-      case GithubResponse.Failed(errorCode, errorMessage) =>
-        logger.warn(s"Failed to get user state: $errorCode, $errorMessage")
+      // 401 means the token itself is invalid; any other failure (rate-limit, 5xx, network) is transient and must not be
+      // reported as "unauthenticated", otherwise callers would see a misleading 403.
+      case GithubResponse.Failed(401, errorMessage) =>
+        logger.warn(s"Rejected invalid GitHub token: $errorMessage")
         None
+      case GithubResponse.Failed(errorCode, errorMessage) =>
+        throw Exception(s"Failed to get user state from GitHub: $errorCode, $errorMessage")
     }
+  end getUserState
 end GithubAuthImpl
 
 object GithubAuthImpl:

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -157,7 +157,7 @@ object Server extends LazyLogging:
     val searchPages = new SearchPages(config.env, searchEngine)
     val frontPage = new FrontPage(config.env, webDatabase, searchEngine)
     val adminPages = new AdminPage(config.env, adminService)
-    val projectPages = new ProjectPages(config.env, projectService, settingsService, webDatabase, searchEngine)
+    val projectPages = new ProjectPages(config.env, projectService, settingsService, webDatabase)
     val artifactPages = new ArtifactPages(config.env, webDatabase)
     val awesomePages = new AwesomePages(config.env, searchEngine)
     val publishApi = new PublishApi(githubAuth, publishProcess)

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -22,6 +22,7 @@ import scaladex.server.route.api.*
 import scaladex.server.service.AdminService
 import scaladex.server.service.ArtifactService
 import scaladex.server.service.MavenCentralService
+import scaladex.server.service.ProjectSettingsService
 import scaladex.server.service.PublishProcess
 import scaladex.view.html.notfound
 
@@ -152,14 +153,16 @@ object Server extends LazyLogging:
 
     val projectService = new ProjectService(webDatabase, searchEngine)
     val artifactService = new ArtifactService(webDatabase)
+    val settingsService = new ProjectSettingsService(webDatabase, projectService, artifactService, searchEngine)
     val searchPages = new SearchPages(config.env, searchEngine)
     val frontPage = new FrontPage(config.env, webDatabase, searchEngine)
     val adminPages = new AdminPage(config.env, adminService)
-    val projectPages = new ProjectPages(config.env, projectService, artifactService, webDatabase, searchEngine)
+    val projectPages = new ProjectPages(config.env, projectService, settingsService, webDatabase, searchEngine)
     val artifactPages = new ArtifactPages(config.env, webDatabase)
     val awesomePages = new AwesomePages(config.env, searchEngine)
     val publishApi = new PublishApi(githubAuth, publishProcess)
-    val apiEndpoints = new ApiEndpointsImpl(projectService, artifactService, searchEngine)
+    val apiEndpoints =
+      new ApiEndpointsImpl(config.env, projectService, artifactService, settingsService, searchEngine, githubAuth)
     val oldSearchApi = new OldSearchApi(searchEngine, webDatabase)
     val badges = new Badges(projectService)
     val authentication = new AuthenticationApi(config.oAuth2.clientId, config.session, githubAuth, webDatabase)

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -16,8 +16,7 @@ import scaladex.core.service.SearchEngine
 import scaladex.core.web.ArtifactPageParams
 import scaladex.core.web.ArtifactsPageParams
 import scaladex.server.TwirlSupport.given
-import scaladex.server.service.ArtifactService
-import scaladex.server.service.SearchSynchronizer
+import scaladex.server.service.ProjectSettingsService
 import scaladex.view.html.forbidden
 import scaladex.view.html.notfound
 import scaladex.view.project.html
@@ -31,14 +30,12 @@ import org.apache.pekko.http.scaladsl.server.Directives.*
 class ProjectPages(
     env: Env,
     projectService: ProjectService,
-    artifactService: ArtifactService,
+    settingsService: ProjectSettingsService,
     database: SchedulerDatabase,
     searchEngine: SearchEngine
 )(
     using ExecutionContext
 ) extends LazyLogging:
-
-  private val searchSynchronizer = new SearchSynchronizer(database, projectService, searchEngine)
 
   def route(user: Option[UserState]): Route =
     concat(
@@ -201,11 +198,7 @@ class ProjectPages(
       post {
         path(projectM / "settings") { projectRef =>
           editForm { form =>
-            val updateF = for
-              _ <- database.updateProjectSettings(projectRef, form)
-              _ <- artifactService.updateLatestVersions(projectRef, form.preferStableVersion)
-              _ <- searchSynchronizer.syncProject(projectRef)
-            yield ()
+            val updateF = settingsService.updateSettings(projectRef, form)
             val projectUri = Uri((Path.Empty / projectRef.organization.value / projectRef.repository.value).toString)
             onComplete(updateF) {
               case Success(()) => redirect(projectUri, StatusCodes.SeeOther)

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -12,7 +12,6 @@ import scala.util.Success
 import scaladex.core.model.*
 import scaladex.core.service.ProjectService
 import scaladex.core.service.SchedulerDatabase
-import scaladex.core.service.SearchEngine
 import scaladex.core.web.ArtifactPageParams
 import scaladex.core.web.ArtifactsPageParams
 import scaladex.server.TwirlSupport.given
@@ -31,8 +30,7 @@ class ProjectPages(
     env: Env,
     projectService: ProjectService,
     settingsService: ProjectSettingsService,
-    database: SchedulerDatabase,
-    searchEngine: SearchEngine
+    database: SchedulerDatabase
 )(
     using ExecutionContext
 ) extends LazyLogging:
@@ -292,7 +290,7 @@ class ProjectPages(
         header <- projectService.getHeader(project)
         directDependencies <-
           header
-            .map(h => database.getProjectDependencies(ref, h.latestVersion))
+            .map(h => database.getProjectDependencies(ref, h.latestVersion, limit = 1000, offset = 0))
             .getOrElse(Future.successful(Seq.empty))
         reverseDependencies <- database.getProjectReverseDependencies(ref, limit = 100, offset = 0)
         reverseDependencyCount <- database.countProjectDependents(ref)

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -290,8 +290,12 @@ class ProjectPages(
         header <- projectService.getHeader(project)
         directDependencies <-
           header
-            .map(h => database.getProjectDependencies(ref, h.latestVersion, limit = 1000, offset = 0))
+            .map(h => database.getProjectDependencies(ref, h.latestVersion, limit = 100, offset = 0))
             .getOrElse(Future.successful(Seq.empty))
+        directDependencyCount <-
+          header
+            .map(h => database.countProjectDependencies(ref, h.latestVersion))
+            .getOrElse(Future.successful(0L))
         reverseDependencies <- database.getProjectReverseDependencies(ref, limit = 100, offset = 0)
         reverseDependencyCount <- database.countProjectDependents(ref)
       yield
@@ -318,6 +322,7 @@ class ProjectPages(
             project,
             header,
             groupedDirectDependencies.toMap,
+            directDependencyCount,
             groupedReverseDependencies.toMap,
             reverseDependencyCount
           )

--- a/modules/server/src/main/scala/scaladex/server/route/api/ApiDocumentation.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/ApiDocumentation.scala
@@ -8,7 +8,11 @@ import endpoints4s.openapi.model.OpenApi
 
 /** Documentation of the public HTTP API of Scaladex
   */
-object ApiDocumentation extends Endpoints with openapi.Endpoints with openapi.JsonEntitiesFromSchemas:
+object ApiDocumentation
+    extends Endpoints
+    with openapi.Endpoints
+    with openapi.JsonEntitiesFromSchemas
+    with openapi.BasicAuthentication:
   val apiV0: OpenApi = openApi(Info(title = "Scaladex API", version = "v0"))(
     getProjects(v0),
     getProjectArtifacts(v0),
@@ -25,6 +29,12 @@ object ApiDocumentation extends Endpoints with openapi.Endpoints with openapi.Js
     getProjectArtifacts(v1),
     getArtifactVersions(v1),
     getLatestArtifactV1,
-    getArtifact(v1)
+    getArtifact(v1),
+    searchProjectsV1,
+    getProjectDependenciesV1,
+    getProjectDependentsV1,
+    getAuthenticatedUserV1,
+    getProjectSettingsV1,
+    patchProjectSettingsV1
   )
 end ApiDocumentation

--- a/modules/server/src/main/scala/scaladex/server/route/api/ApiEndpointsImpl.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/ApiEndpointsImpl.scala
@@ -41,25 +41,16 @@ class ApiEndpointsImpl(
 
   def routes(user: Option[UserState]): Route = cors()(concat(webApi(user), v0Api, v1Api, v1AuthApi))
 
-  // Token -> GitHub authorization (repos/orgs). Bounded and expiring so that revoked tokens and permission changes take
-  // effect within the TTL without a restart. A failed lookup (GitHub outage) is not cached, so it is retried.
   private val userStateCache: AsyncLoadingCache[Secret, Option[UserState]] =
     Scaffeine()
       .expireAfterWrite(10.minutes)
       .maximumSize(4096)
       .buildAsyncFuture(token => githubAuth.getUserState(token))
 
-  /** Resolves the GitHub token to a [[UserState]]. `None` means the token is invalid; a GitHub outage or rate-limit
-    * surfaces as a failed `Future` (HTTP 5xx) rather than a misleading `None`.
-    */
   private def resolveUser(credentials: Credentials): Future[Option[UserState]] =
     userStateCache.get(Secret(credentials.password))
 
-  /** Runs `f` with the current settings of `ref` for a caller allowed to edit it. The nested option encodes the HTTP
-    * outcome: `None` -> 403 (missing/invalid token or no edit permission), `Some(None)` -> 404 (unknown project),
-    * `Some(Some(a))` -> 200. Project existence is public, so an unknown project is reported as 404 even to callers
-    * without edit permission.
-    */
+  // None -> 403, Some(None) -> 404 (unknown project, reported even without edit permission), Some(Some(a)) -> 200.
   private def withEditableProject[A](credentials: Credentials, ref: Project.Reference)(
       f: Project.Settings => Future[A]
   ): Future[Option[Option[A]]] =

--- a/modules/server/src/main/scala/scaladex/server/route/api/ApiEndpointsImpl.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/ApiEndpointsImpl.scala
@@ -1,26 +1,80 @@
 package scaladex.server.route.api
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.*
 
 import scaladex.core.api.Endpoints
 import scaladex.core.api.ProjectResponse
+import scaladex.core.api.SearchResult
+import scaladex.core.api.UserResponse
 import scaladex.core.model.*
+import scaladex.core.model.search.ProjectDocument
+import scaladex.core.service.GithubAuth
 import scaladex.core.service.ProjectService
 import scaladex.core.service.SearchEngine
+import scaladex.core.util.Secret
 import scaladex.server.service.ArtifactService
+import scaladex.server.service.ProjectSettingsService
 
+import com.github.blemale.scaffeine.AsyncLoadingCache
+import com.github.blemale.scaffeine.Scaffeine
+import endpoints4s.algebra.BasicAuthentication.Credentials
 import endpoints4s.pekkohttp.server
 import org.apache.pekko.http.cors.scaladsl.CorsDirectives.cors
 import org.apache.pekko.http.scaladsl.server.Directives.*
 import org.apache.pekko.http.scaladsl.server.Route
 
-class ApiEndpointsImpl(projectService: ProjectService, artifactService: ArtifactService, searchEngine: SearchEngine)(
+class ApiEndpointsImpl(
+    env: Env,
+    projectService: ProjectService,
+    artifactService: ArtifactService,
+    settingsService: ProjectSettingsService,
+    searchEngine: SearchEngine,
+    githubAuth: GithubAuth
+)(
     using ExecutionContext
 ) extends Endpoints
     with server.Endpoints
-    with server.JsonEntitiesFromSchemas:
+    with server.JsonEntitiesFromSchemas
+    with server.BasicAuthentication:
 
-  def routes(user: Option[UserState]): Route = cors()(concat(webApi(user), v0Api, v1Api))
+  def routes(user: Option[UserState]): Route = cors()(concat(webApi(user), v0Api, v1Api, v1AuthApi))
+
+  // Token -> GitHub authorization (repos/orgs). Bounded and expiring so that revoked tokens and permission changes take
+  // effect within the TTL without a restart. A failed lookup (GitHub outage) is not cached, so it is retried.
+  private val userStateCache: AsyncLoadingCache[Secret, Option[UserState]] =
+    Scaffeine()
+      .expireAfterWrite(10.minutes)
+      .maximumSize(4096)
+      .buildAsyncFuture(token => githubAuth.getUserState(token))
+
+  /** Resolves the GitHub token to a [[UserState]]. `None` means the token is invalid; a GitHub outage or rate-limit
+    * surfaces as a failed `Future` (HTTP 5xx) rather than a misleading `None`.
+    */
+  private def resolveUser(credentials: Credentials): Future[Option[UserState]] =
+    userStateCache.get(Secret(credentials.password))
+
+  /** Runs `f` with the current settings of `ref` for a caller allowed to edit it. The nested option encodes the HTTP
+    * outcome: `None` -> 403 (missing/invalid token or no edit permission), `Some(None)` -> 404 (unknown project),
+    * `Some(Some(a))` -> 200. Project existence is public, so an unknown project is reported as 404 even to callers
+    * without edit permission.
+    */
+  private def withEditableProject[A](credentials: Credentials, ref: Project.Reference)(
+      f: Project.Settings => Future[A]
+  ): Future[Option[Option[A]]] =
+    resolveUser(credentials).flatMap {
+      case Some(user) if user.canEdit(ref, env) =>
+        projectService.getSettings(ref).flatMap {
+          case None => Future.successful(Some(None))
+          case Some(settings) => f(settings).map(a => Some(Some(a)))
+        }
+      case _ =>
+        projectService.getProject(ref).map {
+          case None => Some(None)
+          case Some(_) => None
+        }
+    }
 
   private def webApi(user: Option[UserState]): Route =
     autocomplete.implementedByAsync { params =>
@@ -56,6 +110,15 @@ class ApiEndpointsImpl(projectService: ProjectService, artifactService: Artifact
       case (ref, params) =>
         projectService.getArtifactRefs(ref, params.binaryVersion, params.artifactName, params.stableOnly)
     },
+    getProjectDependenciesV1.implementedByAsync {
+      case (ref, version, page) => projectService.getDependencies(ref, version, page)
+    },
+    getProjectDependentsV1.implementedByAsync { case (ref, page) => projectService.getDependents(ref, page) },
+    searchProjectsV1.implementedByAsync {
+      case (params, page) =>
+        for results <- searchEngine.find(params.toSearchParams, page)
+        yield results.map(hit => toSearchResult(hit.document))
+    },
     getLatestArtifactV1.implementedByAsync {
       case (groupId, artifactId) =>
         for artifact <- artifactService.getLatestArtifact(groupId, artifactId) yield artifact.map(_.toResponse)
@@ -68,6 +131,43 @@ class ApiEndpointsImpl(projectService: ProjectService, artifactService: Artifact
       for artifact <- artifactService.getArtifact(mavenRef) yield artifact.map(_.toResponse)
     }
   )
+
+  private def v1AuthApi: Route = concat(
+    getAuthenticatedUserV1.implementedByAsync { credentials => resolveUser(credentials).map(_.map(toUserResponse)) },
+    getProjectSettingsV1.implementedByAsync {
+      case (ref, credentials) =>
+        withEditableProject(credentials, ref)(Future.successful)
+    },
+    patchProjectSettingsV1.implementedByAsync {
+      case (ref, patch, credentials) =>
+        withEditableProject(credentials, ref)(current => settingsService.updateSettings(ref, patch.applyTo(current)))
+    }
+  )
+
+  private def toUserResponse(user: UserState): UserResponse =
+    UserResponse(
+      login = user.info.login,
+      name = user.info.name,
+      avatarUrl = user.info.avatarUrl,
+      isAdmin = user.isAdmin(env),
+      organizations = user.orgs.toSeq.sortBy(_.value),
+      repositories = user.repos.toSeq.sortBy(_.toString)
+    )
+
+  private def toSearchResult(document: ProjectDocument): SearchResult =
+    SearchResult(
+      organization = document.organization,
+      repository = document.repository,
+      description = document.githubInfo.flatMap(_.description),
+      stars = document.githubInfo.flatMap(_.stars),
+      forks = document.githubInfo.flatMap(_.forks),
+      topics = document.githubInfo.map(_.topics).getOrElse(Seq.empty),
+      languages = document.languages,
+      platforms = document.platforms,
+      latestVersion = document.latestVersion,
+      dependents = document.dependents,
+      category = document.category.map(_.label)
+    )
 
   private def toResponse(project: Project): ProjectResponse =
     import project.*

--- a/modules/server/src/main/scala/scaladex/server/service/ProjectSettingsService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ProjectSettingsService.scala
@@ -8,9 +8,7 @@ import scaladex.core.service.ProjectService
 import scaladex.core.service.SchedulerDatabase
 import scaladex.core.service.SearchEngine
 
-/** Persists project settings and keeps the derived state (latest versions, search index) in sync. Shared by the web
-  * settings form and the REST API.
-  */
+// Shared by the web settings form and the REST API.
 class ProjectSettingsService(
     database: SchedulerDatabase,
     projectService: ProjectService,
@@ -19,10 +17,7 @@ class ProjectSettingsService(
 )(using ExecutionContext):
   private val searchSynchronizer = new SearchSynchronizer(database, projectService, searchEngine)
 
-  /** Replaces the settings of `ref` and refreshes the derived state. There is no optimistic locking: a caller doing
-    * read-modify-write (the REST PATCH) can lose a concurrent update. Acceptable given how rarely one project is edited
-    * concurrently; revisit with a version column if that changes.
-    */
+  // No optimistic locking: a caller doing read-modify-write (the REST PATCH) can lose a concurrent update.
   def updateSettings(ref: Project.Reference, settings: Project.Settings): Future[Unit] =
     for
       _ <- database.updateProjectSettings(ref, settings)

--- a/modules/server/src/main/scala/scaladex/server/service/ProjectSettingsService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ProjectSettingsService.scala
@@ -1,0 +1,32 @@
+package scaladex.server.service
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scaladex.core.model.Project
+import scaladex.core.service.ProjectService
+import scaladex.core.service.SchedulerDatabase
+import scaladex.core.service.SearchEngine
+
+/** Persists project settings and keeps the derived state (latest versions, search index) in sync. Shared by the web
+  * settings form and the REST API.
+  */
+class ProjectSettingsService(
+    database: SchedulerDatabase,
+    projectService: ProjectService,
+    artifactService: ArtifactService,
+    searchEngine: SearchEngine
+)(using ExecutionContext):
+  private val searchSynchronizer = new SearchSynchronizer(database, projectService, searchEngine)
+
+  /** Replaces the settings of `ref` and refreshes the derived state. There is no optimistic locking: a caller doing
+    * read-modify-write (the REST PATCH) can lose a concurrent update. Acceptable given how rarely one project is edited
+    * concurrently; revisit with a version column if that changes.
+    */
+  def updateSettings(ref: Project.Reference, settings: Project.Settings): Future[Unit] =
+    for
+      _ <- database.updateProjectSettings(ref, settings)
+      _ <- artifactService.updateLatestVersions(ref, settings.preferStableVersion)
+      _ <- searchSynchronizer.syncProject(ref)
+    yield ()
+end ProjectSettingsService

--- a/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
@@ -12,6 +12,7 @@ import scaladex.infra.DataPaths
 import scaladex.infra.FilesystemStorage
 import scaladex.server.config.ServerConfig
 import scaladex.server.service.ArtifactService
+import scaladex.server.service.ProjectSettingsService
 import scaladex.server.service.SearchSynchronizer
 
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
@@ -31,6 +32,7 @@ trait ControllerBaseSuite extends AsyncFunSpec with Matchers with ScalatestRoute
   val projectService = new ProjectService(database, searchEngine)
   val artifactService = new ArtifactService(database)
   val searchSync = new SearchSynchronizer(database, projectService, searchEngine)
+  val settingsService = new ProjectSettingsService(database, projectService, artifactService, searchEngine)
 
   val dataPaths: DataPaths = DataPaths.from(config.filesystem)
   val localStorage: FilesystemStorage = FilesystemStorage(config.filesystem)

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -30,7 +30,7 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
       _ <- database.updateGithubInfoAndStatus(PlayJsonExtra.reference, PlayJsonExtra.githubInfo, ok)
     yield ()
 
-  val projectPages = new ProjectPages(config.env, projectService, artifactService, database, searchEngine)
+  val projectPages = new ProjectPages(config.env, projectService, settingsService, database, searchEngine)
   val artifactPages = new ArtifactPages(config.env, database)
   val route: Route = projectPages.route(None) ~ artifactPages.route(None)
 

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -30,7 +30,7 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
       _ <- database.updateGithubInfoAndStatus(PlayJsonExtra.reference, PlayJsonExtra.githubInfo, ok)
     yield ()
 
-  val projectPages = new ProjectPages(config.env, projectService, settingsService, database, searchEngine)
+  val projectPages = new ProjectPages(config.env, projectService, settingsService, database)
   val artifactPages = new ArtifactPages(config.env, database)
   val route: Route = projectPages.route(None) ~ artifactPages.route(None)
 

--- a/modules/server/src/test/scala/scaladex/server/route/api/ApiEndpointsImplTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/api/ApiEndpointsImplTests.scala
@@ -1,16 +1,26 @@
 package scaladex.server.route.api
 
 import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 import scaladex.core.api.ArtifactResponse
+import scaladex.core.api.SearchResult
+import scaladex.core.api.UserResponse
 import scaladex.core.model.*
+import scaladex.core.model.search.Page
+import scaladex.core.service.GithubAuth
+import scaladex.core.test.MockGithubAuth
 import scaladex.core.test.Values.*
 import scaladex.core.util.ScalaExtensions.*
+import scaladex.core.util.Secret
 import scaladex.server.route.ControllerBaseSuite
 
+import org.apache.pekko.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.model.MediaTypes
 import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.BasicHttpCredentials
 import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import org.scalactic.source.Position
@@ -18,8 +28,19 @@ import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterEach
 
 class ApiEndpointsImplTests extends ControllerBaseSuite with BeforeAndAfterEach:
-  val endpoints: ApiEndpointsImpl = new ApiEndpointsImpl(projectService, artifactService, searchEngine)
+  // Env.Prod so that edit permissions are actually enforced (in a local env every user is an admin)
+  val endpoints: ApiEndpointsImpl =
+    new ApiEndpointsImpl(Env.Prod, projectService, artifactService, settingsService, searchEngine, githubAuth)
   import endpoints.*
+
+  val typelevel: BasicHttpCredentials = BasicHttpCredentials("token", MockGithubAuth.Typelevel.token)
+  val sonatype: BasicHttpCredentials = BasicHttpCredentials("token", MockGithubAuth.Sonatype.token)
+  val admin: BasicHttpCredentials = BasicHttpCredentials("token", MockGithubAuth.Admin.token)
+
+  val failingGithubAuth: GithubAuth = new GithubAuth:
+    def getToken(code: String): Future[Secret] = Future.failed(new Exception("unavailable"))
+    def getUser(token: Secret): Future[UserInfo] = Future.failed(new Exception("unavailable"))
+    def getUserState(token: Secret): Future[Option[UserState]] = Future.failed(new Exception("GitHub is unavailable"))
 
   override protected def beforeAll(): Unit =
     val insertions = for
@@ -199,6 +220,154 @@ class ApiEndpointsImplTests extends ControllerBaseSuite with BeforeAndAfterEach:
 
     testGet("/api/v1/artifacts/unknown/unknown_3/1.0.0") {
       status shouldBe StatusCodes.NotFound
+    }
+
+    testGet(s"/api/v1/projects/${Cats.reference}/dependencies?page=1&size=5") {
+      status shouldBe StatusCodes.OK
+      val page = responseAs[Page[ProjectDependency]]
+      page.pagination.current shouldBe 1
+      page.items shouldBe empty // the in-memory database has no project dependencies
+    }
+
+    testGet("/api/v1/projects/unknown/unknown/dependencies") {
+      status shouldBe StatusCodes.NotFound
+    }
+
+    testGet(s"/api/v1/projects/${Cats.reference}/dependents") {
+      status shouldBe StatusCodes.OK
+      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1
+    }
+
+    testGet("/api/v1/projects/unknown/unknown/dependents") {
+      status shouldBe StatusCodes.NotFound
+    }
+
+    testGet("/api/v1/search?q=cats") {
+      status shouldBe StatusCodes.OK
+      val page = responseAs[Page[SearchResult]]
+      page.items.map(_.repository) should contain(Cats.reference.repository)
+    }
+
+    testGet("/api/v1/search?q=*&sort=stars&page=1&size=1") {
+      status shouldBe StatusCodes.OK
+      responseAs[Page[SearchResult]].items.size should be <= 1
+    }
+
+    testGet("/api/v1/search?q=cats&sort=not-a-sort") {
+      status shouldBe StatusCodes.OK // an unknown sort falls back to the default rather than failing
+    }
+
+    testGet(s"/api/v1/projects/${Cats.reference}/dependents?size=-5") {
+      status shouldBe StatusCodes.OK // negative size is clamped, not passed through to SQL LIMIT
+      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1
+    }
+
+    testGet(s"/api/v1/projects/${Cats.reference}/dependents?page=0&size=100000") {
+      status shouldBe StatusCodes.OK
+      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1 // page and size are clamped
+    }
+  }
+
+  describe("v1 authenticated") {
+    it("GET /api/v1/users/me requires credentials") {
+      Get("/api/v1/users/me") ~> routes(None) ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
+    }
+
+    it("GET /api/v1/users/me rejects an unknown token") {
+      Get("/api/v1/users/me").addCredentials(BasicHttpCredentials("token", "nope")) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+    }
+
+    it("GET /api/v1/users/me returns the authenticated user") {
+      Get("/api/v1/users/me").addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.OK
+        val user = responseAs[UserResponse]
+        user.login shouldBe MockGithubAuth.Typelevel.info.login
+        user.repositories should contain(Cats.reference)
+      }
+    }
+
+    it("GET settings is forbidden for a user without edit permission") {
+      Get(s"/api/v1/projects/${Cats.reference}/settings").addCredentials(sonatype) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+    }
+
+    it("GET settings returns the current settings") {
+      Get(s"/api/v1/projects/${Cats.reference}/settings").addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[Project.Settings] shouldBe Project.Settings.empty
+      }
+    }
+
+    it("GET settings is 404 for an unknown project (admin)") {
+      Get("/api/v1/projects/unknown/unknown/settings").addCredentials(admin) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it("GET settings is 404 for an unknown project even without edit permission") {
+      Get("/api/v1/projects/unknown/unknown/settings").addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it("returns 500 (not 403) when GitHub cannot be reached") {
+      val failing = new ApiEndpointsImpl(
+        Env.Prod,
+        projectService,
+        artifactService,
+        settingsService,
+        searchEngine,
+        failingGithubAuth
+      )
+      Get("/api/v1/users/me").addCredentials(typelevel) ~> failing.routes(None) ~> check {
+        status shouldBe StatusCodes.InternalServerError
+      }
+    }
+
+    it("PATCH settings updates only the provided fields") {
+      val body = HttpEntity(ContentTypes.`application/json`, """{"contributorsWanted":true,"chatroom":"#cats"}""")
+      Patch(s"/api/v1/projects/${Cats.reference}/settings", body).addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.OK
+        for settings <- projectService.getSettings(Cats.reference)
+        yield
+          settings.map(_.contributorsWanted) shouldBe Some(true)
+          settings.flatMap(_.chatroom) shouldBe Some("#cats")
+      }
+    }
+
+    it("PATCH settings clears a field with an empty string and leaves absent fields untouched") {
+      val ref = Cats.reference
+      val setup = HttpEntity(ContentTypes.`application/json`, """{"contributorsWanted":true,"chatroom":"#room"}""")
+      Patch(s"/api/v1/projects/$ref/settings", setup).addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.OK
+      }
+      val clear = HttpEntity(ContentTypes.`application/json`, """{"chatroom":""}""")
+      Patch(s"/api/v1/projects/$ref/settings", clear).addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.OK
+        for settings <- projectService.getSettings(ref)
+        yield
+          settings.flatMap(_.chatroom) shouldBe None
+          settings.map(_.contributorsWanted) shouldBe Some(true) // untouched: not part of the second patch
+      }
+    }
+
+    it("PATCH settings rejects an unknown category") {
+      val body = HttpEntity(ContentTypes.`application/json`, """{"category":"not-a-category"}""")
+      Patch(s"/api/v1/projects/${Cats.reference}/settings", body).addCredentials(typelevel) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.BadRequest
+      }
+    }
+
+    it("PATCH settings is forbidden without edit permission") {
+      val body = HttpEntity(ContentTypes.`application/json`, """{"contributorsWanted":true}""")
+      Patch(s"/api/v1/projects/${Cats.reference}/settings", body).addCredentials(sonatype) ~> routes(None) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
     }
   }
 

--- a/modules/server/src/test/scala/scaladex/server/route/api/ApiEndpointsImplTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/api/ApiEndpointsImplTests.scala
@@ -9,6 +9,7 @@ import scaladex.core.api.SearchResult
 import scaladex.core.api.UserResponse
 import scaladex.core.model.*
 import scaladex.core.model.search.Page
+import scaladex.core.model.search.PageParams
 import scaladex.core.service.GithubAuth
 import scaladex.core.test.MockGithubAuth
 import scaladex.core.test.Values.*
@@ -222,7 +223,7 @@ class ApiEndpointsImplTests extends ControllerBaseSuite with BeforeAndAfterEach:
       status shouldBe StatusCodes.NotFound
     }
 
-    testGet(s"/api/v1/projects/${Cats.reference}/dependencies?page=1&size=5") {
+    testGet(s"/api/v1/projects/${Cats.reference}/dependencies?page=1&size=20") {
       status shouldBe StatusCodes.OK
       val page = responseAs[Page[ProjectDependency]]
       page.pagination.current shouldBe 1
@@ -248,23 +249,28 @@ class ApiEndpointsImplTests extends ControllerBaseSuite with BeforeAndAfterEach:
       page.items.map(_.repository) should contain(Cats.reference.repository)
     }
 
-    testGet("/api/v1/search?q=*&sort=stars&page=1&size=1") {
+    testGet("/api/v1/search?q=*&sort=stars&page=1&size=50") {
       status shouldBe StatusCodes.OK
-      responseAs[Page[SearchResult]].items.size should be <= 1
+      responseAs[Page[SearchResult]].items.size should be <= 50
     }
 
     testGet("/api/v1/search?q=cats&sort=not-a-sort") {
       status shouldBe StatusCodes.OK // an unknown sort falls back to the default rather than failing
     }
 
-    testGet(s"/api/v1/projects/${Cats.reference}/dependents?size=-5") {
-      status shouldBe StatusCodes.OK // negative size is clamped, not passed through to SQL LIMIT
-      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1
-    }
+    for size <- PageParams.AllowedSizes do
+      testGet(s"/api/v1/projects/${Cats.reference}/dependents?size=$size") {
+        status shouldBe StatusCodes.OK
+      }
 
-    testGet(s"/api/v1/projects/${Cats.reference}/dependents?page=0&size=100000") {
+    for size <- Seq(-5, 0, 5, 30, 100000) do
+      testGet(s"/api/v1/projects/${Cats.reference}/dependents?size=$size") {
+        status shouldBe StatusCodes.BadRequest // only PageParams.AllowedSizes is accepted
+      }
+
+    testGet(s"/api/v1/projects/${Cats.reference}/dependents?page=0") {
       status shouldBe StatusCodes.OK
-      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1 // page and size are clamped
+      responseAs[Page[ProjectDependency]].pagination.current shouldBe 1 // page is clamped to at least 1
     }
   }
 

--- a/modules/server/src/test/scala/scaladex/server/route/api/DocumentationRoutesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/api/DocumentationRoutesTests.scala
@@ -14,4 +14,12 @@ class DocumentationRoutesTests extends ControllerBaseSuite with FailFastCirceSup
         responseAs[Json] shouldNot be(null)
       }
     }
+
+    it("should serve v1 OpenAPI documentation") {
+      Get("/api/v1/open-api.json") ~> DocumentationRoute.route ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[Json] shouldNot be(null)
+      }
+    }
   }
+end DocumentationRoutesTests

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -10,6 +10,7 @@
   project: Project,
   header: Option[ProjectHeader],
   directDependencies: Map[Project.Reference, (ArtifactDependency.Scope, Seq[Version])],
+  directDependencyCount: Long,
   reverseDependency: Map[Project.Reference, (ArtifactDependency.Scope, Version)],
   reverseDependencyCount: Long,
 )
@@ -31,7 +32,7 @@
             @communityBox
             @project.githubInfo.map(gh => statisticsBox(gh, project.reference, reverseDependencyCount))
             @commitActivityBox
-            @directDependenciesBox(directDependencies)
+            @directDependenciesBox(directDependencies, directDependencyCount)
             @reverseDependenciesBox(reverseDependency, reverseDependencyCount)
           </div>
         </div>
@@ -107,9 +108,9 @@
   }
 }
 
-@directDependenciesBox(dependencies: Map[Project.Reference, (ArtifactDependency.Scope, Seq[Version])]) = {
+@directDependenciesBox(dependencies: Map[Project.Reference, (ArtifactDependency.Scope, Seq[Version])], count: Long) = {
   <div class="dependencies box">
-    <h4>@Formats.plural(dependencies.size, "Dependency")</h4>
+    <h4>@Formats.plural(count, "Dependency")</h4>
     <ul>
       @for((ref, (scope, versions)) <- dependencies.toSeq.sortBy { case (ref, _) => ref }){
         <li>
@@ -118,6 +119,9 @@
             <div class="col-xs-4">@versions.mkString(", ")</div>
           </div>
         </li>
+      }
+      @if(count > 100) {
+        <p>and @{count - 100} more</p>
       }
     </ul>
   </div>

--- a/modules/webclient/src/main/scala/scaladex/client/RPC.scala
+++ b/modules/webclient/src/main/scala/scaladex/client/RPC.scala
@@ -4,5 +4,9 @@ import scaladex.core.api.Endpoints
 
 import endpoints4s.fetch
 
-object RPC extends Endpoints with fetch.future.Endpoints with fetch.JsonEntitiesFromSchemas:
+object RPC
+    extends Endpoints
+    with fetch.future.Endpoints
+    with fetch.JsonEntitiesFromSchemas
+    with fetch.BasicAuthentication:
   override def settings: fetch.EndpointsSettings = fetch.EndpointsSettings()


### PR DESCRIPTION
Let's make scaladex more friendly for our text-based friends.

Authenticated endpoints (HTTP Basic `token:<github-token>`):
- GET   /api/v1/users/me
- GET   /api/v1/projects/{org}/{repo}/settings
- PATCH /api/v1/projects/{org}/{repo}/settings

Public endpoints:
- GET /api/v1/search
- GET /api/v1/projects/{org}/{repo}/dependencies
- GET /api/v1/projects/{org}/{repo}/dependents

Auth uses endpoints4s BasicAuthentication with a Scaffeine-cached token -> UserState lookup.
Page size/number are clamped, and dependency lists are collapsed to one entry per project so pagination metadata stays consistent. Settings writes are shared with the web form through the new ProjectSettingsService.

Vibe-codec, then reviewed and adjusted.