### PR TITLE
fix: percent-encode organization segment in search pagination URI

### DIFF
--- a/modules/server/src/main/scala/scaladex/server/route/SearchPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/SearchPages.scala
@@ -8,6 +8,7 @@ import scaladex.core.service.SearchEngine
 import scaladex.server.TwirlSupport.given
 import scaladex.view.search.html.searchresult
 
+import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.http.scaladsl.model.Uri.*
 import org.apache.pekko.http.scaladsl.server.*
 import org.apache.pekko.http.scaladsl.server.Directives.*
@@ -19,12 +20,13 @@ class SearchPages(env: Env, searchEngine: SearchEngine)(
     get(
       concat(
         path("search")(
-          searchParams(user)(params => paging(size = 20)(page => search(params, page, user, "search")))
+          searchParams(user)(params => paging(size = 20)(page => search(params, page, user, Uri("search"))))
         ),
         path(Segment)(organization =>
           searchParams(user) { params =>
             val paramsWithOrg = params.copy(queryString = s"${params.queryString} AND organization:$organization")
-            paging(size = 20)(page => search(paramsWithOrg, page, user, s"organization/$organization"))
+            val uri = Uri((Path("organization") / organization).toString)
+            paging(size = 20)(page => search(paramsWithOrg, page, user, uri))
           }
         )
       )
@@ -54,7 +56,7 @@ class SearchPages(env: Env, searchEngine: SearchEngine)(
         )
     }
 
-  private def search(params: SearchParams, page: PageParams, user: Option[UserState], uri: String) =
+  private def search(params: SearchParams, page: PageParams, user: Option[UserState], uri: Uri) =
     complete {
       val resultsF = searchEngine.find(params, page)
       val topicsF = searchEngine.countByTopics(params, 50)


### PR DESCRIPTION
Organization names containing spaces (e.g. `/Big%20Data%20-%20small%20machine`) triggered an unhandled `IllegalUriException` and a 500. The decoded path segment was interpolated raw into the pagination URI string, which the template then parsed as a `Uri`. Now the segment is built through `Uri.Path` so it's percent-encoded.

```
2026-09-04 01:55:24,872 ERROR scaladex.server.Server$:197  - Unhandled exception in http://index.scala-lang.org/Big%20Data%20-%20small%20machine
org.apache.pekko.http.scaladsl.model.IllegalUriException: Illegal URI reference: Invalid input ' ', expected pchar, '/', '?', '#' or 'EOI' (line 1, column 17): organization/Big Data - small machine
                ^
        at org.apache.pekko.http.scaladsl.model.IllegalUriException$.apply(ErrorInfo.scala:88)
        at org.apache.pekko.http.scaladsl.model.Uri$.apply(Uri.scala:264)
        at org.apache.pekko.http.scaladsl.model.Uri$.apply(Uri.scala:234)
        at scaladex.server.route.SearchPages.search$$anonfun$1$$anonfun$2$$anonfun$1$$anonfun$1$$anonfun$1(SearchPages.scala:72)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)