### PR TITLE
Badges page: let users pick which artifact's badges to view

### DIFF
--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -566,10 +566,14 @@
   }
   
   .project-badges {
+    .badges-header {
+      margin-bottom: 20px;
+    }
+
     .badge-section {
       overflow: hidden;
     }
-  
+
     img {
       margin-bottom: 24px;
     }

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -353,7 +353,7 @@ class ProjectPages(
     getProjectOrRedirect(ref, user) { project =>
       for header <- projectService.getHeader(project) yield
         val validArtifactName = artifactName.filter(name => header.exists(_.allArtifactNames.contains(name)))
-        header.map(_.getDefaultArtifact(None, None, validArtifactName)) match
+        header.flatMap(_.getDefaultArtifact0(None, validArtifactName)) match
           case Some(artifact) =>
             val page = html.badges(env, user, project, header, artifact)
             complete(StatusCodes.OK, page)

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -211,9 +211,7 @@ class ProjectPages(
       },
       get {
         path(projectM / "badges") { ref =>
-          parameter("artifact".?) { artifactName =>
-            getBadges(ref, artifactName.map(Artifact.Name.apply), user)
-          }
+          parameter("artifact".?) { artifactName => getBadges(ref, artifactName.map(Artifact.Name.apply), user) }
         }
       },
       get {

--- a/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ProjectPages.scala
@@ -210,7 +210,11 @@ class ProjectPages(
         }
       },
       get {
-        path(projectM / "badges")(ref => getBadges(ref, user))
+        path(projectM / "badges") { ref =>
+          parameter("artifact".?) { artifactName =>
+            getBadges(ref, artifactName.map(Artifact.Name.apply), user)
+          }
+        }
       },
       get {
         path(projectM / "settings") { projectRef =>
@@ -347,14 +351,16 @@ class ProjectPages(
         complete(page)
     }
 
-  private def getBadges(ref: Project.Reference, user: Option[UserState]): Route =
+  private def getBadges(ref: Project.Reference, artifactName: Option[Artifact.Name], user: Option[UserState]): Route =
     getProjectOrRedirect(ref, user) { project =>
-      for header <- projectService.getHeader(project) yield header.map(_.getDefaultArtifact(None, None)) match
-        case Some(artifact) =>
-          val page = html.badges(env, user, project, header, artifact)
-          complete(StatusCodes.OK, page)
-        case None =>
-          complete(StatusCodes.NotFound)
+      for header <- projectService.getHeader(project) yield
+        val validArtifactName = artifactName.filter(name => header.exists(_.allArtifactNames.contains(name)))
+        header.map(_.getDefaultArtifact(None, None, validArtifactName)) match
+          case Some(artifact) =>
+            val page = html.badges(env, user, project, header, artifact)
+            complete(StatusCodes.OK, page)
+          case None =>
+            complete(StatusCodes.NotFound)
     }
 
   private val editForm: Directive1[Project.Settings] =

--- a/modules/template/src/main/scala/scaladex/view/html/package.scala
+++ b/modules/template/src/main/scala/scaladex/view/html/package.scala
@@ -90,6 +90,9 @@ package object html:
   def dependentsUri(ref: Project.Reference)(page: Int): Uri =
     Uri(s"/$ref/dependents").appendQuery("page" -> page.toString)
 
+  def badgesUri(ref: Project.Reference, artifactName: Artifact.Name): Uri =
+    Uri(s"/$ref/badges").appendQuery("artifact" -> artifactName.value)
+
   // https://www.reddit.com/r/scala/comments/4n73zz/scala_puzzle_gooooooogle_pagination/d41jor5
   def paginationRender(selected: Int, max: Int, toShow: Int = 10): (Option[Int], List[Int], Option[Int]) =
     val min = 1

--- a/modules/template/src/main/twirl/scaladex/view/project/badges.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/badges.scala.html
@@ -5,6 +5,7 @@
 @import scaladex.core.model.UserState
 @import scaladex.core.model.Version
 @import scaladex.view.html.main
+@import scaladex.view.html._
 @import scaladex.view.ProjectTab
 @import scaladex.core.model.Platform
 @import scala.collection.SortedSet
@@ -21,6 +22,19 @@
     @headproject(env, user, project, header, ProjectTab.Badges)
     <div class="container">
       <div class="content-project box project-badges">
+        @if(header.exists(_.allArtifactNames.size > 1)) {
+          <div class="badges-header">
+            <select class="selectpicker" title="Other Artifacts"
+              data-style="btn-default" data-selected-text-format="static"
+              onchange="window.location=this.value">
+              @for(name <- header.map(_.allArtifactNames).getOrElse(Seq.empty)) {
+                <option value="@badgesUri(project.reference, name)" @if(name == artifact.name) {selected}>
+                  @name
+                </option>
+              }
+            </select>
+          </div>
+        }
         <section class="badge-section" id="latest">
           <h2>Latest version</h2>
           <img src="@artifact.latestBadgeUrl(env)" />


### PR DESCRIPTION
Fixes #1525.
Projects with multiple artifacts always showed badges for a single default artifact with no way to see the others. Add an artifact selector, matching the one on the Versions page.

implemented by Claude, verified