### PR TITLE
chore: bundle deployed logback config in repo

### DIFF
--- a/modules/infra/src/main/resources/logback-prod.xml
+++ b/modules/infra/src/main/resources/logback-prod.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${logback.output-file}</file>
+      <append>true</append>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${logback.logs-dir:-logs}/server.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>3GB</totalSizeCap>
+      </rollingPolicy>
+      <encoder>
+        <pattern>%date{ISO8601} %-5level %logger{36}:%line %X{sourceThread} - %msg%n</pattern>
+      </encoder>
+  </appender>
+
+  <appender name="HTTP_ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>http.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <fileNamePattern>${logback.logs-dir:-logs}/http.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+          <maxHistory>30</maxHistory>
+          <totalSizeCap>1GB</totalSizeCap>
+      </rollingPolicy>
+      <encoder>
+          <pattern>%date{ISO8601} %-5level %logger{36}:%line %X{sourceThread} - %msg%n</pattern>
+      </encoder>
+    </appender>
+
+  <logger name="scaladex.server.http-access" level="DEBUG" additivity="false">
+      <appender-ref ref="HTTP_ACCESS"/>
+  </logger>
+
+  <logger name="akka" level="INFO" />
+  <logger name="play.api.libs" level="WARN" />
+  <logger name="com.sksamuel" level="INFO" />
+  <logger name="org.elasticsearch" level="INFO" />
+  <logger name="org.flywaydb.*" level="INFO"/>
+  <logger name="org.elasticsearch.client.RestClient" level="ERROR"/>
+
+  <root level="INFO">
+      <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/project/Deployment.scala
+++ b/project/Deployment.scala
@@ -119,7 +119,8 @@ class Deployment(
           |  -Djava.rmi.server.hostname=localhost \\
           |  -Dcom.sun.management.jmxremote.rmi.port=9998 \\
           |  -Dlogback.output-file=server.log \\
-          |  -Dlogback.configurationFile=/home/$userName/scaladex-credentials/logback.xml \\
+          |  -Dlogback.logs-dir=/home/$userName/server/logs \\
+          |  -Dlogback.configurationFile=logback-prod.xml \\
           |  -Dconfig.file=/home/$userName/scaladex-credentials/application.conf \\
           |  &>/dev/null &
           |""".stripMargin
@@ -199,7 +200,8 @@ class Deployment(
           |  nohup /home/$userName/data/current/bin/data \\
           |    -J-Xmx2g \\
           |    -Dlogback.output-file=data.log \\
-          |    -Dlogback.configurationFile=/home/$userName/scaladex-credentials/logback.xml \\
+          |    -Dlogback.logs-dir=/home/$userName/data/logs \\
+          |    -Dlogback.configurationFile=logback-prod.xml \\
           |    -Dconfig.file=/home/$userName/scaladex-credentials/application.conf \\
           |    init \\
           |    &>/dev/null &


### PR DESCRIPTION
Moves the prod/dev logback config out of the external `scaladex-credentials` repo into `modules/infra` so it's version-controlled with the code.

- Single `logback-prod.xml` shared by both `server` and `data` (both depend on `infra`), referenced via `-Dlogback.configurationFile=logback-prod.xml` (classpath resource).
- Log directory parameterized via `-Dlogback.logs-dir`, so one config serves prod and dev.
- Archived logs are gzip-compressed (`.log.gz`) to save disk.
- Console appender dropped — stdout is redirected to `/dev/null` on deploy.

Local runs are unchanged (they keep the console-only `logback.xml` in each module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)