### PR TITLE
fix: return error badge instead of crashing for unknown artifact name

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/ProjectHeader.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ProjectHeader.scala
@@ -9,18 +9,72 @@ object ProjectHeader:
       defaultArtifactName: Option[Artifact.Name],
       preferStableVersion: Boolean
   ): Option[ProjectHeader] =
-    Option.when(artifacts.nonEmpty) {
-      new ProjectHeader(ref, artifacts, defaultArtifactName, preferStableVersion)
+    // A header only exists if it has a default artifact, which is the case iff artifacts is non-empty.
+    resolveDefaultArtifact(artifacts, defaultArtifactName, preferStableVersion, None, None, None)
+      .map(defaultArtifact =>
+        new ProjectHeader(ref, artifacts, defaultArtifactName, preferStableVersion, defaultArtifact)
+      )
+
+  private def resolveDefaultArtifactName(
+      artifacts: Seq[Artifact],
+      configuredName: Option[Artifact.Name],
+      preferStableVersion: Boolean,
+      language: Option[Language],
+      platform: Option[Platform]
+  ): Option[Artifact.Name] =
+    val filteredArtifacts = artifacts.filter(a => language.forall(_ == a.language) && platform.forall(_ == a.platform))
+    val stableArtifacts = filteredArtifacts.filter(_.version.isStable)
+
+    def ofVersion(version: Version): Option[Artifact.Name] =
+      filteredArtifacts
+        .filter(_.version == version)
+        .maxByOption(a => (a.binaryVersion, a.name, a.releaseDate))(
+          Ordering.Tuple3(Ordering[BinaryVersion], Ordering[Artifact.Name].reverse, Ordering[Instant])
+        )
+        .map(_.name)
+
+    // find version of latest artifact then default artifact of that version
+    def byLatestDate(artifacts: Seq[Artifact]): Option[Artifact.Name] =
+      artifacts.maxByOption(_.releaseDate).flatMap(a => ofVersion(a.version))
+
+    val configured = configuredName.filter(name => filteredArtifacts.exists(_.name == name))
+    if preferStableVersion then configured.orElse(byLatestDate(stableArtifacts)).orElse(byLatestDate(filteredArtifacts))
+    else configured.orElse(byLatestDate(filteredArtifacts))
+  end resolveDefaultArtifactName
+
+  /** Resolves the default artifact name (resolveDefaultArtifactName), then picks its latest version. Names and versions
+    * are resolved separately because artifacts may not share the same versioning. Returns None when no artifact
+    * matches.
+    */
+  private def resolveDefaultArtifact(
+      artifacts: Seq[Artifact],
+      configuredName: Option[Artifact.Name],
+      preferStableVersion: Boolean,
+      language: Option[Language],
+      platform: Option[Platform],
+      artifactName: Option[Artifact.Name]
+  ): Option[Artifact] =
+    val defaultArtifactName =
+      artifactName.orElse(
+        resolveDefaultArtifactName(artifacts, configuredName, preferStableVersion, language, platform)
+      )
+    defaultArtifactName.flatMap { name =>
+      val filteredArtifacts = artifacts.filter { a =>
+        a.name == name && language.forall(_ == a.language) && platform.forall(_ == a.platform)
+      }
+      if preferStableVersion then filteredArtifacts.maxByOption(a => (a.version.isStable, a.version))
+      else filteredArtifacts.maxByOption(_.version)
     }
+  end resolveDefaultArtifact
 end ProjectHeader
 
-final case class ProjectHeader(
+final case class ProjectHeader private (
     ref: Project.Reference,
     artifacts: Seq[Artifact],
     defaultArtifactName: Option[Artifact.Name],
-    preferStableVersion: Boolean
+    preferStableVersion: Boolean,
+    defaultArtifact: Artifact
 ):
-  lazy val defaultArtifact: Artifact = getDefaultArtifact(None, None)
   lazy val latestVersion: Version = defaultArtifact.version
   lazy val latestArtifacts: Seq[Artifact] = artifacts.filter(_.version == latestVersion)
 
@@ -33,7 +87,7 @@ final case class ProjectHeader(
   def artifacts(artifactName: Artifact.Name, platform: Platform): Seq[Artifact] =
     artifacts.filter(a => a.name == artifactName && a.platform == platform)
 
-  def versionsUrl: String = artifactsUrl(getDefaultArtifact(None, None), withBinaryVersion = false)
+  def versionsUrl: String = artifactsUrl(defaultArtifact, withBinaryVersion = false)
 
   def versionsUrl(language: Language): String = artifactsUrl(getDefaultArtifact(Some(language), None))
 
@@ -46,60 +100,21 @@ final case class ProjectHeader(
     val queryParams = if filters.nonEmpty then "?" + filters.mkString("&") else ""
     s"/$ref/artifacts/${defaultArtifact.name}$queryParams"
 
-  def getDefaultArtifact0(binaryVersion: Option[BinaryVersion], artifactName: Option[Artifact.Name]): Artifact =
-    getDefaultArtifact(binaryVersion.map(_.language), binaryVersion.map(_.platform), artifactName)
+  def getDefaultArtifact0(binaryVersion: Option[BinaryVersion], artifactName: Option[Artifact.Name]): Option[Artifact] =
+    ProjectHeader.resolveDefaultArtifact(
+      artifacts,
+      defaultArtifactName,
+      preferStableVersion,
+      binaryVersion.map(_.language),
+      binaryVersion.map(_.platform),
+      artifactName
+    )
 
+  // Falls back to the always-present default artifact, so it never fails even for an absent language/platform.
   def getDefaultArtifact(language: Option[Language], platform: Option[Platform]): Artifact =
-    getDefaultArtifact(language, platform, None)
-
-  /** getDefaultArtifact is split in two steps: first we get the default artifact name and then, the latest version. The
-    * reason is, we cannot use the latest version of all artifacts to get the default artifact if they don't share the
-    * same versioning. Instead we use the latest release date. But once we have the artifact with the latest release
-    * date, we really want to get the latest version of that artifact, which is not necessarily the latest one released
-    * because of back-publishing.
-    */
-  def getDefaultArtifact(
-      language: Option[Language],
-      platform: Option[Platform],
-      artifactName: Option[Artifact.Name]
-  ): Artifact =
-    val defaultArtifactName = artifactName.getOrElse(getDefaultArtifactName(language, platform))
-    val filteredArtifacts = artifacts.filter { a =>
-      a.name == defaultArtifactName && language.forall(_ == a.language) && platform.forall(_ == a.platform)
-    }
-    if preferStableVersion then filteredArtifacts.maxBy(a => (a.version.isStable, a.version))
-    else filteredArtifacts.maxBy(_.version)
-  end getDefaultArtifact
-
-  private def getDefaultArtifactName(language: Option[Language], platform: Option[Platform]): Artifact.Name =
-    val filteredArtifacts = artifacts.filter(a => language.forall(_ == a.language) && platform.forall(_ == a.platform))
-    val stableArtifacts = filteredArtifacts.filter(_.version.isStable)
-
-    def ofVersion(version: Version): Artifact.Name =
-      filteredArtifacts
-        .filter(_.version == version)
-        .maxBy(a => (a.binaryVersion, a.name, a.releaseDate))(
-          Ordering.Tuple3(Ordering[BinaryVersion], Ordering[Artifact.Name].reverse, Ordering[Instant])
-        )
-        .name
-
-    // find version of latest artifact then default artifact of that version
-    def byLatestDate(artifacts: Seq[Artifact]): Option[Artifact.Name] =
-      artifacts.maxByOption(_.releaseDate).map(a => ofVersion(a.version))
-
-    if preferStableVersion then
-      defaultArtifactName
-        .filter(name => filteredArtifacts.exists(_.name == name))
-        .orElse(byLatestDate(stableArtifacts))
-        .orElse(byLatestDate(filteredArtifacts))
-        .get
-    else
-      defaultArtifactName
-        .filter(name => filteredArtifacts.exists(_.name == name))
-        .orElse(byLatestDate(filteredArtifacts))
-        .get
-    end if
-  end getDefaultArtifactName
+    ProjectHeader
+      .resolveDefaultArtifact(artifacts, defaultArtifactName, preferStableVersion, language, platform, None)
+      .getOrElse(defaultArtifact)
 
   def allScalaVersions: Seq[Scala] = aggregatedLanguages.collect { case v: Scala => v }
   def allScalaJsVersions: Seq[ScalaJs] = aggregatedPlatforms.collect { case v: ScalaJs => v }

--- a/modules/core/shared/src/main/scala/scaladex/core/model/ProjectHeader.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/ProjectHeader.scala
@@ -9,7 +9,7 @@ object ProjectHeader:
       defaultArtifactName: Option[Artifact.Name],
       preferStableVersion: Boolean
   ): Option[ProjectHeader] =
-    // A header only exists if it has a default artifact, which is the case iff artifacts is non-empty.
+    // A header only exists if it has a default artifact, which is the case if artifacts is non-empty.
     resolveDefaultArtifact(artifacts, defaultArtifactName, preferStableVersion, None, None, None)
       .map(defaultArtifact =>
         new ProjectHeader(ref, artifacts, defaultArtifactName, preferStableVersion, defaultArtifact)

--- a/modules/server/src/main/scala/scaladex/server/route/Badges.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/Badges.scala
@@ -118,7 +118,9 @@ class Badges(projectService: ProjectService)(using ExecutionContext):
       binaryVersion: Option[BinaryVersion],
       artifact: Option[Artifact.Name]
   ): Future[Option[Artifact.Reference]] =
-    projectService.getHeader(project.reference).map(_.map(_.getDefaultArtifact0(binaryVersion, artifact).reference))
+    projectService
+      .getHeader(project.reference)
+      .map(_.flatMap(_.getDefaultArtifact0(binaryVersion, artifact).map(_.reference)))
 end Badges
 
 object Badges:

--- a/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/BadgesTests.scala
@@ -83,6 +83,16 @@ class BadgesTests extends ControllerBaseSuite with BeforeAndAfterAll:
       )
     }
   }
