### PR TITLE
fix: prevent empty.max crash on latest-by-scala-version badge

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -95,6 +95,7 @@ class Badges(projectService: ProjectService)(using ExecutionContext):
             else
               val platform = platformParam
                 .flatMap(Platform.parse)
+                .filter(platforms.contains)
                 .orElse(targetTypeParam.flatMap(selectPlatformFromTargetType(_, platforms)))
                 .getOrElse(platforms.max)
               val artifacts = header.artifacts(artifactName, platform)

--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -101,6 +101,7 @@ class Badges(projectService: ProjectService)(using ExecutionContext):
               val artifacts = header.artifacts(artifactName, platform)
               val summary = Badges.summaryOfLatestVersions(artifacts.map(_.reference), platform)
               shieldsSvg(s"$artifactName - $platform", summary, color, style, logo, logoWidth)
+            end if
         }
         onSuccess(res)(identity)
       }

--- a/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
@@ -64,6 +64,16 @@ class BadgesTests extends ControllerBaseSuite with BeforeAndAfterAll:
     }
   }
 
+  it("fallback when the requested platform is valid but not published for the artifact") {
+    Get(s"/${Cats.reference}/cats-core/latest-by-scala-version.svg?platform=sbt1.0") ~> route ~> check {
+      status shouldEqual StatusCodes.TemporaryRedirect
+      val redirection = headers.collectFirst { case Location(uri) => uri }
+      redirection should contain(
+        Uri("https://img.shields.io/badge/cats--core_--_JVM-2.6.1_(Scala_3.x),_2.5.0_(Scala_2.13)-green.svg?")
+      )
+    }
+  }
+
   it("error badge instead of crashing for an unknown project") {
     Get("/nebula-contrib/zio-nebula/zio-nebula/latest-by-scala-version.svg?platform=jvm") ~> route ~> check {
       status shouldEqual StatusCodes.TemporaryRedirect


### PR DESCRIPTION
## Problem

The `latest-by-scala-version.svg` badge route crashes with `empty.max` when the `platform` query param parses to a valid platform that the artifact doesn't actually publish for.

The `platforms.isEmpty` guard only checks that the artifact has *some* platforms — it never validates that the user-supplied `platform` is one of them. So `header.artifacts(name, platform)` returns empty and `summaryOfLatestVersions` calls `.max` on an empty collection.

```
2026-09-04 01:30:27,583 ERROR scaladex.server.Server$:197  - Unhandled exception in http://index.scala-lang.org/localytics/sbt-s3/sbt-s3/latest-by-scala-version.svg?platform=sbt1.0
java.lang.UnsupportedOperationException: empty.max
        at scala.collection.IterableOnceOps.max(IterableOnce.scala:1150)
        at scala.collection.IterableOnceOps.max$(IterableOnce.scala:1147)
        at scala.collection.AbstractIterable.max(Iterable.scala:936)
        at scaladex.server.route.Badges$.scaladex$server$route$Badges$$$summaryOfLatestVersions(Badges.scala:128)
        at scaladex.server.route.Badges.$anonfun$10(Badges.scala:101)
```

## Fix

Only accept the parsed `platform` param if it's among the artifact's available platforms (`.filter(platforms.contains)`), otherwise fall back to `targetType` selection or `platforms.max` as before. This guarantees `header.artifacts(...)` is non-empty.

Added a regression test covering a valid-but-unpublished platform param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)