### PR TITLE
(little) frontend redesign

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,7 @@ lazy val server = project
     ),
     Compile / unmanagedResourceDirectories += (Assets / WebKeys.public).value,
     Compile / resourceGenerators += (Assets / WebKeys.assets).map(Seq(_)),
+    Compile / watchSources += Watched.WatchSource((Assets / sourceDirectory).value),
     fork := true,
     Compile / run / javaOptions ++= (infra / Compile / run / javaOptions).value,
     reStart / javaOptions ++= (infra / Compile / run / javaOptions).value,

--- a/modules/server/src/main/assets/css/base/_base.scss
+++ b/modules/server/src/main/assets/css/base/_base.scss
@@ -2,6 +2,10 @@
 // This file contains very base styles.
 // -----------------------------------------------------------------------------
 
+html {
+    background: $gray-darker;
+}
+
 .box {
     background: #fff;
     @include border-top-radius($border-radius-base);

--- a/modules/server/src/main/assets/css/partials/_admin.scss
+++ b/modules/server/src/main/assets/css/partials/_admin.scss
@@ -1,4 +1,20 @@
 .admin-content {
+  background: #fff;
+
+  .input-group {
+    display: flex;
+    margin-bottom: 10px;
+
+    .input-group-addon {
+      flex: 0 0 140px;
+      text-align: left;
+    }
+  }
+  margin: 40px auto;
+  padding: 30px;
+  @include border-top-radius($border-radius-base);
+  @include border-bottom-radius($border-radius-base);
+
   .table>thead>tr>th,
   .table>thead>tr>td,
   .table>tbody>tr>th,

--- a/modules/server/src/main/assets/css/partials/_awesome.scss
+++ b/modules/server/src/main/assets/css/partials/_awesome.scss
@@ -7,7 +7,17 @@
 }
 
 .awesome-header {
-  background: url("/assets/img/head-project-background.png") no-repeat center top #0D343C;
+  background-color: $gray-darker;
+  background-image:
+    linear-gradient(to bottom, rgba($gray-darker, 0.15) 0%, rgba($gray-darker, 0.8) 100%),
+    url("/assets/img/head-project-background.png");
+  background-repeat: no-repeat, no-repeat;
+  // This header is much shorter than the mountain image's own aspect ratio,
+  // so with background-size:cover, "top" position crops out the peaks on
+  // one side (whichever is lower in the source image) and leaves flat sky
+  // on the other. Centering the crop vertically keeps it visually even.
+  background-position: center center, center center;
+  background-size: auto, cover;
   padding: 20px 0;
 
   .container {

--- a/modules/server/src/main/assets/css/partials/_awesome.scss
+++ b/modules/server/src/main/assets/css/partials/_awesome.scss
@@ -81,6 +81,9 @@
     overflow: auto;
     background: white;
     padding: 20px;
+    @include border-top-radius($border-radius-base);
+    @include border-bottom-radius($border-radius-base);
+    @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.05));
     @media screen and (max-width: $screen-md-min) {
       margin: 0 15px 20px 15px;
     }  
@@ -140,6 +143,9 @@
     background: white;
     margin-bottom: 40px;
     padding: 30px 20px;
+    @include border-top-radius($border-radius-base);
+    @include border-bottom-radius($border-radius-base);
+    @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.05));
     h2 {
       text-align: center;
       text-transform: uppercase;
@@ -243,7 +249,7 @@
       color: rgba(255,255,255,0.5);
     }
   }
-  background: $gray-lighter;
+  background: $gray-darker;
   padding-bottom: 40px;
   @media screen and (min-width: $screen-md-min) {
       padding-bottom: 80px;

--- a/modules/server/src/main/assets/css/partials/_frontpage.scss
+++ b/modules/server/src/main/assets/css/partials/_frontpage.scss
@@ -2,8 +2,18 @@
 // -----------------------------------------------------------------------------
 #container-home {
   .home-search {
-    background: url('/assets/img/head-project-background.png') no-repeat center top #0D343C;
-    padding: 80px 0 100px 0;
+    // The image itself is 1920px wide with a flat rgb(13,52,60) fill baked
+    // into its own left/right edges (the mountain silhouette only occupies
+    // the middle). On viewports wider than that, background-color extends
+    // that same flat color outward so the image's edge blends in exactly,
+    // instead of scaling/stretching the image to fill the width.
+    background-color: rgb(13, 52, 60);
+    background-image:
+      linear-gradient(to bottom, rgba($gray-darker, 0) 0, rgba($gray-darker, 0) 220px, $gray-darker 271px),
+      url('/assets/img/head-project-background.png');
+    background-repeat: no-repeat, no-repeat;
+    background-position: center top, center top;
+    padding: 80px 0 40px 0;
     h1 {
       font-size: 42px;
       color: #fff;

--- a/modules/server/src/main/assets/css/partials/_frontpage.scss
+++ b/modules/server/src/main/assets/css/partials/_frontpage.scss
@@ -117,11 +117,78 @@
     }
   }
   .recent-projects {
-    padding: 40px 0 80px 0;
+    padding: 0 0 80px 0;
     h2 {
       margin-bottom: ($line-height-computed * 1.5);
+      color: $gray-lighter;
     }
-    a {
+    // Bootstrap's grid classes (float/margin/padding) fight with this custom
+    // layout with just enough specificity to win depending on where the JS
+    // masonry layout has currently reparented a card, so these box-model
+    // properties are reset unconditionally rather than scoped to one parent.
+    [class*="col-"] {
+      float: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      min-width: 0;
+      box-sizing: border-box;
+
+      > a {
+        display: block;
+        width: 100%;
+        min-width: 0;
+      }
+    }
+    .row {
+      // Base (no-JS) fallback: a plain wrapping grid, equal-ish widths.
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      margin: 0;
+
+      > [class*="col-"] {
+        display: flex;
+        width: calc(33.333% - 14px);
+      }
+
+      @media (max-width: $bp-medium) {
+        > [class*="col-"] {
+          width: calc(50% - 10px);
+        }
+      }
+
+      @media (max-width: $bp-small) {
+        > [class*="col-"] {
+          width: 100%;
+        }
+      }
+
+      // JS-enhanced real masonry: children become .masonry-col flex columns,
+      // each holding the items greedily assigned to it by actual height.
+      &.masonry-row {
+        flex-wrap: nowrap;
+        align-items: flex-start;
+        gap: 0;
+      }
+    }
+    .masonry-col {
+      flex: 1 1 0;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+
+      > [class*="col-"] {
+        display: flex;
+        width: 100%;
+      }
+    }
+    > .container > a.btn {
+      display: block;
+      width: 100%;
+      margin: 10px 0 0 0;
+    }
+    .row a {
       h4 {
         font-size: 16px;
       }

--- a/modules/server/src/main/assets/css/partials/_frontpage.scss
+++ b/modules/server/src/main/assets/css/partials/_frontpage.scss
@@ -201,42 +201,68 @@
         text-decoration: none;
         h4 {
           color: $brand-primary;
-          text-decoration: underline;
         }
       }
     }
   }
   .content-project {
     &.box {
-      padding: 10px;
+      padding: 22px;
     }
-    height: 186px;
-    margin-bottom: 30px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: auto;
+    min-height: 168px;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid rgba($gray-dark, 0.08);
+    @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.05));
+    transition: $base-transition;
     .content-project-header {
-      & > img,
-      & > h4 {
-        display: inline-block;
-        vertical-align: middle;
-      }
-      border-bottom: 1px solid rgba($gray-dark, 0.12);
-      padding-bottom: 20px;
-      margin-bottom: 20px;
+      display: flex;
+      align-items: center;
+      border-bottom: 1px solid rgba($gray-dark, 0.1);
+      padding-bottom: 16px;
+      margin-bottom: 16px;
       h4 {
         margin: 0;
-        display: inline-block;
-        padding-left: 15px;
-        width: 90%;
+        padding-left: 12px;
+        width: auto;
+        min-width: 0;
+        overflow-wrap: anywhere;
+        font-weight: 700;
+        color: $gray-darker;
       }
       img {
-        width: 28px;
-        height: auto;
-        float: left;
+        width: 32px;
+        height: 32px;
+        flex-shrink: 0;
+        @include border-top-radius(4px);
+        @include border-bottom-radius(4px);
       }
     }
-    .content-project-body {}
+    .content-project-body {
+      flex: 1;
+      min-width: 0;
+      color: $gray-light;
+      font-size: 13px;
+      .description {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        color: $gray;
+        font-size: $font-size-base;
+        margin-bottom: 8px;
+      }
+    }
     &:hover,
     &:focus {
-      @include box-shadow(0 1px 15px rgba(0, 0, 0, 0.15));
+      border-color: transparent;
+      @include box-shadow(0 10px 24px rgba(0, 0, 0, 0.12));
     }
   }
 }

--- a/modules/server/src/main/assets/css/partials/_github.scss
+++ b/modules/server/src/main/assets/css/partials/_github.scss
@@ -120,6 +120,24 @@
         }
     }
 
