### PR TITLE
Project page: add paginated Dependents tab

### DIFF
--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -353,7 +353,7 @@
     }
   }
 
-  .artifacts, .versions {
+  .artifacts, .versions, .dependents {
     .artifacts-header {
       display: flex;
       align-items: center;
@@ -444,6 +444,20 @@
       color: $headings-color;
       font-size: 20px;
       margin-left: 12px;
+    }
+  }
+
+  .dependents {
+    .dependent-name {
+      color: $brand-secondary;
+      font-size: 24px;
+      &:active, &:focus, &:hover {
+        text-decoration: none;
+        color: $brand-primary;
+      }
+    }
+    .dependent-info {
+      font-size: 16px;
     }
   }
 

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -10,6 +10,7 @@ import scala.util.Failure
 import scala.util.Success
 
 import scaladex.core.model.*
+import scaladex.core.model.search.Pagination
 import scaladex.core.service.ProjectService
 import scaladex.core.service.SchedulerDatabase
 import scaladex.core.service.SearchEngine
@@ -187,6 +188,33 @@ class ProjectPages(
         }
       },
       get {
+        path(projectM / "dependents") { ref =>
+          paging(size = 20) { page =>
+            getProjectOrRedirect(ref, user) { project =>
+              for
+                header <- projectService.getHeader(project)
+                offset = (page.page - 1) * page.size
+                dependents <- database.getProjectReverseDependencies(ref, limit = page.size, offset = offset)
+                count <- database.countProjectDependents(ref)
+              yield
+                val groupedDependents = dependents
+                  .groupBy(_.source)
+                  .view
+                  .mapValues { deps =>
+                    val scope = deps.map(_.scope).min
+                    val version = deps.map(_.targetVersion).max
+                    (scope, version)
+                  }
+                  .toMap
+                val pageCount = math.max(1, math.ceil(count.toDouble / page.size).toInt)
+                val pagination = Pagination(page.page, pageCount, count)
+                val dependentsPage = html.dependents(env, user, project, header, groupedDependents, pagination)
+                complete(dependentsPage)
+            }
+          }
+        }
+      },
+      get {
         path(projectM / "badges")(ref => getBadges(ref, user))
       },
       get {
@@ -301,7 +329,6 @@ class ProjectPages(
           header
             .map(h => database.getProjectDependencies(ref, h.latestVersion))
             .getOrElse(Future.successful(Seq.empty))
-        reverseDependencies <- database.getProjectReverseDependencies(ref, limit = 100, offset = 0)
         reverseDependencyCount <- database.countProjectDependents(ref)
       yield
         val groupedDirectDependencies = directDependencies
@@ -312,14 +339,6 @@ class ProjectPages(
             val versions = deps.map(_.targetVersion).distinct
             (scope, versions)
           }
-        val groupedReverseDependencies = reverseDependencies
-          .groupBy(_.source)
-          .view
-          .mapValues { deps =>
-            val scope = deps.map(_.scope).min
-            val version = deps.map(_.targetVersion).max
-            (scope, version)
-          }
         val page =
           html.project(
             env,
@@ -327,7 +346,6 @@ class ProjectPages(
             project,
             header,
             groupedDirectDependencies.toMap,
-            groupedReverseDependencies.toMap,
             reverseDependencyCount
           )
         complete(page)

--- a/modules/template/src/main/scala/scaladex/view/ProjectTab.scala
+++ b/modules/template/src/main/scala/scaladex/view/ProjectTab.scala
@@ -5,6 +5,7 @@ object ProjectTab:
   object Main extends ProjectTab
   object Artifacts extends ProjectTab
   object Versions extends ProjectTab
+  object Dependents extends ProjectTab
   object Badges extends ProjectTab
   object Settings extends ProjectTab
   object VersionMatrix extends ProjectTab

--- a/modules/template/src/main/scala/scaladex/view/html/package.scala
+++ b/modules/template/src/main/scala/scaladex/view/html/package.scala
@@ -87,6 +87,9 @@ package object html:
     Uri(s"/$ref/artifacts")
       .appendQuery("binary-version", binaryVersion.map(_.value))
 
+  def dependentsUri(ref: Project.Reference)(page: Int): Uri =
+    Uri(s"/$ref/dependents").appendQuery("page" -> page.toString)
+
   // https://www.reddit.com/r/scala/comments/4n73zz/scala_puzzle_gooooooogle_pagination/d41jor5
   def paginationRender(selected: Int, max: Int, toShow: Int = 10): (Option[Int], List[Int], Option[Int]) =
     val min = 1

--- a/modules/template/src/main/twirl/scaladex/view/project/dependents.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/dependents.scala.html
@@ -1,0 +1,69 @@
+@import scaladex.core.model._
+@import scaladex.core.model.search.Pagination
+@import scaladex.view.html.main
+@import scaladex.view.html._
+@import scaladex.view.Formats
+@import scaladex.view.ProjectTab
+
+@(
+    env: Env,
+    user: Option[UserState],
+    project: Project,
+    header: Option[ProjectHeader],
+    dependents: Map[Project.Reference, (ArtifactDependency.Scope, Version)],
+    pagination: Pagination
+)
+
+@main(env, title = project.repository.toString, user) {
+  <main id="container-project">
+    @headproject(env, user, project, header, ProjectTab.Dependents)
+    <div class="container">
+      <div class="content-project dependents box" data-organization="@project.reference.organization"
+      data-repository="@project.reference.repository">
+        <div class="artifacts-header">
+          <h2>Dependents</h2>
+        </div>
+        <div class="result-count">
+          Found <b>@pagination.totalSize</b> @Formats.wordPlural(pagination.totalSize, "dependent")
+        </div>
+        @if(dependents.isEmpty) {
+          <div>This project has no known dependents yet</div>
+        } else {
+          <div>
+            @for((ref, (scope, version)) <- dependents.toSeq.sortBy { case (ref, _) => ref }) {
+              <div class="panel">
+                <div class="dependent-row panel-body center">
+                  <div class="col-md-6">
+                    <a class="dependent-name" href="/@ref">@ref</a>
+                  </div>
+                  <div class="col-md-6">
+                    <div class="artifact-info dependent-info">
+                      depends on <b>@version</b> @scopeSpan(scope)
+                    </div>
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+          @paginate(pagination, dependentsUri(project.reference))
+        }
+      </div>
+    </div>
+  </main>
+}
+
+@scopeDescription(scope: ArtifactDependency.Scope) = @{
+  scope.value match {
+    case "provided" => "Expected to be provided by the runtime environment; not bundled in the final artifact"
+    case "runtime" => "Needed only at runtime, not for compiling against this dependency"
+    case "test" => "Used only for compiling and running tests"
+    case "optional" => "Optional: not pulled in transitively by projects depending on this one"
+    case "macro" => "Used only for macro expansion at compile time"
+    case other => other
+  }
+}
+@scopeSpan(scope: ArtifactDependency.Scope) = {
+  @if(scope.value != "compile") {
+    <span class="label label-default" data-toggle="tooltip" data-placement="top" title="@scopeDescription(scope)">@scope</span>
+  }
+}

--- a/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/headproject.scala.html
@@ -115,6 +115,7 @@
               <li role="artifacts" class="@isActive(ProjectTab.Artifacts)"><a href="/@project.reference/artifacts">Artifacts</a></li>
               <li role="versions" class="@isActive(ProjectTab.Versions)"><a href="@header.versionsUrl">Versions</a></li>
               <!-- <li role="version-matrix" class="@isActive(ProjectTab.VersionMatrix)"><a href="/@project.reference/version-matrix">Version Matrix</a></li> -->
+              <li role="dependents" class="@isActive(ProjectTab.Dependents)"><a href="/@project.reference/dependents">Dependents</a></li>
               <li role="badges" class="@isActive(ProjectTab.Badges)"><a href="/@project.reference/badges">Badges</a></li>
             }
             @if(canEdit) {

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -10,7 +10,6 @@
   project: Project,
   header: Option[ProjectHeader],
   directDependencies: Map[Project.Reference, (ArtifactDependency.Scope, Seq[Version])],
-  reverseDependency: Map[Project.Reference, (ArtifactDependency.Scope, Version)],
   reverseDependencyCount: Long,
 )
 @main(env, title = project.repository.value, user, extraMeta = project.twitterCard.toHeadMeta, extraMetaProperty = project.ogp.toHeadMetaProperty) {
@@ -32,7 +31,6 @@
             @project.githubInfo.map(gh => statisticsBox(gh, project.reference, reverseDependencyCount))
             @commitActivityBox
             @directDependenciesBox(directDependencies)
-            @reverseDependenciesBox(reverseDependency, reverseDependencyCount)
           </div>
         </div>
       </div>
@@ -52,7 +50,7 @@
           <a href="https://github.com/@ref/network"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-code-branch"></i> @Formats.plural(github.forks.getOrElse(0).toLong, "fork")</li></a>
           <a href="https://github.com/@ref/commits"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-clock-rotate-left"></i> @Formats.plural(github.commits.getOrElse(0).toLong, "commit")</li></a>
           <a href="https://github.com/@ref/issues"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-circle-exclamation"></i> @Formats.plural(github.issues.getOrElse(0).toLong, "open issue")</li></a>
-          <a href="#dependents"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-sitemap"></i> @Formats.plural(dependentsCount, "dependent")</li></a>
+          <a href="/@ref/dependents"><li class="col-md-6 col-sm-6"><i class="fa-solid fa-sitemap"></i> @Formats.plural(dependentsCount, "dependent")</li></a>
         </ul>
       </div>
     </div>
@@ -116,25 +114,6 @@
       }
     </ul>
   </div>
-}
-
-@reverseDependenciesBox(dependencies: Map[Project.Reference, (ArtifactDependency.Scope, Version)], count: Long) = {
-  <section class="dependencies box" id="dependents">
-    <h4>@Formats.plural(count, "Dependent")</h4>
-    <ul>
-      @for((ref, (scope, version)) <- dependencies.toSeq.sortBy { case (ref, _) => ref }){
-        <li>
-          <div class="row">
-            <div class="col-xs-8"><a href="/@ref">@ref</a> @scopeSpan(scope)</div>
-            <div class="col-xs-4">on @version</div>
-          </div>
-        </li>
-      }
-      @if(count > 100) {
-        <p>and @{count - 100} more</p>
-      }
-    </ul>
-  </section>
 }
 
 @scopeDescription(scope: ArtifactDependency.Scope) = @{


### PR DESCRIPTION
Fixes #1368.
The main page's Dependents box was capped at 100 entries with no way to see the rest for popular projects. Give it its own tab with real pagination and remove the now-redundant sidebar list.

implemented by Claude, verified