+
+  it("error badge instead of crashing for latest.svg of an unknown artifact of a known project") {
+    Get(s"/${Cats.reference}/does-not-exist/latest.svg") ~> route ~> check {
+      status shouldEqual StatusCodes.TemporaryRedirect
+      val redirection = headers.collectFirst { case Location(uri) => uri }
+      redirection should contain(
+        Uri("https://img.shields.io/badge/does--not--exist-no_published_artifacts-lightgrey.svg?")
+      )
+    }
+  }
 end BadgesTests
 
 class BadgesUnitTests extends AnyFunSpec with Matchers:


### PR DESCRIPTION
## Problem

Requesting `latest.svg` for an explicit artifact name that doesn't exist crashes the request handler. `ProjectHeader.getDefaultArtifact` filters artifacts by the requested name, gets an empty set, and throws `empty.maxBy`.

```
2026-09-04 02:14:15,658 ERROR scaladex.server.Server$:197  - Unhandled exception in http://index.scala-lang.org/polyvariant/better-tostring/better-tostring/latest.svg
java.lang.UnsupportedOperationException: empty.maxBy
        at scala.collection.IterableOnceOps.maxBy(IterableOnce.scala:1183)
        at scala.collection.AbstractIterable.maxBy(Iterable.scala:936)
        at scaladex.core.model.ProjectHeader.getDefaultArtifact(ProjectHeader.scala:70)
        at scaladex.core.model.ProjectHeader.getDefaultArtifact0(ProjectHeader.scala:50)
        at scaladex.server.route.Badges.getDefaultArtifact$$anonfun$1$$anonfun$1(Badges.scala:121)
```

## Fix

- `getDefaultArtifact0` returns `Option[Artifact]`, so the `latest.svg` route renders the existing "no published artifacts" badge instead of 500ing.
- `ProjectHeader` artifact resolution is made total (no `maxBy`/`get`): the non-emptiness invariant is discharged once in `apply`, and the default artifact is carried on the header.
- Added a regression test for `latest.svg` with an unknown artifact name.