+    .markdown-heading {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+
+        .anchor {
+            margin-left: 0;
+        }
+
+        .anchor .octicon-link {
+            visibility: hidden;
+        }
+
+        &:hover .anchor .octicon-link {
+            visibility: visible;
+        }
+    }
+
 
     h1 {
         padding-bottom: 0.3em;

--- a/modules/server/src/main/assets/css/partials/_header.scss
+++ b/modules/server/src/main/assets/css/partials/_header.scss
@@ -82,6 +82,7 @@
           padding: 3px 8px;
           font-family: Caveat;
           font-size: 21px;
+          font-weight: 400;
         }
 
         .btn {

--- a/modules/server/src/main/assets/css/partials/_header.scss
+++ b/modules/server/src/main/assets/css/partials/_header.scss
@@ -10,7 +10,11 @@
     left: 0;
     position: absolute;
     z-index: 9999;
-    @include box-shadow(0 2px 20px rgba(0, 0, 0, 0.2));
+    margin-top: 8px;
+    overflow: hidden;
+    @include border-top-radius($border-radius-base);
+    @include border-bottom-radius($border-radius-base);
+    @include box-shadow(0 8px 24px rgba(0, 0, 0, 0.25));
     ul {
         padding: 0;
         margin: 0;

--- a/modules/server/src/main/assets/css/partials/_header.scss
+++ b/modules/server/src/main/assets/css/partials/_header.scss
@@ -66,11 +66,14 @@
         }
 
         .btn-default {
-          padding: 7px 8px;
-          background-color: #224951;
+          padding: 7px 12px;
+          background-color: transparent;
+          border: 1px solid rgba(#fff, 0.3);
           color: white;
           &:hover, &:focus {
-            opacity: 0.75;
+            background-color: rgba(#fff, 0.1);
+            border-color: rgba(#fff, 0.5);
+            opacity: 1;
             text-decoration: none;
           }
         }

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -66,59 +66,101 @@ main {
 // Common Pop-up
 .overlay {
   position: fixed;
-  z-index: 10;
+  z-index: 1000;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
-  background: rgba(0, 0, 0, 0.7);
   display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+
+  .overlay-backdrop {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba($gray-darker, 0.7);
+  }
 
   .popup {
-    margin: 70px auto;
-    padding: 40px 20px 20px 20px;
     background: #fff;
-    border-radius: 5px;
-    width: 60%;
-    position: relative;
-    transition: all 5s ease-in-out;
-    max-height: calc(100vh - 100px);
+    @include border-top-radius($border-radius-base * 2);
+    @include border-bottom-radius($border-radius-base * 2);
+    @include box-shadow(0 20px 50px rgba(0, 0, 0, 0.3));
+    padding: 36px;
+    width: 100%;
+    max-width: 520px;
+    max-height: calc(100vh - 40px);
     overflow: auto;
+    position: relative;
+    z-index: 1;
+    transition: transform $base-duration $base-timing, opacity $base-duration $base-timing;
 
     h2 {
       margin-top: 0;
+      font-size: 22px;
+    }
+
+    .intro {
+      color: $gray;
+    }
+
+    .steps {
+      padding-left: 20px;
+      margin-bottom: 0;
+      li {
+        margin-bottom: 10px;
+        padding-left: 6px;
+      }
+      .badge {
+        background: $brand-primary;
+      }
     }
 
     .close {
       position: absolute;
-      top: 20px;
-      right: 30px;
-      transition: all 200ms;
-      font-size: 30px;
-      font-weight: bold;
+      top: 16px;
+      right: 16px;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      color: $gray;
+      font-size: 22px;
+      line-height: 1;
       text-decoration: none;
+      transition: $base-transition;
 
       &:hover {
-        color: #06D85F;
+        background: $gray-lighter;
+        color: $gray-darker;
+        text-decoration: none;
       }
-    }
-
-    .content {
-      max-height: 30%;
-      overflow: auto;
     }
   }
 
   &:target {
-    display: block;
+    display: flex;
   }
 }
 
 // Result page
 // -----------------------------------------------------------------------------
 #container-search {
-  background: $gray-lighter;
+  background: $gray-darker;
   padding: 30px 0 40px 0;
+  > .container > h2,
+  > .container > .row > h4 {
+    color: $gray-lighter;
+  }
+  .search-subtitle {
+    min-height: 48px;
+  }
   @media screen and (min-width: $screen-md-min) {
     padding: 60px 0 80px 0;
   }

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -224,29 +224,70 @@ main {
     }
   }
 
-  .filters {
-    padding-left: 0;
-
-    li {
-      display: block;
-
-      input {
-        margin-right: 12px;
-      }
-    }
-  }
-
   .filters, .list-result {
     margin-top: 20px;
   }
 
   .list-result {
+    // Individual results are their own cards now, not one continuous box.
+    &.box {
+      background: transparent;
+      padding: 0;
+    }
+
+    // .no-results is on the SAME element as .list-result (not a descendant),
+    // hence "&" here instead of plain nesting.
+    &.no-results {
+      background: #fff;
+      padding: 30px;
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      color: $gray;
+      @include border-top-radius($border-radius-base);
+      @include border-bottom-radius($border-radius-base);
+
+      .fa-magnifying-glass {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 48px;
+        height: 48px;
+        flex-shrink: 0;
+        border-radius: 50%;
+        background: $gray-lighter;
+        font-size: 18px;
+        color: $gray-light;
+      }
+      p {
+        margin: 0 0 4px 0;
+        font-size: 18px;
+      }
+      .hint {
+        font-size: 14px;
+        color: $gray-light;
+      }
+    }
+
     .item-list {
       display: block;
+      background: #fff;
 
-      padding: 15px 0;
-      margin: 0;
-      border-bottom: 1px solid rgba($gray-dark, 0.12);
+      padding: 20px;
+      margin: 0 0 16px 0;
+      border: 1px solid rgba($gray-dark, 0.08);
+      @include border-top-radius($border-radius-base);
+      @include border-bottom-radius($border-radius-base);
+      @include box-shadow(0 1px 3px rgba(0, 0, 0, 0.05));
+      transition: $base-transition;
+
+      &:hover, &:focus {
+        @include box-shadow(0 6px 16px rgba(0, 0, 0, 0.1));
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
 
       .targets,
       .homepage,

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -15,7 +15,7 @@ main {
 }
 
 .banner {
-  background: #0c353c;
+  background: $gray-darker;
   text-align: center;
   padding: 8px 0;
   color: #fff;
@@ -126,6 +126,7 @@ main {
   .filter-tag {
     margin: 0;
     padding: 10px 0 0 0;
+    color: $gray-lighter;
   }
   .filter-tag {
     li {
@@ -147,6 +148,20 @@ main {
     h3 {
       display: inline-block;
       margin-right: 20px;
+      color: $gray-lighter;
+    }
+
+    .btn-group .btn-default {
+      background: rgba(#fff, 0.08);
+      border-color: transparent;
+      color: $gray-lighter;
+      &:hover {
+        background: rgba(#fff, 0.15);
+      }
+      &.active {
+        background: #fff;
+        color: $gray-darker;
+      }
     }
 
     .btn-primary {

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -381,12 +381,126 @@ main {
   }
 }
 
-html, body {
-  height: 100%;
+// Used by both the search results sidebar (#container-search) and the
+// Awesome Scala sidebar (#container-awesome-*), which live on different
+// page-level containers, so this stays unscoped rather than tied to one.
+.filters {
+  padding-left: 0;
+
+  // The controls are nested inside a <form>, not direct children of
+  // .filters, hence the descendant (not child) selectors here.
+  .btn {
+    width: 100%;
+    margin-bottom: 20px;
+  }
+
+  h3 {
+    margin-top: 0;
+    color: $gray-lighter;
+  }
+
+  fieldset {
+    border: none;
+    margin: 0 0 24px 0;
+    padding: 0 0 20px 0;
+    border-bottom: 1px solid rgba(#fff, 0.12);
+
+    &:last-of-type {
+      border-bottom: none;
+      padding-bottom: 0;
+      margin-bottom: 0;
+    }
+
+    legend {
+      all: unset;
+      display: block;
+      width: 100%;
+      font-family: $font-family-serif;
+      font-weight: 700;
+      font-size: 15px;
+      color: $gray-lighter;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-bottom: 10px;
+    }
+
+    ul {
+      max-height: 260px;
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+  }
+
+  li {
+    display: block;
+
+    label {
+      display: flex;
+      align-items: center;
+      margin-bottom: 0;
+      padding: 5px 0;
+      font-weight: 400;
+      color: $gray-light;
+      cursor: pointer;
+      transition: $base-transition;
+
+      &:hover {
+        color: #fff;
+      }
+    }
+
+    input[type="checkbox"] {
+      appearance: none;
+      -webkit-appearance: none;
+      margin-right: 10px;
+      width: 17px;
+      height: 17px;
+      flex-shrink: 0;
+      border: 2px solid rgba(#fff, 0.25);
+      border-radius: 4px;
+      background: transparent;
+      position: relative;
+      cursor: pointer;
+      transition: $base-transition;
+
+      &:hover {
+        border-color: $brand-primary;
+      }
+
+      &:checked {
+        background: $brand-primary;
+        border-color: $brand-primary;
+
+        &::after {
+          content: '';
+          position: absolute;
+          left: 5px;
+          top: 1px;
+          width: 4px;
+          height: 8px;
+          border: solid #fff;
+          border-width: 0 2px 2px 0;
+          transform: rotate(45deg);
+        }
+      }
+    }
+  }
 }
 
 .white {
   color: #fff;
+}
+
+// Simple standalone pages (404, 403, invalid query) with no page-level
+// container of their own, so they sit directly on the dark body background.
+.error-page {
+  padding: 60px 0;
+  h1 {
+    color: $gray-lighter;
+  }
+  a {
+    color: $brand-primary;
+  }
 }
 
 .float-right {

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -320,13 +320,18 @@ main {
         padding-left: 22px;
         margin-top: 12px;
         span {
-          margin-left: 20px;
           a {
             &:hover,
             &:focus {
               text-decoration: none;
             }
           }
+        }
+        > div:first-child {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: flex-end;
+          gap: 6px;
         }
         .item-filter-tag {
           color: $gray-light;

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -367,6 +367,10 @@ main {
       }
     }
     .contributing-result {
+      ul {
+        list-style: none;
+        padding-left: 0;
+      }
       a {
         display: block;
         padding-bottom: 10px;

--- a/modules/server/src/main/assets/css/partials/_main.scss
+++ b/modules/server/src/main/assets/css/partials/_main.scss
@@ -333,10 +333,25 @@ main {
           justify-content: flex-end;
           gap: 6px;
         }
+        // Same pill as the topic tags on the project page (.label.label-default),
+        // but with a solid darker background - the translucent version reads
+        // fine on the dark hero but washes out on these white cards.
         .item-filter-tag {
-          color: $gray-light;
-          font-style: italic;
-          font-weight: 300;
+          display: inline-block;
+          padding: .2em .6em .3em;
+          background-color: $gray-dark;
+          color: #fff;
+          font-style: normal;
+          font-weight: 500;
+          font-size: 75%;
+          line-height: 1;
+          white-space: nowrap;
+          cursor: pointer;
+          border-radius: .25em;
+
+          &:hover {
+            color: #fff;
+          }
         }
         .icons-container{
           display: inline-grid;

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -468,7 +468,8 @@
     }
 
     .artifact-version {
-      font-size: 30px;
+      font-size: 20px;
+      font-weight: 700;
       color: $brand-secondary;
       &:active,
       &:focus,

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -131,23 +131,108 @@
   .edit-project {
     h1 {
       margin-top: 0;
-      margin-bottom: 40px;
+      margin-bottom: 30px;
     }
-    .btn-default {
-      background: $gray-lighter;
-      margin-left: 10px;
-      &:focus,
-      &:hover {
-        background: $gray-light;
-        color: $gray-lighter;
+
+    .settings-section {
+      padding: 24px 0;
+      border-bottom: 1px solid $gray-lighter;
+
+      &:first-of-type {
+        padding-top: 0;
+      }
+      &:last-of-type {
+        border-bottom: none;
       }
 
+      h2 {
+        margin: 0 0 20px 0;
+        font-size: 18px;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: $gray;
+      }
     }
-    fieldset fieldset legend {
-      font-size: 16px;
+
+    .form-group {
+      margin-bottom: 24px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      > label {
+        display: block;
+        font-weight: 700;
+        color: $gray-darker;
+        margin-bottom: 4px;
+      }
+
+      .help {
+        color: $gray-light;
+        font-size: 14px;
+        margin: 0 0 10px 0;
+
+        code {
+          font-size: 12px;
+        }
+      }
+
+      .form-control,
+      .selectpicker + .dropdown-toggle,
+      .bootstrap-select {
+        max-width: 480px;
+      }
+
+      .selectpicker + .dropdown-toggle,
+      .bootstrap-select {
+        width: 100% !important;
+      }
     }
-    img[alt="Contributors Wanted"] {
-      background-color: #002b37;
+
+    .form-group-toggle {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 20px;
+
+      .form-group-toggle-text {
+        > label {
+          margin-bottom: 0;
+        }
+
+        .help {
+          margin: 4px 0 0 0;
+        }
+      }
+
+      input[type="checkbox"] {
+        flex-shrink: 0;
+        margin-top: 2px;
+      }
+    }
+
+    .documentation-links {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      li {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 10px;
+
+        .form-control {
+          flex: 1 1 0;
+        }
+      }
+    }
+
+    .settings-actions {
+      display: flex;
+      gap: 10px;
+      padding-top: 24px;
+      margin-top: 4px;
     }
   }
 

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -259,13 +259,16 @@
   
   .head-project {
     padding: 20px 0;
-    background-color: $gray-darker;
+    // Same treatment as the homepage hero: keep the image at its native
+    // size (no stretching/zooming to "cover" a tall box) and fade its own
+    // bottom edge into a flat extension of the image's own edge color,
+    // instead of a hard cutoff into the content box below.
+    background-color: rgb(13, 52, 60);
     background-image:
-      linear-gradient(to bottom, rgba($gray-darker, 0.15) 0%, rgba($gray-darker, 0.8) 100%),
+      linear-gradient(to bottom, rgba($gray-darker, 0) 0, rgba($gray-darker, 0) 220px, $gray-darker 271px),
       url('/assets/img/head-project-background.png');
     background-repeat: no-repeat, no-repeat;
     background-position: center top, center top;
-    background-size: auto, cover;
     color: #fff;
     .head-last-version {
       color: $gray-lighter;

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -408,14 +408,6 @@
         display: inline;
       }
     }
-    .btn-secondary {
-      .filter-option-inner-inner {
-        color: $headings-color;
-      }
-      .caret {
-        color: $headings-color;
-      }
-    }
     .dropdown {
       margin-right: 15px;
     }

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -1,7 +1,7 @@
 // Project page
 // -----------------------------------------------------------------------------
 #container-project {
-  background: $gray-lighter;
+  background: $gray-darker;
   padding: 0 0 40px 0;
 
   .content-project {
@@ -192,7 +192,7 @@
         margin-left: 10px;
         margin-top: 0;
         margin-bottom: 12px;
-        background: #3985aaba;
+        background: rgba($brand-secondary, 0.7);
         color: aliceblue;
         border-radius: 32px;
         padding: 3px 10px;

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -39,30 +39,6 @@
   }
 
   .content-main {
-    .markdown-body {
-      .anchor {
-        display: inline-block;
-        padding-right: 2px;
-        margin-left: -18px;
-      }
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        &:hover {
-          .octicon-link {
-            visibility: visible;
-          }
-        }
-        .octicon-link {
-          vertical-align: middle;
-          visibility: hidden;
-        }
-      }
-    }
-
     h3 {
       margin-top: ($line-height-computed / 1.7);
       margin-bottom: $line-height-computed;

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -55,6 +55,12 @@
   .dependencies,
   .dependents {
     overflow: hidden;
+    .row {
+      > div {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+    }
     span {
       i {
         font-size: 14px;
@@ -62,10 +68,13 @@
     }
     .label {
       font-size: 10px;
-      padding: 2px 5px;
-      top: -2px;
-      position: relative;
+      padding: 2px 6px;
+      top: 0;
+      position: static;
+      vertical-align: middle;
       margin-left: 5px;
+      background-color: $gray-dark;
+      cursor: help;
     }
   }
 

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -259,7 +259,13 @@
   
   .head-project {
     padding: 20px 0;
-    background: url('/assets/img/head-project-background.png') no-repeat center top #0D343C;
+    background-color: $gray-darker;
+    background-image:
+      linear-gradient(to bottom, rgba($gray-darker, 0.15) 0%, rgba($gray-darker, 0.8) 100%),
+      url('/assets/img/head-project-background.png');
+    background-repeat: no-repeat, no-repeat;
+    background-position: center top, center top;
+    background-size: auto, cover;
     color: #fff;
     .head-last-version {
       color: $gray-lighter;

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -351,10 +351,26 @@
   }
 
   .artifacts, .versions {
+    .artifacts-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 10px;
+
+      h2 {
+        margin: 0;
+      }
+
+      .float-right {
+        float: none;
+      }
+    }
     .center {
       @media (min-width: $screen-md-min) {
         display: flex;
-        justify-content: center;
+        justify-content: flex-start;
         align-items: center;
       }
     }

--- a/modules/server/src/main/assets/css/utilities/_variables.scss
+++ b/modules/server/src/main/assets/css/utilities/_variables.scss
@@ -6,25 +6,25 @@
 //------------------------------------------------------------------------------
 
 $brand-primary: rgb(242, 101, 39);
-$brand-secondary: rgb(0, 63, 145);
+$brand-secondary: #073642;
 $gray-darker: rgb(0, 43, 55);
 $gray-dark: rgb(34, 73, 81);
 $gray: rgb(88, 110, 117);
-$gray-light: rgb(125, 147, 154);
-$gray-lighter: rgb(237, 241, 241);
+$gray-light: rgb(137, 146, 149);
+$gray-lighter: rgb(229, 234, 234);
 
 
 // Scaffolding
 //------------------------------------------------------------------------------
 
 $text-color: $gray;
-$body-bg: $gray-lighter;
+$body-bg: $gray-darker;
 
 //Typography
 //------------------------------------------------------------------------------
 
-// Source Sans Pro
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,400italic,600,700);
+// Lato
+@import url(https://fonts.googleapis.com/css?family=Lato:400,300,400italic,600,700);
 
 // Roboto Slab
 @import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,300,700);
@@ -32,7 +32,7 @@ $body-bg: $gray-lighter;
 // Caveat
 @import url(https://fonts.googleapis.com/css?family=Caveat);
 
-$font-family-sans-serif: "Source Sans Pro", sans-serif;
+$font-family-sans-serif: "Lato", sans-serif;
 $font-family-serif: "Roboto Slab", serif;
 $font-size-base: 16px;
 $line-height-base: 1.528571429;
@@ -51,7 +51,7 @@ $headings-color: $gray-dark;
 // Components
 //------------------------------------------------------------------------------
 
-$border-radius-base: 2px;
+$border-radius-base: 6px;
 
 // Tooltips
 //------------------------------------------------------------------------------
@@ -62,6 +62,15 @@ $tooltip-bg: $gray-darker;
 //------------------------------------------------------------------------------
 
 $input-color-placeholder: $gray-light;
+$input-border: rgb(214, 221, 221);
+$input-border-focus: $brand-secondary;
+
+// Buttons
+//------------------------------------------------------------------------------
+
+$btn-default-color: $gray-dark;
+$btn-default-bg: #fff;
+$btn-default-border: rgb(214, 221, 221);
 
 // Navs
 //------------------------------------------------------------------------------

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
@@ -16,13 +16,23 @@
 }
 
 // bootstrap-sass has no built-in "secondary" button variant, so a
-// data-style="btn-secondary" select would otherwise pick up whatever
-// color the browser/bootstrap-select default happens to be - inconsistent
-// from one page to another. Pin it to the same text color everywhere.
+// data-style="btn-secondary" select would otherwise get no background/
+// border at all (just whatever the browser's native button default is -
+// an ugly gray) and pick up inconsistent text color from one page to
+// another. Give it the same white/bordered look as .btn-default.
 .btn-secondary {
+    background-color: #fff;
+    border-color: $input-border;
+
     .filter-option-inner-inner,
     .caret {
         color: $headings-color;
+        font-weight: 400;
+    }
+
+    &:hover, &:focus, &.focus {
+        background-color: #fff;
+        border-color: $input-border;
     }
 }
 

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
@@ -3,8 +3,15 @@
 // Bootstrap’s Selects default CSS.
 // -----------------------------------------------------------------------------
 .bootstrap-select {
-    .dropdown-toggle:focus {
-        outline: none !important;
+    // Some of these selects (e.g. "Other Artifacts") sit inside an <h2>,
+    // which otherwise leaks its serif heading font/weight into the button.
+    .dropdown-toggle {
+        font-family: $font-family-sans-serif;
+        font-weight: 400;
+
+        &:focus {
+            outline: none !important;
+        }
     }
 }
 

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-select.scss
@@ -8,6 +8,17 @@
     }
 }
 
+// bootstrap-sass has no built-in "secondary" button variant, so a
+// data-style="btn-secondary" select would otherwise pick up whatever
+// color the browser/bootstrap-select default happens to be - inconsistent
+// from one page to another. Pin it to the same text color everywhere.
+.btn-secondary {
+    .filter-option-inner-inner,
+    .caret {
+        color: $headings-color;
+    }
+}
+
 .order-by {
     .bootstrap-select {
         &:not([class*="col-"]):not([class*="form-control"]):not(.input-group-btn) {

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-switch.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-switch.scss
@@ -1,14 +1,18 @@
+// Sized/weighted to match the .btn-secondary dropdowns it usually sits next
+// to (e.g. the Target filter) - same ~40px height, same normal-weight,
+// sentence-case type, instead of a shorter, bold, all-caps pill.
 .bootstrap-switch {
-  border: none;
+  border: 1px solid $input-border;
+  overflow: hidden;
   @include border-top-radius($border-radius-base);
   @include border-bottom-radius($border-radius-base);
   @include box-shadow(0 1px 2px rgba(0, 0, 0, 0.08));
 
   .bootstrap-switch-label {
-    padding: 7px;
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1.52857;
+    padding: 10px 7px;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.2;
     background: #fff;
     color: $gray-dark;
   }
@@ -16,10 +20,10 @@
   .bootstrap-switch-handle-on,
   .bootstrap-switch-handle-off {
     border: none;
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    font-size: 13px;
+    font-weight: 400;
   }
 
   .bootstrap-switch-handle-on.bootstrap-switch-brand {

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-switch.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap-switch.scss
@@ -1,7 +1,34 @@
 .bootstrap-switch {
+  border: none;
+  @include border-top-radius($border-radius-base);
+  @include border-bottom-radius($border-radius-base);
+  @include box-shadow(0 1px 2px rgba(0, 0, 0, 0.08));
+
   .bootstrap-switch-label {
     padding: 7px;
-    font-size: 16px;
-    line-height:1.52857;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.52857;
+    background: #fff;
+    color: $gray-dark;
+  }
+
+  .bootstrap-switch-handle-on,
+  .bootstrap-switch-handle-off {
+    border: none;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .bootstrap-switch-handle-on.bootstrap-switch-brand {
+    color: #fff;
+    background: $brand-secondary;
+  }
+
+  .bootstrap-switch-handle-off.bootstrap-switch-brand-off {
+    color: $gray-light;
+    background: $gray-lighter;
   }
 }

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap.scss
@@ -49,7 +49,9 @@ body {
 // Buttons
 //------------------------------------------------------------------------------
 .btn {
-    border: none;
+    border: 1px solid transparent;
+    font-weight: 600;
+    transition: background-color $base-duration $base-timing, border-color $base-duration $base-timing, color $base-duration $base-timing, opacity $base-duration $base-timing, box-shadow $base-duration $base-timing;
     @include button-size(($padding-base-vertical + 1), ($padding-base-horizontal + 8), $font-size-base, $line-height-base, $btn-border-radius-base);
     &:active,
     &.active {
@@ -64,6 +66,15 @@ body {
         &:first-child {
             margin-left: 0;
         }
+    }
+}
+
+.btn-default {
+    &:hover,
+    &:focus {
+        background-color: darken($gray-lighter, 8%);
+        border-color: darken($gray-lighter, 8%);
+        color: $gray-darker;
     }
 }
 

--- a/modules/server/src/main/assets/css/vendors-extensions/_bootstrap.scss
+++ b/modules/server/src/main/assets/css/vendors-extensions/_bootstrap.scss
@@ -16,7 +16,14 @@ body {
 // Forms
 //------------------------------------------------------------------------------
 .form-control {
+    border-color: $input-border;
     box-shadow: none !important;
+    transition: border-color $base-duration $base-timing, box-shadow $base-duration $base-timing;
+
+    &:focus {
+        border-color: $input-border-focus;
+        box-shadow: 0 0 0 3px rgba($input-border-focus, 0.15) !important;
+    }
 }
 
 .has-feedback {

--- a/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
@@ -21,7 +21,7 @@ class FrontPage(env: Env, database: WebDatabase, searchEngine: SearchEngine)(usi
   // drop whichever ones don't fit well, instead of stretching a card to
   // force the columns to line up.
   val displayedProjects = 12
-  val limitOfProjects = displayedProjects + 4
+  val limitOfProjects: Int = displayedProjects + 4
 
   def route(userState: Option[UserState]): Route = pathSingleSlash(complete(frontPage(userState)))
 

--- a/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/FrontPage.scala
@@ -16,7 +16,12 @@ import org.apache.pekko.http.scaladsl.server.Route
 import play.twirl.api.HtmlFormat
 
 class FrontPage(env: Env, database: WebDatabase, searchEngine: SearchEngine)(using ExecutionContext):
-  val limitOfProjects = 12
+  // We fetch a few extra projects beyond what's displayed so the client can
+  // arrange the masonry grid on the homepage using real card heights and
+  // drop whichever ones don't fit well, instead of stretching a card to
+  // force the columns to line up.
+  val displayedProjects = 12
+  val limitOfProjects = displayedProjects + 4
 
   def route(userState: Option[UserState]): Route = pathSingleSlash(complete(frontPage(userState)))
 

--- a/modules/template/src/main/scala/scaladex/view/Formats.scala
+++ b/modules/template/src/main/scala/scaladex/view/Formats.scala
@@ -1,20 +1,19 @@
 package scaladex.view
 
 object Formats:
-  // TODO: add tests
+  private def pluralize(word: String, plural: String): String =
+    if plural.nonEmpty then plural
+    else if word.endsWith("y") then s"${word.dropRight(1)}ies"
+    else s"${word}s"
+
   def plural(n: Long, word: String, plural: String = ""): String =
     n match
-      case 0 => s"No $word"
+      case 0 => s"No ${pluralize(word, plural)}"
       case 1 => s"$n $word"
-      case _ if plural.isEmpty && word.endsWith("y") => s"$n ${word.dropRight(1)}ies"
-      case _ if plural.isEmpty => s"$n ${word}s"
-      case _ => s"$n $plural"
+      case _ => s"$n ${pluralize(word, plural)}"
 
   def wordPlural(n: Long, word: String, plural: String = ""): String =
     n match
-      case 0 => s"$word"
-      case 1 => s"$word"
-      case _ if plural.isEmpty && word.endsWith("y") => s"${word.dropRight(1)}ies"
-      case _ if plural.isEmpty => s"${word}s"
-      case _ => s"$plural"
+      case 1 => word
+      case _ => pluralize(word, plural)
 end Formats

--- a/modules/template/src/main/twirl/scaladex/view/awesome/awesomeCategory.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/awesomeCategory.scala.html
@@ -1,4 +1,5 @@
 @import scaladex.view.html._
+@import scaladex.view.Formats
 @import scaladex.core.model.UserState
 @import scaladex.core.model.Platform
 @import scaladex.core.model.Env
@@ -42,10 +43,12 @@
         <div class="col-md-9 col-md-offset-3 topbar">
           <div class="col-md-3">
             <div class="result-count">
-              @if(projects.pagination.current == 1) {
-                @projects.pagination.totalSize results
-              } else {
-                Page @projects.pagination.current of @projects.pagination.totalSize results
+              @if(projects.pagination.totalSize > 0) {
+                @if(projects.pagination.current == 1) {
+                  @Formats.plural(projects.pagination.totalSize, "result")
+                } else {
+                  Page @projects.pagination.current of @Formats.plural(projects.pagination.totalSize, "result")
+                }
               }
             </div>
           </div>

--- a/modules/template/src/main/twirl/scaladex/view/awesome/filter.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/filter.scala.html
@@ -6,7 +6,7 @@
 @import scaladex.core.model.search.AwesomeParams
 
 @(
-  category: Category, 
+  category: Category,
   languages: Seq[(Language, Int)],
   platforms: Seq[(Platform, Int)],
   params: AwesomeParams
@@ -15,33 +15,37 @@
   <form action="/awesome/@category.label" action="GET">
     <input type="hidden" name="sort" value="@params.sorting.label">
     <h3>Filters</h3>
-    <fieldset>
-      <legend>Languages</legend>
-      <ul>
-      @for((language, count) <- languages) {
-        <li>
-          <label>
-            <input type="checkbox" @if(params.languages.contains(language)) { checked }
-                    name="language" value="@language.value" onclick="this.form.submit()">
-            @language (@count)
-          </label>
-        </li>
-      }
-      </ul>
-    </fieldset>
-    <fieldset>
-      <legend>Platforms</legend>
-      <ul>
-      @for((platform, count) <- platforms) {
-        <li>
-          <label>
-            <input type="checkbox" @if(params.platforms.contains(platform)) { checked }
-                    name="platform" value="@platform.value" onclick="this.form.submit()">
-            @platform (@count)
-          </label>
-        </li>
-      }
-      </ul>
-    </fieldset>
+    @if(languages.nonEmpty) {
+      <fieldset>
+        <legend>Languages</legend>
+        <ul>
+        @for((language, count) <- languages) {
+          <li>
+            <label>
+              <input type="checkbox" @if(params.languages.contains(language)) { checked }
+                      name="language" value="@language.value" onclick="submitFilterFormAjax(this.form, '#container-awesome-category')">
+              @language (@count)
+            </label>
+          </li>
+        }
+        </ul>
+      </fieldset>
+    }
+    @if(platforms.nonEmpty) {
+      <fieldset>
+        <legend>Platforms</legend>
+        <ul>
+        @for((platform, count) <- platforms) {
+          <li>
+            <label>
+              <input type="checkbox" @if(params.platforms.contains(platform)) { checked }
+                      name="platform" value="@platform.value" onclick="submitFilterFormAjax(this.form, '#container-awesome-category')">
+              @platform (@count)
+            </label>
+          </li>
+        }
+        </ul>
+      </fieldset>
+    }
   </form>
 </div>

--- a/modules/template/src/main/twirl/scaladex/view/awesome/howToContribute.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/howToContribute.scala.html
@@ -1,17 +1,18 @@
 <div class="how-to">
-  <a class="btn btn-default" href="#how-to-popup">How to contribute</a>
+  <a class="btn btn-default" href="#how-to-popup"><i class="fa-solid fa-circle-info"></i> How to contribute</a>
   <div id="how-to-popup" class="overlay">
+    <a class="overlay-backdrop" href="#" aria-label="Close"></a>
     <div class="popup">
+      <a class="close" href="#" aria-label="Close">&times;</a>
       <h2>How to contribute to <span class="awesome">Awesome Scala</span></h2>
-      <a class="close" href="#">&times;</a>
-      <div class="content">
-        <p>
-          As a library author, you can help Scaladex users find you library by tagging your project with one of the proposed categories.
-        </p>
-        <p>
-          To do so, log in with your Github credentials, go to your project page and click the <span class="badge">Edit</span> button.
-        </p>
-      </div>
+      <p class="intro">
+        As a library author, you can help Scaladex users find your library by tagging your project with one of the proposed categories.
+      </p>
+      <ol class="steps">
+        <li>Log in with your GitHub credentials.</li>
+        <li>Go to your project's page on Scaladex.</li>
+        <li>Click the <span class="badge">Edit</span> button and pick a category.</li>
+      </ol>
     </div>
   </div>
 </div>

--- a/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
@@ -2,6 +2,15 @@
 @import scaladex.core.model.search.ProjectDocument
 
 @(projects: Seq[ProjectDocument])
+@if(projects.isEmpty) {
+  <div class="list-result box no-results">
+    <i class="fa-solid fa-magnifying-glass"></i>
+    <div>
+      <p>No projects match your search.</p>
+      <p class="hint">Try a different query or remove some filters.</p>
+    </div>
+  </div>
+} else {
 <ol class="list-result box">
   @for(project <- projects){
   <li class="item-list">
@@ -112,3 +121,4 @@
   </li>
   }
 </ol>
+}

--- a/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
@@ -82,11 +82,7 @@
             @for(github <- project.githubInfo) {
               @if(github.topics.nonEmpty) {
                 @for(topic <- github.topics) {
-                  <span class="item-filter-tag">
-                    <a href="/search?topic=@topic">
-                      @topic
-                    </a>
-                  </span>
+                  <span class="item-filter-tag" data-topic-href="/search?topic=@topic">@topic</span>
                 }
               }
             }

--- a/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/awesome/resultList.scala.html
@@ -96,21 +96,21 @@
             @for(github <- project.githubInfo) {
               @for(stars <- github.stars) {
                 <span>
-                  <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Stars" href="#"><span>@stars</span><i class="fa-solid fa-star"></i></a>
+                  <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Stars"><span>@stars</span><i class="fa-solid fa-star"></i></span>
                 </span>
               }
               @for(forks <- github.forks) {
                 <span>
-                  <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Forks" href="#"><span>@forks</span><i class="fa-solid fa-code-branch"></i></a>
+                  <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Forks"><span>@forks</span><i class="fa-solid fa-code-branch"></i></span>
                 </span>
               }
               @for(commitsPerYear <- github.commitsPerYear){
                 <span>
-                  <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Commits in the past year" href="#"><span>@commitsPerYear</span><i class="fa-solid fa-code-merge"></i></a>
+                  <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Commits in the past year"><span>@commitsPerYear</span><i class="fa-solid fa-code-merge"></i></span>
                 </span>
               }
               <span>
-                <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Contributors" href="#"><span>@github.contributorCount</span><i class="fa-solid fa-users"></i></a>
+                <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Contributors"><span>@github.contributorCount</span><i class="fa-solid fa-users"></i></span>
               </span>
             }
             </div>

--- a/modules/template/src/main/twirl/scaladex/view/forbidden.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/forbidden.scala.html
@@ -3,7 +3,7 @@
 
 @(env: Env, user: Option[UserState])
 @main(env, title = "Forbidden", user) {
-<main>
+<main class="error-page">
   <h1>Forbidden</h1>
 </main>
 }

--- a/modules/template/src/main/twirl/scaladex/view/frontpage.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/frontpage.scala.html
@@ -2,6 +2,7 @@
 @import scaladex.core.model.search.SearchParams
 @import scaladex.core.model._
 @import scaladex.view.model.EcosystemHighlight
+@import scaladex.view.Formats
 
 @(
   env: Env,
@@ -102,7 +103,7 @@
       <div class="ecosystem-badge col-sm-4">
         <a href="@highlight.currentVersion.search.target">
           <h4 class="badge-title">@highlight.ecosystem @highlight.currentVersion.version</h4>
-          <p>@highlight.currentVersion.libraryCount projects</p>
+          <p>@Formats.plural(highlight.currentVersion.libraryCount.toLong, "project")</p>
         </a>
         @if(highlight.otherVersions.nonEmpty) {
           <p class="badge-other-versions">Other versions: @highlight.otherVersions.map { ver => <a href="@ver.search.target">@ver.version</a>}</p>

--- a/modules/template/src/main/twirl/scaladex/view/invalidQuery.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/invalidQuery.scala.html
@@ -4,7 +4,7 @@
 
 @(env: Env, user: Option[UserState], params: SearchParams)
 @main(env, title = "Invalid Query", showSearch = true, params = params, user = user) {
-<main class="container">
+<main class="container error-page">
   <h1>Not a valid query</h1>
   <pre>@params.queryString</pre>
   <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax" target="_blank" rel="noreferrer">

--- a/modules/template/src/main/twirl/scaladex/view/main.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/main.scala.html
@@ -169,21 +169,165 @@
     }
 
     <script>
-        // Tooltips
-        $(function () {
-          $('[data-toggle="tooltip"]').tooltip();
-          $(".js-keywords-multiple").select2({tags: true});
-          $(".js-stackoverflowtags-multiple").select2({tags: true});
-          $('.edit-project input[type="checkbox"]').bootstrapSwitch();
-          $('#stable-only').bootstrapSwitch({
+        // Init/re-init widgets on a chunk of content, so they still work
+        // after an AJAX content swap (see ajaxSwap below).
+        function initPageWidgets(scope) {
+          var $scope = $(scope || document);
+          $scope.find('[data-toggle="tooltip"]').tooltip({container: 'body'});
+          $scope.find('.selectpicker').selectpicker();
+          $scope.find('#stable-only').bootstrapSwitch({
             handleWidth: 30,
             labelWidth: 78,
             labelText: 'Stable Only',
-            onSwitchChange: function(event, state){
-              console.log(event)
-              event.target.form.submit()
+            onColor: 'brand',
+            offColor: 'brand-off',
+            onSwitchChange: function (event, state) {
+              submitFilterFormAjax(event.target.form);
             }
           });
+          if (window.emojify) { emojify.run(); }
+          if (window.ScaladexClient) { ScaladexClient.createSparkline(); }
+        }
+
+        // Several links/forms (the artifacts/versions filters, the project
+        // tabs, the search sorting tabs) used to submit a form or follow a
+        // link the plain way, causing a full page reload. Instead, fetch the
+        // target URL and swap in just the relevant content card.
+        function ajaxSwap(targetUrl, contentSelector) {
+          fetch(targetUrl)
+            .then(function (res) { return res.text(); })
+            .then(function (html) {
+              var doc = new DOMParser().parseFromString(html, 'text/html');
+              var newContent = doc.querySelector(contentSelector);
+              var oldContent = document.querySelector(contentSelector);
+              if (newContent && oldContent) {
+                oldContent.replaceWith(newContent);
+                history.pushState({}, '', targetUrl);
+                if (doc.title) { document.title = doc.title; }
+                initPageWidgets(newContent);
+              } else {
+                window.location = targetUrl;
+              }
+            })
+            .catch(function () {
+              window.location = targetUrl;
+            });
+        }
+
+        function submitFilterFormAjax(form, contentSelector) {
+          var params = new URLSearchParams(new FormData(form));
+          var targetUrl = window.location.pathname + '?' + params.toString();
+          ajaxSwap(targetUrl, contentSelector || '.content-project.box');
+        }
+
+        // Project tabs (Project / Artifacts / Versions / Badges / Settings)
+        // and the search results' "Sorting" tabs.
+        document.addEventListener('click', function (event) {
+          var tabLink = event.target.closest('.project-nav-bar a');
+          if (tabLink && tabLink.href) {
+            event.preventDefault();
+            ajaxSwap(tabLink.href, '#container-project');
+          }
+        });
+
+        // The "Sorting" control is a button-group form (each button is a
+        // submit button carrying name="sort"), not plain links.
+        document.addEventListener('submit', function (event) {
+          var form = event.target;
+          if (form.closest && form.closest('.order-by')) {
+            event.preventDefault();
+            var params = new URLSearchParams(new FormData(form, event.submitter));
+            var targetUrl = window.location.pathname + '?' + params.toString();
+            ajaxSwap(targetUrl, '#container-search');
+          }
+        });
+
+        window.addEventListener('popstate', function () {
+          window.location.reload();
+        });
+
+        // Tooltips
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip({container: 'body'});
+          $(".js-keywords-multiple").select2({tags: true});
+          $(".js-stackoverflowtags-multiple").select2({tags: true});
+          $('.edit-project input[type="checkbox"]').bootstrapSwitch();
+          initPageWidgets(document);
+        });
+
+        // Real masonry for the homepage project grids: each card is greedily
+        // assigned to whichever column is currently shortest, using its
+        // actual rendered height. The server sends a few more cards than we
+        // display so that, whatever their heights turn out to be, we can
+        // drop the ones that don't help balance the columns instead of
+        // stretching a card to force them to line up.
+        var MASONRY_DISPLAY_COUNT = 12;
+        var masonryRows = [];
+
+        function columnCountFor(width) {
+          if (width <= 480) { return 1; }
+          if (width <= 768) { return 2; }
+          return 3;
+        }
+
+        function layoutMasonryRow(entry) {
+          var row = entry.row;
+          var items = entry.items;
+          row.querySelectorAll('.masonry-col').forEach(function (col) { col.remove(); });
+          items.forEach(function (item) { item.remove(); });
+
+          var columnCount = columnCountFor(row.getBoundingClientRect().width || window.innerWidth);
+          if (columnCount <= 1) {
+            row.classList.remove('masonry-row');
+            items.slice(0, MASONRY_DISPLAY_COUNT).forEach(function (item) { row.appendChild(item); });
+            return;
+          }
+
+          var gapPx = 20;
+          var rowWidth = row.getBoundingClientRect().width;
+          var colWidth = (rowWidth - gapPx * (columnCount - 1)) / columnCount;
+
+          var cols = [];
+          var heights = [];
+          for (var i = 0; i < columnCount; i++) {
+            var col = document.createElement('div');
+            col.className = 'masonry-col';
+            // Set explicit pixel widths instead of relying on flex-grow: a
+            // flex-basis distribution alongside `gap` was leaving unexplained
+            // slack at both row edges in some engines.
+            col.style.flex = '0 0 auto';
+            col.style.width = colWidth + 'px';
+            if (i < columnCount - 1) { col.style.marginRight = gapPx + 'px'; }
+            row.appendChild(col);
+            cols.push(col);
+            heights.push(0);
+          }
+          row.classList.add('masonry-row');
+
+          var placed = 0;
+          for (var idx = 0; idx < items.length && placed < MASONRY_DISPLAY_COUNT; idx++) {
+            var shortest = 0;
+            for (var c = 1; c < columnCount; c++) {
+              if (heights[c] < heights[shortest]) { shortest = c; }
+            }
+            cols[shortest].appendChild(items[idx]);
+            heights[shortest] += items[idx].getBoundingClientRect().height + 20;
+            placed++;
+          }
+        }
+
+        function layoutAllMasonryRows() {
+          masonryRows.forEach(layoutMasonryRow);
+        }
+
+        document.querySelectorAll('.recent-projects .row').forEach(function (row) {
+          masonryRows.push({ row: row, items: Array.prototype.slice.call(row.children) });
+        });
+        window.addEventListener('load', layoutAllMasonryRows);
+        var masonryResizeTimer;
+        window.addEventListener('resize', function () {
+          clearTimeout(masonryResizeTimer);
+          masonryResizeTimer = setTimeout(layoutAllMasonryRows, 150);
         });
 
         // Run client scalajs code (for instance, autocomplete)

--- a/modules/template/src/main/twirl/scaladex/view/main.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/main.scala.html
@@ -231,6 +231,18 @@
           }
         });
 
+        // Topic tags on result cards: plain elements (not <a>) since each
+        // card is itself one big <a> - a nested <a> would be invalid HTML,
+        // and browsers "fix" that by force-closing the outer link early.
+        document.addEventListener('click', function (event) {
+          var tag = event.target.closest('.item-filter-tag[data-topic-href]');
+          if (tag) {
+            event.preventDefault();
+            event.stopPropagation();
+            window.location = tag.dataset.topicHref;
+          }
+        });
+
         // The "Sorting" control is a button-group form (each button is a
         // submit button carrying name="sort"), not plain links.
         document.addEventListener('submit', function (event) {

--- a/modules/template/src/main/twirl/scaladex/view/main.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/main.scala.html
@@ -185,6 +185,7 @@
               submitFilterFormAjax(event.target.form);
             }
           });
+          $scope.find('.edit-project input[type="checkbox"]').bootstrapSwitch();
           if (window.emojify) { emojify.run(); }
           if (window.ScaladexClient) { ScaladexClient.createSparkline(); }
         }
@@ -251,7 +252,6 @@
           $('[data-toggle="tooltip"]').tooltip({container: 'body'});
           $(".js-keywords-multiple").select2({tags: true});
           $(".js-stackoverflowtags-multiple").select2({tags: true});
-          $('.edit-project input[type="checkbox"]').bootstrapSwitch();
           initPageWidgets(document);
         });
 

--- a/modules/template/src/main/twirl/scaladex/view/main.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/main.scala.html
@@ -112,7 +112,7 @@
                   <ul>
                       <li><h5>Community</h5></li>
                       <li><a href="https://github.com/scalacenter/scaladex"><i class="fa-brands fa-github fa-lg"></i> Github</a></li>
-                      <li><a href="https://discord.com/invite/scala"><i class="fab fa-discord fa-lg"></i> Discord</a></li>
+                      <li><a href="https://discord.com/invite/scala"><i class="fa-brands fa-discord fa-lg"></i> Discord</a></li>
                   </ul>
               </div>
               <div class="col-md-3">

--- a/modules/template/src/main/twirl/scaladex/view/notfound.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/notfound.scala.html
@@ -3,7 +3,7 @@
 
 @(env: Env, user: Option[UserState])
 @main(env, title = "Not found", user) {
-<main class="container">
+<main class="container error-page">
   <h1>Not found</h1>
 </main>
 }

--- a/modules/template/src/main/twirl/scaladex/view/project/artifacts.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifacts.scala.html
@@ -28,7 +28,10 @@
     <div class="container">
       <div class="content-project artifacts box" data-organization="@project.reference.organization"
       data-repository="@project.reference.repository">
-        @artifactsFilters(project.reference, params, allBinaryVersions, withStableOnly = false)
+        <div class="artifacts-header">
+          <h2>Artifacts</h2>
+          @artifactsFilters(project.reference, params, allBinaryVersions, withStableOnly = false)
+        </div>
         <div class="result-count">
           Found <b>@artifacts.size</b> @Formats.wordPlural(artifacts.size, "artifact")
         </div>

--- a/modules/template/src/main/twirl/scaladex/view/project/artifactsFilters.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifactsFilters.scala.html
@@ -10,9 +10,12 @@
 )
 
 <form class="float-right" action="#" action="GET">
-  <select class="selectpicker" name="binary-version" 
-    title= "@params.binaryVersionsSummary.getOrElse("Scala Versions")" multiple data-style="btn-secondary" data-actions-box="true" data-selected-text-format="static"
-    onchange="this.form.submit()">
+  @if(withStableOnly) {
+    <input type="checkbox" id="stable-only" name="stable-only" value="true" @if(params.stableOnly) { checked }>
+  }
+  <select class="selectpicker" name="binary-version"
+    title= "@params.binaryVersionsSummary.getOrElse("Target")" multiple data-style="btn-secondary" data-actions-box="true" data-selected-text-format="static"
+    onchange="submitFilterFormAjax(this.form)">
     @for((platform, binaryVersions) <- allBinaryVersions.groupBy(_.platform).toSeq.sortBy(_._1).reverse) {
       <optgroup label="@platform">
         @for(binaryVersion <- binaryVersions.sorted.reverse) {
@@ -24,7 +27,4 @@
       </optgroup>
     }
   </select>
-  @if(withStableOnly) {
-    <input type="checkbox" id="stable-only" name="stable-only" value="true" @if(params.stableOnly) { checked }>
-  }
 </form>

--- a/modules/template/src/main/twirl/scaladex/view/project/editproject.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/editproject.scala.html
@@ -19,64 +19,65 @@
       <div class="row">
         <div class="col-md-12">
           <div class="edit-project box content-project">
-            <a class="btn btn-default pull-right" href="/@project.organization/@project.repository">Cancel</a>
-            <button type="submit" form="project-settings" class="btn btn-primary pull-right">Update</button>
-
             <h1>Project Settings</h1>
             <form action="/@project.organization/@project.repository/settings" method="POST" id="project-settings">
-              <div class="form-group">
-                <label for="category">Category</label>
-                <p>This is used to compute the <a href="/awesome">Awesome Scala</a> page.</p>
-                <select
-                  id="category"
-                  name="category"
-                  data-live-search="true"
-                  class="selectpicker"
-                  data-style="btn-primary">
-                @if(project.settings.category.isEmpty) {<option>Choose a category</option>}
-                @for(meta <- MetaCategory.all) {
-                  <optgroup label="@meta.title">
-                    @for(category <- meta.categories) {
-                      <option
-                        value="@category.label" 
-                        @if(project.settings.category.contains(category)){selected}>
-                          @category.title
-                      </option>
-                    }
-                  </optgroup>
-                }
-                </select>
-              </div>
+              <section class="settings-section">
+                <h2>General</h2>
+                <div class="form-group">
+                  <label for="category">Category</label>
+                  <p class="help">This is used to compute the <a href="/awesome">Awesome Scala</a> page.</p>
+                  <select
+                    id="category"
+                    name="category"
+                    data-live-search="true"
+                    class="selectpicker"
+                    data-style="btn-secondary">
+                  @if(project.settings.category.isEmpty) {<option>Choose a category</option>}
+                  @for(meta <- MetaCategory.all) {
+                    <optgroup label="@meta.title">
+                      @for(category <- meta.categories) {
+                        <option
+                          value="@category.label"
+                          @if(project.settings.category.contains(category)){selected}>
+                            @category.title
+                        </option>
+                      }
+                    </optgroup>
+                  }
+                  </select>
+                </div>
 
-              <div class="form-group">
-                <label for="chatroom">Chatroom</label>
-                <input name="chatroom" value="@project.settings.chatroom.getOrElse("")"
-                  class="form-control list-group-item"
-                  placeholder="https://gitter.im/@project.reference">
-              </div>
-              <div class="form-group">
-                <label for="contributorsWanted">Contributors Wanted</label>
-                <br/>
-                <input type="checkbox" name="contributorsWanted" id="contributorsWanted" @if(project.settings.contributorsWanted){ checked }> 
-              </div>
+                <div class="form-group">
+                  <label for="chatroom">Chatroom</label>
+                  <input name="chatroom" value="@project.settings.chatroom.getOrElse("")"
+                    class="form-control"
+                    placeholder="https://gitter.im/@project.reference">
+                </div>
 
-              <fieldset>
-                <legend>Artifact Settings</legend>
+                <div class="form-group form-group-toggle">
+                  <div class="form-group-toggle-text">
+                    <label for="contributorsWanted">Contributors Wanted</label>
+                    <p class="help">Shows a badge on the project page inviting contributors.</p>
+                  </div>
+                  <input type="checkbox" id="contributorsWanted" name="contributorsWanted" @if(project.settings.contributorsWanted){ checked }>
+                </div>
+              </section>
+
+              <section class="settings-section">
+                <h2>Artifacts</h2>
                 <div class="form-group">
                   <label for="defaultArtifact">Default Artifact</label>
-                  <p>
+                  <p class="help">
                     When a project has lots of artifacts you can hint the index on what artifact to choose in the drop down.
-                  See <a target="_blank" href="https://github.com/scalacenter/scaladex/blob/main/core/shared/src/main/scala/scaladex/core/model/ArtifactSelection.scala">
-                    ArtifactSelection.scala
-                  </a> for more details.
+                    See <a target="_blank" href="https://github.com/scalacenter/scaladex/blob/main/core/shared/src/main/scala/scaladex/core/model/ArtifactSelection.scala">ArtifactSelection.scala</a> for more details.
                   </p>
                   <select
                     id="defaultArtifact"
                     name="defaultArtifact"
                     data-live-search="true"
-                    class="selectpicker" data-style="btn-primary">
+                    class="selectpicker" data-style="btn-secondary">
                   @for(artifact <- artifactNames){
-                    <option 
+                    <option
                       value="@artifact"
                       @if(project.settings.defaultArtifact.contains(artifact)){ selected }>
                       @artifact
@@ -85,21 +86,25 @@
                   </select>
                 </div>
 
-                <div class="form-group">
-                  <label for="preferStableVersion">Stable version filter</label>
-                  <p>If enabled, Scaladex filters pre-release versions out to compute the latest version.</p>
-                  <input type="checkbox" name="preferStableVersion" id="preferStableVersion" @if(project.settings.preferStableVersion){ checked }>
+                <div class="form-group form-group-toggle">
+                  <div class="form-group-toggle-text">
+                    <label for="preferStableVersion">Stable version filter</label>
+                    <p class="help">If enabled, Scaladex filters pre-release versions out to compute the latest version.</p>
+                  </div>
+                  <input type="checkbox" id="preferStableVersion" name="preferStableVersion" @if(project.settings.preferStableVersion){ checked }>
                 </div>
+
                 <div class="form-group">
                   <label for="deprecatedArtifacts">Deprecated Artifacts</label>
                   <select
                     name="deprecatedArtifacts"
-                    class="js-keywords-multiple js-states form-control"
+                    class="selectpicker"
+                    data-style="btn-secondary"
                     id="deprecatedArtifacts"
                     multiple="multiple">
                     @for(artifact <- artifactNames) {
                       <option
-                        value="@artifact" 
+                        value="@artifact"
                         @if(project.settings.deprecatedArtifacts.contains(artifact)){selected}>
                           @artifact
                       </option>
@@ -110,77 +115,76 @@
                   <label for="cliArtifacts">Command Line Artifacts</label>
                   <select
                     name="cliArtifacts"
-                    class="js-keywords-multiple js-states form-control"
+                    class="selectpicker"
+                    data-style="btn-secondary"
                     id="cliArtifacts"
                     multiple="multiple">
                   @for(artifact <- artifactNames) {
                     <option
-                      value="@artifact" 
+                      value="@artifact"
                       @if(project.settings.cliArtifacts.contains(artifact)){selected}>
                         @artifact
                     </option>
                   }
                   </select>
                 </div>
-              </fieldset>
+              </section>
 
-              <fieldset>
-                <legend>Documentation</legend>
-                <pre>
-[groupId]    org.example
-[artifactId] foo_2.11
-[version]    1.2.3
-[major]      1
-[minor]      2
-[name]       foo
-                </pre>
-                
+              <section class="settings-section">
+                <h2>Documentation</h2>
                 <div class="form-group">
                   <label for="customScalaDoc">Custom Scaladoc Link</label>
+                  <p class="help">
+                    Use the placeholders below, filled in per-release: <code>[groupId]</code> org.example,
+                    <code>[artifactId]</code> foo_2.11, <code>[version]</code> 1.2.3, <code>[major]</code> 1,
+                    <code>[minor]</code> 2, <code>[name]</code> foo.
+                  </p>
                   <input
-                    name="customScalaDoc" 
+                    name="customScalaDoc"
                     value="@project.settings.customScalaDoc.getOrElse("")"
                     placeholder="https://www.javadoc.io/doc/[groupId]/[artifactId]/[version]"
-                    type="text" 
+                    type="text"
                     class="form-control" id="customScalaDoc">
                 </div>
 
-                <fieldset class="documentation-link">
+                <div class="form-group">
                   <label>Documentation links</label>
-                  <ul>
+                  <ul class="documentation-links">
                   @for((doc, i) <- project.settings.documentationLinks.zipWithIndex){
-                    <li class="list-group">
+                    <li>
                       <input
                         name="documentationLinks[@i].label" value="@doc.label"
                         placeholder="User Guide"
-                        class="form-control list-group-item">
-                      <input 
+                        class="form-control">
+                      <input
                         name="documentationLinks[@i].url"
                         value="@doc.pattern"
                         placeholder="http://example.org/guide/[major].x"
-                        class="form-control list-group-item">
+                        class="form-control">
                     </li>
                   }
                   @for(i <- (0 to 1).map(_ + project.settings.documentationLinks.size)) {
-                    <li class="list-group">
+                    <li>
                       <input
                         name="documentationLinks[@i].label" value=""
                         placeholder="User Guide"
-                        class="form-control list-group-item">
-                      <input 
+                        class="form-control">
+                      <input
                         name="documentationLinks[@i].url"
                         value=""
                         placeholder="http://example.org/guide/[major].x"
-                        class="form-control list-group-item">
+                        class="form-control">
                     </li>
                   }
                   </ul>
-                </fieldset>
-              </fieldset>
+                </div>
+              </section>
 
+              <div class="settings-actions">
+                <button type="submit" class="btn btn-primary">Update</button>
+                <a class="btn btn-default" href="/@project.organization/@project.repository">Cancel</a>
+              </div>
             </form>
-            <button type="submit" form="project-settings" class="btn btn-primary">Update</button>
-            <a class="btn btn-default" href="/@project.organization/@project.repository">Cancel</a>
           </div>
         </div>
       </div>

--- a/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
@@ -119,7 +119,7 @@
             }
             @if(canEdit) {
               <li role="settings" class="@isActive(ProjectTab.Settings)">
-                <a data-toggle="tooltip" data-placement="bottom" title="edit project's settings" href="/@project.reference/settings">
+                <a href="/@project.reference/settings">
                   <i class="fa-solid fa-gear"></i>
                   Settings
                 </a>

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -38,11 +38,6 @@
       </div>
     </div>
   </main>
-  <script type="text/javascript">
-          document.addEventListener("DOMContentLoaded", function () {
-            ScaladexClient.createSparkline();
-          })
-  </script>
 }
 
 @statisticsBox(github: GithubInfo, ref: Project.Reference, dependentsCount: Long) = {

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -137,6 +137,18 @@
   </section>
 }
 
+@scopeDescription(scope: ArtifactDependency.Scope) = @{
+  scope.value match {
+    case "provided" => "Expected to be provided by the runtime environment; not bundled in the final artifact"
+    case "runtime" => "Needed only at runtime, not for compiling against this dependency"
+    case "test" => "Used only for compiling and running tests"
+    case "optional" => "Optional: not pulled in transitively by projects depending on this one"
+    case "macro" => "Used only for macro expansion at compile time"
+    case other => other
+  }
+}
 @scopeSpan(scope: ArtifactDependency.Scope) = {
-  @if(scope.value != "compile") { <span class="label label-default">@scope</span> }
+  @if(scope.value != "compile") {
+    <span class="label label-default" data-toggle="tooltip" data-placement="top" title="@scopeDescription(scope)">@scope</span>
+  }
 }

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -46,13 +46,13 @@
     <div class="row">
       <div >
         <ul class="row">
-          <a href="https://github.com/@ref/watchers"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-eye"></i> @github.watchers watchers</li></a>
-          <a href="https://github.com/@ref/graphs/contributors"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-users"></i> @github.contributors.size Contributors</li></a>
-          <a href="https://github.com/@ref/stargazers"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-star"></i> @github.stars Stars</li></a>
-          <a href="https://github.com/@ref/network"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-code-branch"></i> @github.forks Forks</li></a>
-          <a href="https://github.com/@ref/commits"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-clock-rotate-left"></i> @github.commits Commits</li></a>
-          <a href="https://github.com/@ref/issues"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-circle-exclamation"></i> @github.issues Open issues</li></a>
-          <a href="#dependents"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-sitemap"></i> @dependentsCount Dependents</li></a>
+          <a href="https://github.com/@ref/watchers"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-eye"></i> @Formats.plural(github.watchers.getOrElse(0).toLong, "watcher")</li></a>
+          <a href="https://github.com/@ref/graphs/contributors"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-users"></i> @Formats.plural(github.contributors.size.toLong, "contributor")</li></a>
+          <a href="https://github.com/@ref/stargazers"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-star"></i> @Formats.plural(github.stars.getOrElse(0).toLong, "star")</li></a>
+          <a href="https://github.com/@ref/network"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-code-branch"></i> @Formats.plural(github.forks.getOrElse(0).toLong, "fork")</li></a>
+          <a href="https://github.com/@ref/commits"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-clock-rotate-left"></i> @Formats.plural(github.commits.getOrElse(0).toLong, "commit")</li></a>
+          <a href="https://github.com/@ref/issues"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-circle-exclamation"></i> @Formats.plural(github.issues.getOrElse(0).toLong, "open issue")</li></a>
+          <a href="#dependents"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-sitemap"></i> @Formats.plural(dependentsCount, "dependent")</li></a>
         </ul>
       </div>
     </div>

--- a/modules/template/src/main/twirl/scaladex/view/project/versions.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/versions.scala.html
@@ -28,19 +28,21 @@
     <div class="container">
       <div class="content-project versions box" data-organization="@project.reference.organization"
       data-repository="@project.reference.repository">
-        @artifactsFilters(project.reference, params, allBinaryVersions)
-        <h2>
-          @artifactName
-          <select class="selectpicker" title="Other Artifacts"
-            data-style="btn-default" data-selected-text-format="static" 
-            onchange="window.location=this.value">
-            @for(name <- header.map(_.allArtifactNames).getOrElse(Seq.empty)) {
-              <option value="@versionsUri(project.reference, name, params)" @if(name == artifactName) {selected}>
-                @name
-              </option>
-            }
-          </select>
-        </h2>
+        <div class="artifacts-header">
+          <h2>
+            @artifactName
+            <select class="selectpicker" title="Other Artifacts"
+              data-style="btn-default" data-selected-text-format="static"
+              onchange="window.location=this.value">
+              @for(name <- header.map(_.allArtifactNames).getOrElse(Seq.empty)) {
+                <option value="@versionsUri(project.reference, name, params)" @if(name == artifactName) {selected}>
+                  @name
+                </option>
+              }
+            </select>
+          </h2>
+          @artifactsFilters(project.reference, params, allBinaryVersions)
+        </div>
         <div class="result-count">
           Found <b>@artifactByVersions.size</b> @Formats.wordPlural(artifactByVersions.size, "version")
         </div>

--- a/modules/template/src/main/twirl/scaladex/view/search/filter.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/filter.scala.html
@@ -15,51 +15,59 @@
       <a class="btn btn-primary" href="/search?q=">Normal Search</a>
       <input type="hidden" name="contributingSearch" value="true">
     } else {
-      <a class="btn btn-primary" href="/search?q=&contributingSearch=true">Contributing Search</a>
+      <a class="btn btn-primary" href="/search?q=&contributingSearch=true"
+        data-toggle="tooltip" data-placement="bottom" data-container="body"
+        title="Only show projects that have open issues tagged as beginner-friendly, good for first contribution">Contributing Search</a>
     }
     <h3>Filters</h3>
-    <fieldset>
-      <legend>Languages</legend>
-      <ul>
-      @for((language, count) <- languages) {
-        <li>
-          <label>
-            <input type="checkbox" @if(params.languages.contains(language)) { checked }
-                    name="language" value="@language.value" onclick="this.form.submit()">
-            @language (@count)
-          </label>
-        </li>
-      }
-      </ul>
-    </fieldset>
-    <fieldset>
-      <legend>Platforms</legend>
-      <ul>
-      @for((platform, count) <- platforms) {
-        <li>
-          <label>
-            <input type="checkbox" @if(params.platforms.contains(platform)) { checked }
-                    name="platform" value="@platform.value" onclick="this.form.submit()">
-            @platform (@count)
-          </label>
-        </li>
-      }
-      </ul>
-    </fieldset>
-    <fieldset>
-      <legend>Topics</legend>
-      <ul>
-        @for((topic, count) <- topics.sortBy(_._1)) {
-        <li>
-          <label>
-            <input type="checkbox" @if(params.topics.contains(topic)) { checked }
-                   name="topic" value="@topic" onclick="this.form.submit()">
-            @topic (@count)
-          </label>
-        </li>
+    @if(languages.nonEmpty) {
+      <fieldset>
+        <legend>Languages</legend>
+        <ul>
+        @for((language, count) <- languages) {
+          <li>
+            <label>
+              <input type="checkbox" @if(params.languages.contains(language)) { checked }
+                      name="language" value="@language.value" onclick="submitFilterFormAjax(this.form, '#container-search')">
+              @language (@count)
+            </label>
+          </li>
         }
-      </ul>
-    </fieldset>
+        </ul>
+      </fieldset>
+    }
+    @if(platforms.nonEmpty) {
+      <fieldset>
+        <legend>Platforms</legend>
+        <ul>
+        @for((platform, count) <- platforms) {
+          <li>
+            <label>
+              <input type="checkbox" @if(params.platforms.contains(platform)) { checked }
+                      name="platform" value="@platform.value" onclick="submitFilterFormAjax(this.form, '#container-search')">
+              @platform (@count)
+            </label>
+          </li>
+        }
+        </ul>
+      </fieldset>
+    }
+    @if(topics.nonEmpty) {
+      <fieldset>
+        <legend>Topics</legend>
+        <ul>
+          @for((topic, count) <- topics.sortBy(_._1)) {
+          <li>
+            <label>
+              <input type="checkbox" @if(params.topics.contains(topic)) { checked }
+                     name="topic" value="@topic" onclick="submitFilterFormAjax(this.form, '#container-search')">
+              @topic (@count)
+            </label>
+          </li>
+          }
+        </ul>
+      </fieldset>
+    }
 
     <input type="hidden" name="q" value="@params.queryString">
     @if(you){

--- a/modules/template/src/main/twirl/scaladex/view/search/result.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/result.scala.html
@@ -1,5 +1,6 @@
 @import org.apache.pekko.http.scaladsl.model.Uri
 @import scaladex.view.html._
+@import scaladex.view.Formats
 @import scaladex.core.model.search.Pagination
 @import scaladex.core.model.search.SearchParams
 @import scaladex.core.model.search.ProjectHit
@@ -15,20 +16,24 @@
   languages: Seq[(Language, Int)],
   platforms: Seq[(Platform, Int)]
 )
-@if(params.contributingSearch){
-  <h2 class="text-center">Contributing Search</h2>
-  <div class="row">
+@* Always render the title/subtitle area (even empty) so switching in and out
+   of Contributing Search doesn't shift the rest of the page up/down. *@
+<h2 class="text-center">@if(params.contributingSearch) { Contributing Search } else { Search Results }</h2>
+<div class="row search-subtitle">
+  @if(params.contributingSearch) {
     <h4 class="text-center">All the projects below have beginner-friendly issues which are great places to start contributing</h4>
-  </div>
-}
+  }
+</div>
 
 <div class="row">
   <div class="col-md-2">
     <div class="result-count">
-      @if(pagination.current == 1) {
-        @pagination.totalSize results
-      } else {
-        Page @pagination.current of @pagination.totalSize results
+      @if(pagination.totalSize > 0) {
+        @if(pagination.current == 1) {
+          @Formats.plural(pagination.totalSize, "result")
+        } else {
+          Page @pagination.current of @Formats.plural(pagination.totalSize, "result")
+        }
       }
     </div>
   </div>

--- a/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
@@ -100,11 +100,7 @@
             @for(github <- project.githubInfo) {
               @if(github.topics.nonEmpty) {
                 @for(topic <- github.topics) {
-                  <span class="item-filter-tag">
-                    <a href="/search?topic=@topic">
-                      @topic
-                    </a>
-                  </span>
+                  <span class="item-filter-tag" data-topic-href="/search?topic=@topic">@topic</span>
                 }
               }
             }

--- a/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
@@ -114,16 +114,16 @@
             @for(github <- project.githubInfo) {
               @for(stars <- github.stars) {
                 <span>
-                  <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Stars" href="#"><span>@stars</span> <i class="fa-solid fa-star"></i></a>
+                  <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Stars"><span>@stars</span> <i class="fa-solid fa-star"></i></span>
                 </span>
               }
               @for(commitsPerYear <- github.commitsPerYear) {
                 <span>
-<a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Commits in the past year" href="#"><span>@commitsPerYear</span> <i class="fa-solid fa-code-merge"></i></a>
+<span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Commits in the past year"><span>@commitsPerYear</span> <i class="fa-solid fa-code-merge"></i></span>
                 </span>
               }
               <span>
-                <a class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Contributors" href="#"><span>@github.contributorCount</span> <i class="fa-solid fa-users"></i></a>
+                <span class="stats-icon" data-toggle="tooltip" data-placement="bottom" title="Contributors"><span>@github.contributorCount</span> <i class="fa-solid fa-users"></i></span>
               </span>
             }
             </div>

--- a/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/search/resultList.scala.html
@@ -4,6 +4,19 @@
 @import scaladex.core.model.search.SearchParams
 
 @(projects: Seq[ProjectHit], params: SearchParams)
+@if(projects.isEmpty) {
+  <div class="list-result box no-results">
+    <i class="fa-solid fa-magnifying-glass"></i>
+    <div>
+      @if(params.queryString.trim.nonEmpty) {
+        <p>No projects found for &ldquo;@params.queryString&rdquo;.</p>
+      } else {
+        <p>No projects match the selected filters.</p>
+      }
+      <p class="hint">Try a broader search term, check the spelling, or clear some filters.</p>
+    </div>
+  </div>
+} else {
 <ol class="list-result box">
   @for(hit <- projects; project = hit.document){
   <li class="item-list">
@@ -121,3 +134,4 @@
   </li>
   }
 </ol>
+}

--- a/modules/template/src/main/twirl/scaladex/view/searchinput.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/searchinput.scala.html
@@ -1,4 +1,5 @@
 @import scaladex.core.model.search.SearchParams
+@import scaladex.view.Formats
 
 @(params: SearchParams = SearchParams(), you: Boolean = false, totalProjects: Option[Long], totalArtifacts: Option[Long])
 
@@ -12,7 +13,7 @@
           @if(params.contributingSearch){
             placeholder="Search beginner-friendly projects and issues"
           } else {
-            placeholder="Search @for(projects <- totalProjects; artifacts <- totalArtifacts) {within @projects projects and @artifacts artifacts}"
+            placeholder="Search @for(projects <- totalProjects; artifacts <- totalArtifacts) {within @Formats.plural(projects, "project") and @Formats.plural(artifacts, "artifact")}"
           }
           >
         @if(you){


### PR DESCRIPTION
The complete list of changes should be visible in commits, here's the summary:

- New dark navy palette (docs.scala-lang.org-inspired, orange brand kept) applied site-wide, including every page hero.
- Homepage: real masonry grid + redesigned project cards.
- Project Settings page reworked entirely.
- Search & Awesome Scala: card-based results, better empty states, filters/tabs/sorting now AJAX (no full page reloads).
- Consistent styling for buttons, inputs, dropdowns, switches, and the How to contribute popup.
- Misc polish: pluralization fixes, icon/alignment fixes, styled error pages.

I was the navigator, and AI was behind the wheel.

<img width="1820" height="1522" alt="image" src="https://github.com/user-attachments/assets/eb8aa901-9284-480c-930d-f55d497e6b2f" />
<img width="1820" height="1522" alt="image" src="https://github.com/user-attachments/assets/b66b9c9d-542d-476a-ac8f-4e8656f44092" />
<img width="1820" height="1522" alt="image" src="https://github.com/user-attachments/assets/d069de8c-d102-4213-902d-0d25468a89f5" />
