### PR TITLE
Host scaladocs locally, fetched from Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/.scalafmt
 scaladex.log
 .bloop/
 .metals/
+scaladex-scaladoc/
 **/project/metals.sbt
 .bsp/
 .vscode/

--- a/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/Artifact.scala
@@ -184,6 +184,10 @@ case class Artifact(
       case None => Some(s"https://www.javadoc.io/doc/$groupId/$artifactId/$version")
       case _ => None
 
+  // Routed through our own scaladoc-hosting page (ArtifactPages), which serves a locally-unpacked
+  // copy when we have one, falling back to the project's actual external scaladoc link otherwise.
+  def scaladocPath: String = s"/artifacts/$groupId/$artifactId/$version/scaladoc"
+
   def scastieURL: Option[String] =
     val tryBaseUrl = "https://scastie.scala-lang.org/try"
 

--- a/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralClient.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralClient.scala
@@ -11,3 +11,4 @@ trait MavenCentralClient:
   def getAllArtifactIds(groupId: Artifact.GroupId): Future[Seq[Artifact.ArtifactId]]
   def getAllVersions(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Version]]
   def getPomFile(mavenReference: Artifact.Reference): Future[Option[(String, Instant)]]
+  def getJavadocJar(mavenReference: Artifact.Reference): Future[Option[Array[Byte]]]

--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -70,4 +70,8 @@ scaladex {
     temp = /tmp/scaladex/
     scaladoc = scaladex-scaladoc
   }
+  scaladoc {
+    max-cache-size = 20g
+    max-unpacked-size = 512m
+  }
 }

--- a/modules/infra/src/main/resources/reference.conf
+++ b/modules/infra/src/main/resources/reference.conf
@@ -68,5 +68,6 @@ scaladex {
     contrib = scaladex-contrib
     index = small-index
     temp = /tmp/scaladex/
+    scaladoc = scaladex-scaladoc
   }
 }

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -1,33 +1,23 @@
 package scaladex.infra
 
-import java.time.Instant
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-
-import scala.concurrent.ExecutionContextExecutor
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.util.Try
-import scala.util.control.NonFatal
-
-import scaladex.core.model.Artifact
-import scaladex.core.model.SbtPlugin
-import scaladex.core.model.Version
-import scaladex.core.service.MavenCentralClient
-import scaladex.core.util.JsoupUtils
-import scaladex.infra.config.HttpClientConfig
-
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
-import org.apache.pekko.http.scaladsl.model
-import org.apache.pekko.http.scaladsl.model.HttpRequest
-import org.apache.pekko.http.scaladsl.model.HttpResponse
-import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.{model, Http}
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import org.apache.pekko.stream.scaladsl.Flow
 import org.apache.pekko.util.ByteString
+import scaladex.core.model.{Artifact, BinaryVersion, SbtPlugin, Version}
+import scaladex.core.service.MavenCentralClient
+import scaladex.core.util.JsoupUtils
+import scaladex.infra.config.HttpClientConfig
+
+import java.time.{Instant, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
+import scala.util.Try
+import scala.util.control.NonFatal
 
 class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
     extends CommonAkkaHttpClient(config)
@@ -86,35 +76,31 @@ class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default
 
   override def getJavadocJar(ref: Artifact.Reference): Future[Option[Array[Byte]]] =
     val jarUri = getJavadocJarUri(ref)
-    val future = for
-      response <- queueRequestWithRetry(HttpRequest(uri = jarUri))
-      res <- getJarBytes(response, jarUri)
-    yield res
-    future.recoverWith {
-      case NonFatal(exception) =>
-        logger.warn(s"Could not get javadoc jar of $ref because of $exception")
-        Future.successful(None)
-    }
+    queueRequestWithRetry(HttpRequest(uri = jarUri))
+      .flatMap(response => getJarBytes(response, jarUri))
+      .recoverWith {
+        case NonFatal(exception) =>
+          logger.warn(s"Could not get javadoc jar of $ref because of $exception")
+          Future.successful(None)
+      }
   end getJavadocJar
 
-  private def getJarBytes(response: HttpResponse, uri: String): Future[Option[Array[Byte]]] =
-    response match
-      case _ @HttpResponse(StatusCodes.OK, _, entity, _) =>
-        entity.dataBytes.runFold(ByteString.empty)(_ ++ _).map(bytes => Some(bytes.toArray))
-      case _ =>
-        logger.warn(s"Cannot get $uri: ${response.status}")
-        response.discardEntityBytes()
-        Future.successful(None)
+  private def getJarBytes(response: HttpResponse, uri: String): Future[Option[Array[Byte]]] = response match
+    case _ @HttpResponse(StatusCodes.OK, _, entity, _) =>
+      entity.dataBytes.runFold(ByteString.empty)(_ ++ _).map(bytes => Some(bytes.toArray))
+    case _ =>
+      logger.warn(s"Cannot get $uri: ${response.status}")
+      response.discardEntityBytes()
+      Future.successful(None)
 
   private def getJavadocJarUri(ref: Artifact.Reference): String =
-    val groupIdUrl: String = ref.groupId.value.replace('.', '/')
     val jarFileName = getJavadocJarFileName(ref.artifactId, ref.version)
-    s"$baseUri/${groupIdUrl}/${ref.artifactId.value}/${ref.version.value}/$jarFileName"
+    s"$baseUri/${ref.groupId.mavenUrl}/${ref.artifactId.value}/${ref.version.value}/$jarFileName"
 
-  private def getJavadocJarFileName(artifactId: Artifact.ArtifactId, version: Version): String =
-    artifactId.binaryVersion.platform match
-      case SbtPlugin(Version.Minor(0, 13)) => s"${artifactId.name.value}-${version.value}-javadoc.jar"
-      case _ => s"${artifactId.value}-${version.value}-javadoc.jar"
+  private def getJavadocJarFileName(artifactId: Artifact.ArtifactId, version: Version) = artifactId match
+    case Artifact.ArtifactId(name, BinaryVersion(SbtPlugin(Version.Minor(0, 13)), _)) =>
+      s"$name-${version.value}-javadoc.jar"
+    case _ => s"${artifactId.value}-${version.value}-javadoc.jar"
 
   private def getPomFileWithLastModifiedTime(response: HttpResponse, uri: String): Future[Option[(String, Instant)]] =
     response match
@@ -148,9 +134,8 @@ class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default
     page.iterator.take(200).mkString.replaceAll("\\s+", " ")
 
   private def getPomUri(ref: Artifact.Reference): String =
-    val groupIdUrl: String = ref.groupId.value.replace('.', '/')
     val pomFileName = getPomFileName(ref.artifactId, ref.version)
-    s"$baseUri/${groupIdUrl}/${ref.artifactId.value}/${ref.version.value}/$pomFileName"
+    s"$baseUri/${ref.groupId.mavenUrl}/${ref.artifactId.value}/${ref.version.value}/$pomFileName"
 
   // Wed, 04 Nov 2020 23:36:02 GMT
   private val dateFormatter = DateTimeFormatter.RFC_1123_DATE_TIME

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -1,23 +1,34 @@
 package scaladex.infra
 
-import com.typesafe.scalalogging.LazyLogging
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.{model, Http}
-import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
-import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
-import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.util.ByteString
-import scaladex.core.model.{Artifact, BinaryVersion, SbtPlugin, Version}
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.BinaryVersion
+import scaladex.core.model.SbtPlugin
+import scaladex.core.model.Version
 import scaladex.core.service.MavenCentralClient
 import scaladex.core.util.JsoupUtils
 import scaladex.infra.config.HttpClientConfig
 
-import java.time.{Instant, ZonedDateTime}
-import java.time.format.DateTimeFormatter
-import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
-import scala.util.Try
-import scala.util.control.NonFatal
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 
 class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
     extends CommonAkkaHttpClient(config)

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -27,6 +27,7 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 
 class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default)(using system: ActorSystem)
     extends CommonAkkaHttpClient(config)
@@ -82,6 +83,38 @@ class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default
         Future.successful(None)
     }
   end getPomFile
+
+  override def getJavadocJar(ref: Artifact.Reference): Future[Option[Array[Byte]]] =
+    val jarUri = getJavadocJarUri(ref)
+    val future = for
+      response <- queueRequestWithRetry(HttpRequest(uri = jarUri))
+      res <- getJarBytes(response, jarUri)
+    yield res
+    future.recoverWith {
+      case NonFatal(exception) =>
+        logger.warn(s"Could not get javadoc jar of $ref because of $exception")
+        Future.successful(None)
+    }
+  end getJavadocJar
+
+  private def getJarBytes(response: HttpResponse, uri: String): Future[Option[Array[Byte]]] =
+    response match
+      case _ @HttpResponse(StatusCodes.OK, _, entity, _) =>
+        entity.dataBytes.runFold(ByteString.empty)(_ ++ _).map(bytes => Some(bytes.toArray))
+      case _ =>
+        logger.warn(s"Cannot get $uri: ${response.status}")
+        response.discardEntityBytes()
+        Future.successful(None)
+
+  private def getJavadocJarUri(ref: Artifact.Reference): String =
+    val groupIdUrl: String = ref.groupId.value.replace('.', '/')
+    val jarFileName = getJavadocJarFileName(ref.artifactId, ref.version)
+    s"$baseUri/${groupIdUrl}/${ref.artifactId.value}/${ref.version.value}/$jarFileName"
+
+  private def getJavadocJarFileName(artifactId: Artifact.ArtifactId, version: Version): String =
+    artifactId.binaryVersion.platform match
+      case SbtPlugin(Version.Minor(0, 13)) => s"${artifactId.name.value}-${version.value}-javadoc.jar"
+      case _ => s"${artifactId.value}-${version.value}-javadoc.jar"
 
   private def getPomFileWithLastModifiedTime(response: HttpResponse, uri: String): Future[Option[(String, Instant)]] =
     response match

--- a/modules/infra/src/main/scala/scaladex/infra/config/FilesystemConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/FilesystemConfig.scala
@@ -5,11 +5,12 @@ import java.nio.file.Paths
 
 import com.typesafe.config.Config
 
-case class FilesystemConfig(temp: Path, index: Path, contrib: Path)
+case class FilesystemConfig(temp: Path, index: Path, contrib: Path, scaladoc: Path)
 
 object FilesystemConfig:
   def from(config: Config): FilesystemConfig =
     val temp = Paths.get(config.getString("scaladex.filesystem.temp"))
     val index = Paths.get(config.getString("scaladex.filesystem.index"))
     val contrib = Paths.get(config.getString("scaladex.filesystem.contrib"))
-    FilesystemConfig(temp, index, contrib)
+    val scaladoc = Paths.get(config.getString("scaladex.filesystem.scaladoc"))
+    FilesystemConfig(temp, index, contrib, scaladoc)

--- a/modules/infra/src/main/scala/scaladex/infra/config/ScaladocConfig.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/config/ScaladocConfig.scala
@@ -1,0 +1,11 @@
+package scaladex.infra.config
+
+import com.typesafe.config.Config
+
+case class ScaladocConfig(maxCacheBytes: Long, maxUnpackedBytes: Long)
+
+object ScaladocConfig:
+  def from(config: Config): ScaladocConfig = ScaladocConfig(
+    maxCacheBytes = config.getMemorySize("scaladex.scaladoc.max-cache-size").toBytes,
+    maxUnpackedBytes = config.getMemorySize("scaladex.scaladoc.max-unpacked-size").toBytes
+  )

--- a/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
@@ -61,6 +61,18 @@ class MavenCentralClientImplTests extends AsyncFunSpec with Matchers:
     yield res.get._1.startsWith("<?xml") shouldBe true
   }
 
+  it(s"retrieve javadoc jar for a jvm artifact") {
+    for res <- client.getJavadocJar(Artifact.Reference.from("org.typelevel", "cats-core_2.13", "2.9.0"))
+    yield
+      res shouldBe defined
+      res.get.length should be > 1000
+  }
+
+  it(s"return None for a javadoc jar that doesn't exist") {
+    for res <- client.getJavadocJar(Artifact.Reference.from("ch.epfl.scala", "does-not-exist_2.13", "0.0.0"))
+    yield res shouldBe None
+  }
+
   it(s"parse date time") {
     client.parseDate("Wed, 23 Sep 2020 11:40:44 GMT") shouldBe Instant.ofEpochSecond(1600861244L)
   }

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -162,7 +162,12 @@ object Server extends LazyLogging:
     val frontPage = new FrontPage(config.env, webDatabase, searchEngine)
     val adminPages = new AdminPage(config.env, adminService)
     val projectPages = new ProjectPages(config.env, projectService, settingsService, webDatabase)
-    val scaladocService = ScaladocService(config.filesystem.scaladoc, mavenCentralClient)
+    val scaladocService = ScaladocService(
+      config.filesystem.scaladoc,
+      mavenCentralClient,
+      config.scaladoc.maxCacheBytes,
+      config.scaladoc.maxUnpackedBytes
+    )
     val artifactPages = new ArtifactPages(config.env, webDatabase, scaladocService)
     val awesomePages = new AwesomePages(config.env, searchEngine)
     val publishApi = new PublishApi(githubAuth, publishProcess)

--- a/modules/server/src/main/scala/scaladex/server/Server.scala
+++ b/modules/server/src/main/scala/scaladex/server/Server.scala
@@ -6,6 +6,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal
 
+import scaladex.core.service.MavenCentralClient
 import scaladex.core.service.ProjectService
 import scaladex.data.util.PidLock
 import scaladex.infra.DataPaths
@@ -24,6 +25,7 @@ import scaladex.server.service.ArtifactService
 import scaladex.server.service.MavenCentralService
 import scaladex.server.service.ProjectSettingsService
 import scaladex.server.service.PublishProcess
+import scaladex.server.service.ScaladocService
 import scaladex.view.html.notfound
 
 import cats.effect.ContextShift
@@ -93,7 +95,8 @@ object Server extends LazyLogging:
                 searchEngine,
                 webDatabase,
                 adminService,
-                publishProcess
+                publishProcess,
+                mavenCentralClient
               )
               _ <- IO(
                 Http()
@@ -143,7 +146,8 @@ object Server extends LazyLogging:
       searchEngine: ElasticsearchEngine,
       webDatabase: SqlDatabase,
       adminService: AdminService,
-      publishProcess: PublishProcess
+      publishProcess: PublishProcess,
+      mavenCentralClient: MavenCentralClient
   )(
       using system: ActorSystem
   ): Route =
@@ -158,7 +162,8 @@ object Server extends LazyLogging:
     val frontPage = new FrontPage(config.env, webDatabase, searchEngine)
     val adminPages = new AdminPage(config.env, adminService)
     val projectPages = new ProjectPages(config.env, projectService, settingsService, webDatabase)
-    val artifactPages = new ArtifactPages(config.env, webDatabase)
+    val scaladocService = ScaladocService(config.filesystem.scaladoc, mavenCentralClient)
+    val artifactPages = new ArtifactPages(config.env, webDatabase, scaladocService)
     val awesomePages = new AwesomePages(config.env, searchEngine)
     val publishApi = new PublishApi(githubAuth, publishProcess)
     val apiEndpoints =

--- a/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
+++ b/modules/server/src/main/scala/scaladex/server/config/ServerConfig.scala
@@ -9,6 +9,7 @@ import scaladex.infra.config.FilesystemConfig
 import scaladex.infra.config.GithubConfig
 import scaladex.infra.config.MavenCentralConfig
 import scaladex.infra.config.PostgreSQLConfig
+import scaladex.infra.config.ScaladocConfig
 
 import com.softwaremill.pekkohttpsession.SessionConfig
 import com.typesafe.config.Config
@@ -26,7 +27,8 @@ case class ServerConfig(
     filesystem: FilesystemConfig,
     github: GithubConfig,
     mavenCentral: MavenCentralConfig,
-    caching: CacheConfig
+    caching: CacheConfig,
+    scaladoc: ScaladocConfig
 )
 
 object ServerConfig:
@@ -48,6 +50,7 @@ object ServerConfig:
     val github = GithubConfig.from(config)
     val mavenCentral = MavenCentralConfig.from(config)
     val caching = CacheConfig.from(config)
+    val scaladoc = ScaladocConfig.from(config)
 
     ServerConfig(
       env,
@@ -61,7 +64,8 @@ object ServerConfig:
       filesystem,
       github,
       mavenCentral,
-      caching
+      caching,
+      scaladoc
     )
   end load
 end ServerConfig

--- a/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
@@ -1,18 +1,22 @@
 package scaladex.server.route
 
-import com.typesafe.scalalogging.LazyLogging
-import org.apache.pekko.http.scaladsl.model.*
-import org.apache.pekko.http.scaladsl.server.Directives.*
-import org.apache.pekko.http.scaladsl.server.Route
-import scaladex.core.model.{Artifact, Env, Project, UserState}
+import scala.concurrent.ExecutionContext
+import scala.util.Success
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.Env
+import scaladex.core.model.Project
+import scaladex.core.model.UserState
 import scaladex.core.service.WebDatabase
 import scaladex.server.TwirlSupport.given
 import scaladex.server.service.ScaladocService
 import scaladex.view.html
 import scaladex.view.project.html.scaladoc
 
-import scala.concurrent.ExecutionContext
-import scala.util.Success
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.Route
 
 class ArtifactPages(env: Env, database: WebDatabase, scaladocService: ScaladocService)(using ExecutionContext)
     extends LazyLogging:

--- a/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
@@ -1,82 +1,75 @@
 package scaladex.server.route
 
-import scala.concurrent.ExecutionContext
-import scala.util.Success
-
-import scaladex.core.model.Artifact
-import scaladex.core.model.Env
-import scaladex.core.model.Project
-import scaladex.core.model.UserState
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.Route
+import scaladex.core.model.{Artifact, Env, Project, UserState}
 import scaladex.core.service.WebDatabase
 import scaladex.server.TwirlSupport.given
 import scaladex.server.service.ScaladocService
 import scaladex.view.html
 import scaladex.view.project.html.scaladoc
 
-import com.typesafe.scalalogging.LazyLogging
-import org.apache.pekko.http.scaladsl.model.*
-import org.apache.pekko.http.scaladsl.server.Directives.*
-import org.apache.pekko.http.scaladsl.server.Route
+import scala.concurrent.ExecutionContext
+import scala.util.Success
 
 class ArtifactPages(env: Env, database: WebDatabase, scaladocService: ScaladocService)(using ExecutionContext)
     extends LazyLogging:
-  def route(user: Option[UserState]): Route =
-    concat(
-      get {
-        // The Scaladex-branded shell: a thin bar + a full-height iframe pointing at scaladoc-content below.
-        path("artifacts" / artifactRefM / "scaladoc") { ref =>
-          val resultF = for
-            artifact <- database.getArtifact(ref).map(_.get)
-            project <- database.getProject(artifact.projectRef)
-          yield project.map(p => (p, artifact))
+  def route(user: Option[UserState]): Route = concat(
+    get {
+      // The Scaladex-branded shell: a thin bar + a full-height iframe pointing at scaladoc-content below.
+      path("artifacts" / artifactRefM / "scaladoc") { ref =>
+        val resultF = for
+          artifact <- database.getArtifact(ref).map(_.get)
+          project <- database.getProject(artifact.projectRef)
+        yield project.map(p => (p, artifact))
 
-          onComplete(resultF) {
-            case Success(Some((project, artifact))) =>
-              complete(scaladoc(project, artifact))
-            case _ =>
-              complete(StatusCodes.NotFound, html.notfound(env, user))
-          }
-        }
-      },
-      get {
-        // The raw scaladoc content, iframed by the page above. Serves a locally-unpacked copy of the
-        // artifact's -javadoc.jar when we have (or can fetch) one, falling back to a redirect to the
-        // project's actual external scaladoc link otherwise - same target as the old bare redirect here.
-        pathPrefix("artifacts" / artifactRefM / "scaladoc-content") { ref =>
-          val resultF = for
-            artifact <- database.getArtifact(ref).map(_.get)
-            project <- database.getProject(artifact.projectRef)
-            available <- scaladocService.ensureAvailable(artifact.reference)
-          yield (project, artifact, available)
-
-          onComplete(resultF) {
-            case Success((_, artifact, true)) =>
-              val localDir = scaladocService.localDir(artifact.reference)
-              concat(
-                pathEndOrSingleSlash(getFromFile(localDir.resolve("index.html").toFile)),
-                getFromDirectory(localDir.toString)
-              )
-            case Success((project, artifact, false)) =>
-              redirectToExternalScaladoc(project, artifact, user)
-            case _ =>
-              complete(StatusCodes.NotFound, html.notfound(env, user))
-          }
+        onComplete(resultF) {
+          case Success(Some((project, artifact))) =>
+            complete(scaladoc(project, artifact))
+          case _ =>
+            complete(StatusCodes.NotFound, html.notfound(env, user))
         }
       }
-    )
+    },
+    get {
+      // The raw scaladoc content, iframed by the page above. Serves a locally-unpacked copy of the
+      // artifact's -javadoc.jar when we have (or can fetch) one, falling back to a redirect to the
+      // project's actual external scaladoc link otherwise - same target as the old bare redirect here.
+      pathPrefix("artifacts" / artifactRefM / "scaladoc-content") { ref =>
+        val resultF = for
+          artifact <- database.getArtifact(ref).map(_.get)
+          project <- database.getProject(artifact.projectRef)
+          available <- scaladocService.ensureAvailable(artifact.reference)
+        yield (project, artifact, available)
+
+        onComplete(resultF) {
+          case Success((_, artifact, true)) =>
+            val localDir = scaladocService.localDir(artifact.reference)
+            concat(
+              pathEndOrSingleSlash(getFromFile(localDir.resolve("index.html").toFile)),
+              getFromDirectory(localDir.toString)
+            )
+          case Success((project, artifact, false)) =>
+            redirectToExternalScaladoc(project, artifact, user)
+          case _ =>
+            complete(StatusCodes.NotFound, html.notfound(env, user))
+        }
+      }
+    }
+  )
 
   private def redirectToExternalScaladoc(
       project: Option[Project],
       artifact: Artifact,
       user: Option[UserState]
-  ): Route =
-    extractUnmatchedPath { dri =>
-      project.flatMap(_.scaladoc(artifact)).map(doc => Uri(doc.link)) match
-        case Some(scaladocUri) =>
-          val finalUri = scaladocUri.withPath(scaladocUri.path ++ dri)
-          redirect(finalUri, StatusCodes.SeeOther)
-        case None =>
-          complete(StatusCodes.NotFound, html.notfound(env, user))
-      end match
-    }
+  ): Route = extractUnmatchedPath { dri =>
+    (for
+      p <- project
+      doc <- p.scaladoc(artifact)
+      uri = Uri(doc.link)
+      finalUri = uri.withPath(uri.path ++ dri)
+    yield redirect(finalUri, StatusCodes.SeeOther)).getOrElse(complete(StatusCodes.NotFound, html.notfound(env, user)))
+  }
 end ArtifactPages

--- a/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/ArtifactPages.scala
@@ -3,35 +3,80 @@ package scaladex.server.route
 import scala.concurrent.ExecutionContext
 import scala.util.Success
 
+import scaladex.core.model.Artifact
 import scaladex.core.model.Env
+import scaladex.core.model.Project
 import scaladex.core.model.UserState
 import scaladex.core.service.WebDatabase
 import scaladex.server.TwirlSupport.given
+import scaladex.server.service.ScaladocService
 import scaladex.view.html
+import scaladex.view.project.html.scaladoc
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.http.scaladsl.model.*
 import org.apache.pekko.http.scaladsl.server.Directives.*
 import org.apache.pekko.http.scaladsl.server.Route
 
-class ArtifactPages(env: Env, database: WebDatabase)(using ExecutionContext) extends LazyLogging:
+class ArtifactPages(env: Env, database: WebDatabase, scaladocService: ScaladocService)(using ExecutionContext)
+    extends LazyLogging:
   def route(user: Option[UserState]): Route =
     concat(
       get {
-        path("artifacts" / artifactRefM / "scaladoc" ~ RemainingPath) { (ref, dri) =>
-          val scaladocUriF = for
+        // The Scaladex-branded shell: a thin bar + a full-height iframe pointing at scaladoc-content below.
+        path("artifacts" / artifactRefM / "scaladoc") { ref =>
+          val resultF = for
             artifact <- database.getArtifact(ref).map(_.get)
             project <- database.getProject(artifact.projectRef)
-          yield project.flatMap(_.scaladoc(artifact).map(doc => Uri(doc.link)))
+          yield project.map(p => (p, artifact))
 
-          onComplete(scaladocUriF) {
-            case Success(Some(scaladocUri)) =>
-              val finalUri = scaladocUri.withPath(scaladocUri.path ++ dri)
-              redirect(finalUri, StatusCodes.SeeOther)
+          onComplete(resultF) {
+            case Success(Some((project, artifact))) =>
+              complete(scaladoc(project, artifact))
+            case _ =>
+              complete(StatusCodes.NotFound, html.notfound(env, user))
+          }
+        }
+      },
+      get {
+        // The raw scaladoc content, iframed by the page above. Serves a locally-unpacked copy of the
+        // artifact's -javadoc.jar when we have (or can fetch) one, falling back to a redirect to the
+        // project's actual external scaladoc link otherwise - same target as the old bare redirect here.
+        pathPrefix("artifacts" / artifactRefM / "scaladoc-content") { ref =>
+          val resultF = for
+            artifact <- database.getArtifact(ref).map(_.get)
+            project <- database.getProject(artifact.projectRef)
+            available <- scaladocService.ensureAvailable(artifact.reference)
+          yield (project, artifact, available)
+
+          onComplete(resultF) {
+            case Success((_, artifact, true)) =>
+              val localDir = scaladocService.localDir(artifact.reference)
+              concat(
+                pathEndOrSingleSlash(getFromFile(localDir.resolve("index.html").toFile)),
+                getFromDirectory(localDir.toString)
+              )
+            case Success((project, artifact, false)) =>
+              redirectToExternalScaladoc(project, artifact, user)
             case _ =>
               complete(StatusCodes.NotFound, html.notfound(env, user))
           }
         }
       }
     )
+
+  private def redirectToExternalScaladoc(
+      project: Option[Project],
+      artifact: Artifact,
+      user: Option[UserState]
+  ): Route =
+    extractUnmatchedPath { dri =>
+      project.flatMap(_.scaladoc(artifact)).map(doc => Uri(doc.link)) match
+        case Some(scaladocUri) =>
+          val finalUri = scaladocUri.withPath(scaladocUri.path ++ dri)
+          redirect(finalUri, StatusCodes.SeeOther)
+        case None =>
+          complete(StatusCodes.NotFound, html.notfound(env, user))
+      end match
+    }
 end ArtifactPages

--- a/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
@@ -1,0 +1,103 @@
+package scaladex.server.service
+
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipInputStream
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+import scala.util.control.NonFatal
+
+import scaladex.core.model.Artifact
+import scaladex.core.service.MavenCentralClient
+
+import com.typesafe.scalalogging.LazyLogging
+
+/** Serves a project's scaladoc by lazily downloading and unpacking its `-javadoc.jar` from Maven Central on first
+  * request, then serving the unpacked files from disk on every subsequent request. There is deliberately no eviction:
+  * this is meant to run on a single server with disk to spare, and we'd rather learn real usage before adding one.
+  */
+class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(using ExecutionContext)
+    extends LazyLogging:
+  // Only dedupes concurrent requests for the same not-yet-cached artifact; cleared once resolved either way, so a
+  // transient failure (Maven Central hiccup) doesn't get baked in - the next request just tries again.
+  private val inFlight = TrieMap.empty[Artifact.Reference, Future[Boolean]]
+
+  def localDir(ref: Artifact.Reference): Path =
+    cacheDir
+      .resolve(ref.groupId.value.replace('.', '/'))
+      .resolve(ref.artifactId.value)
+      .resolve(ref.version.value)
+
+  /** @return
+    *   true if the scaladoc for this artifact is available on disk (either already was, or was just downloaded and
+    *   unpacked), false if Maven Central has no javadoc jar for it.
+    */
+  def ensureAvailable(ref: Artifact.Reference): Future[Boolean] =
+    if isUnpacked(ref) then Future.successful(true)
+    else
+      inFlight.getOrElseUpdate(
+        ref,
+        download(ref).andThen { case _ => inFlight.remove(ref) }
+      )
+
+  private def isUnpacked(ref: Artifact.Reference): Boolean =
+    Files.isRegularFile(localDir(ref).resolve("index.html"))
+
+  private def download(ref: Artifact.Reference): Future[Boolean] =
+    mavenCentralClient.getJavadocJar(ref).map {
+      case None => false
+      case Some(bytes) =>
+        try
+          unpack(bytes, localDir(ref))
+          true
+        catch
+          case NonFatal(exception) =>
+            logger.warn(s"Failed to unpack javadoc jar of $ref", exception)
+            false
+    }
+
+  /** Unpacks into a sibling temp directory, then atomically moves it into place - so a concurrent request never sees
+    * a partially-unpacked directory.
+    */
+  private def unpack(bytes: Array[Byte], destination: Path): Unit =
+    val staging = Files.createTempDirectory(cacheDir, "unpacking-")
+    try
+      Using.resource(new ZipInputStream(new ByteArrayInputStream(bytes))) { zip =>
+        Iterator
+          .continually(zip.getNextEntry)
+          .takeWhile(_ != null)
+          .foreach { entry =>
+            // guard against zip-slip: reject any entry that would resolve outside `staging`
+            val entryPath = staging.resolve(entry.getName).normalize()
+            if !entryPath.startsWith(staging) then
+              throw new SecurityException(s"Zip entry escapes destination directory: ${entry.getName}")
+            if entry.isDirectory then Files.createDirectories(entryPath)
+            else
+              Files.createDirectories(entryPath.getParent)
+              Files.copy(zip, entryPath, StandardCopyOption.REPLACE_EXISTING)
+          }
+      }
+      Files.createDirectories(destination.getParent)
+      Files.move(staging, destination, StandardCopyOption.ATOMIC_MOVE)
+    finally deleteRecursively(staging)
+  end unpack
+
+  // no-op once `unpack` has already moved `staging` away; only cleans up on failure
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.iterator.asScala.toSeq.reverse.foreach(Files.deleteIfExists)
+      }
+end ScaladocService
+
+object ScaladocService:
+  def apply(cacheDir: Path, mavenCentralClient: MavenCentralClient)(using ExecutionContext): ScaladocService =
+    if Files.notExists(cacheDir) then Files.createDirectories(cacheDir)
+    new ScaladocService(cacheDir, mavenCentralClient)
+end ScaladocService

--- a/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
@@ -1,13 +1,14 @@
 package scaladex.server.service
 
 import java.io.ByteArrayInputStream
+import java.io.FilterInputStream
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.Comparator
 import java.util.zip.ZipInputStream
 
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Using
@@ -15,18 +16,35 @@ import scala.util.control.NonFatal
 
 import scaladex.core.model.Artifact
 import scaladex.core.service.MavenCentralClient
+import scaladex.server.service.ScaladocService.*
 
+import com.github.benmanes.caffeine.cache.RemovalCause
+import com.github.blemale.scaffeine.AsyncLoadingCache
+import com.github.blemale.scaffeine.Scaffeine
 import com.typesafe.scalalogging.LazyLogging
 
 /** Serves a project's scaladoc by lazily downloading and unpacking its `-javadoc.jar` from Maven Central on first
-  * request, then serving the unpacked files from disk on every subsequent request. There is deliberately no eviction:
-  * this is meant to run on a single server with disk to spare, and we'd rather learn real usage before adding one.
+  * request, then serving the unpacked files from disk on every subsequent request. Unpacked artifacts are tracked in a
+  * `maxCacheBytes`-bounded cache, keyed by their size on disk: once the total exceeds that budget, the least recently
+  * used ones are evicted and their files deleted, so disk usage stays bounded under sustained traffic.
   */
-class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(using ExecutionContext)
+class ScaladocService(
+    cacheDir: Path,
+    mavenCentralClient: MavenCentralClient,
+    maxCacheBytes: Long,
+    maxUnpackedBytes: Long
+)(using ExecutionContext)
     extends LazyLogging:
-  // Only dedupes concurrent requests for the same not-yet-cached artifact; cleared once resolved either way, so a
-  // transient failure (Maven Central hiccup) doesn't get baked in - the next request just tries again.
-  private val inFlight = TrieMap.empty[Artifact.Reference, Future[Boolean]]
+  if Files.notExists(cacheDir) then Files.createDirectories(cacheDir)
+
+  private val cache: AsyncLoadingCache[Artifact.Reference, Entry] =
+    Scaffeine()
+      .maximumWeight(maxCacheBytes)
+      .weigher((_, entry: Entry) => entry.sizeOnDisk.toInt)
+      .removalListener((ref: Artifact.Reference, _, cause) =>
+        if cause != RemovalCause.REPLACED then deleteRecursively(localDir(ref))
+      )
+      .buildAsyncFuture(load)
 
   def localDir(ref: Artifact.Reference): Path =
     cacheDir
@@ -38,29 +56,28 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
     *   true if the scaladoc for this artifact is available on disk (either already was, or was just downloaded and
     *   unpacked), false if Maven Central has no javadoc jar for it.
     */
-  def ensureAvailable(ref: Artifact.Reference): Future[Boolean] =
-    if isUnpacked(ref) then Future.successful(true)
-    else
-      inFlight.getOrElseUpdate(
-        ref,
-        download(ref).andThen(_ => inFlight.remove(ref))
-      )
+  def ensureAvailable(ref: Artifact.Reference): Future[Boolean] = cache.get(ref).map {
+    case Entry.Available(_) => true
+    case Entry.Unavailable => false
+  }
 
   private def isUnpacked(ref: Artifact.Reference): Boolean =
     Files.isRegularFile(localDir(ref).resolve("index.html"))
 
-  private def download(ref: Artifact.Reference): Future[Boolean] =
-    mavenCentralClient.getJavadocJar(ref).map {
-      case None => false
-      case Some(bytes) =>
-        try
-          unpack(bytes, localDir(ref))
-          true
-        catch
-          case NonFatal(exception) =>
-            logger.warn(s"Failed to unpack javadoc jar of $ref", exception)
-            false
-    }
+  private def load(ref: Artifact.Reference): Future[Entry] =
+    if isUnpacked(ref) then Future.successful(Entry.Available(sizeOnDisk(localDir(ref))))
+    else
+      mavenCentralClient.getJavadocJar(ref).map {
+        case None => Entry.Unavailable
+        case Some(bytes) =>
+          try
+            unpack(bytes, localDir(ref))
+            Entry.Available(sizeOnDisk(localDir(ref)))
+          catch
+            case NonFatal(exception) =>
+              logger.warn(s"Failed to unpack javadoc jar of $ref", exception)
+              Entry.Unavailable
+      }
 
   /** Unpacks into a sibling temp directory, then atomically moves it into place - so a concurrent request never sees a
     * partially-unpacked directory.
@@ -69,6 +86,7 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
     val staging = Files.createTempDirectory(cacheDir, "unpacking-")
     try
       Using.resource(new ZipInputStream(new ByteArrayInputStream(bytes))) { zip =>
+        val boundedZip = BoundedInputStream(zip, maxUnpackedBytes)
         Iterator
           .continually(zip.getNextEntry)
           .takeWhile(_ != null)
@@ -76,11 +94,11 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
             // guard against zip-slip: reject any entry that would resolve outside `staging`
             val entryPath = staging.resolve(entry.getName).normalize()
             if !entryPath.startsWith(staging) then
-              throw new SecurityException(s"Zip entry escapes destination directory: ${entry.getName}")
+              throw SecurityException(s"Zip entry escapes destination directory: ${entry.getName}")
             if entry.isDirectory then Files.createDirectories(entryPath)
             else
               Files.createDirectories(entryPath.getParent)
-              Files.copy(zip, entryPath, StandardCopyOption.REPLACE_EXISTING)
+              Files.copy(boundedZip, entryPath, StandardCopyOption.REPLACE_EXISTING)
           }
       }
       Files.createDirectories(destination.getParent)
@@ -89,16 +107,33 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
     end try
   end unpack
 
-  // no-op once `unpack` has already moved `staging` away; only cleans up on failure
-  private def deleteRecursively(dir: Path): Unit =
-    if Files.exists(dir) then
-      Using.resource(Files.walk(dir)) { stream =>
-        stream.sorted(Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
-      }
+  private def sizeOnDisk(dir: Path): Long =
+    Using.resource(Files.walk(dir)) { stream => stream.filter(Files.isRegularFile(_)).mapToLong(Files.size(_)).sum() }
+
+  private def deleteRecursively(dir: Path): Unit = if Files.exists(dir) then
+    Using.resource(Files.walk(dir)) { stream =>
+      stream.sorted(Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
+    }
 end ScaladocService
 
 object ScaladocService:
-  def apply(cacheDir: Path, mavenCentralClient: MavenCentralClient)(using ExecutionContext): ScaladocService =
-    if Files.notExists(cacheDir) then Files.createDirectories(cacheDir)
-    new ScaladocService(cacheDir, mavenCentralClient)
+  private enum Entry(val sizeOnDisk: Long):
+    case Unavailable extends Entry(0L)
+    case Available(size: Long) extends Entry(size)
+
+  /** Rejects reads past `maxBytes`, tracked cumulatively across every entry read through this instance. Only overrides
+    * the bulk-read method, since that's the one `Files.copy` actually calls.
+    */
+  private final class BoundedInputStream(in: InputStream, maxBytes: Long) extends FilterInputStream(in):
+    private var remaining = maxBytes
+
+    override def read(b: Array[Byte], off: Int, len: Int): Int =
+      val n = super.read(b, off, len)
+      if n > 0 then
+        remaining -= n
+        if remaining < 0 then
+          throw new SecurityException(s"Zip content exceeds maximum unpacked size of $maxBytes bytes")
+      n
+  end BoundedInputStream
+
 end ScaladocService

--- a/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
@@ -1,22 +1,18 @@
 package scaladex.server.service
 
-import java.io.ByteArrayInputStream
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.util.zip.ZipInputStream
-
-import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.jdk.CollectionConverters.*
-import scala.util.Using
-import scala.util.control.NonFatal
-
+import com.typesafe.scalalogging.LazyLogging
 import scaladex.core.model.Artifact
 import scaladex.core.service.MavenCentralClient
 
-import com.typesafe.scalalogging.LazyLogging
+import java.io.ByteArrayInputStream
+import java.nio.file.{Files, Path, StandardCopyOption}
+import java.util.zip.ZipInputStream
+import java.util.Comparator
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+import scala.util.control.NonFatal
 
 /** Serves a project's scaladoc by lazily downloading and unpacking its `-javadoc.jar` from Maven Central on first
   * request, then serving the unpacked files from disk on every subsequent request. There is deliberately no eviction:
@@ -30,7 +26,7 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
 
   def localDir(ref: Artifact.Reference): Path =
     cacheDir
-      .resolve(ref.groupId.value.replace('.', '/'))
+      .resolve(ref.groupId.mavenUrl)
       .resolve(ref.artifactId.value)
       .resolve(ref.version.value)
 
@@ -43,7 +39,7 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
     else
       inFlight.getOrElseUpdate(
         ref,
-        download(ref).andThen { case _ => inFlight.remove(ref) }
+        download(ref).andThen(_ => inFlight.remove(ref))
       )
 
   private def isUnpacked(ref: Artifact.Reference): Boolean =
@@ -92,7 +88,9 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
   // no-op once `unpack` has already moved `staging` away; only cleans up on failure
   private def deleteRecursively(dir: Path): Unit =
     if Files.exists(dir) then
-      Using.resource(Files.walk(dir)) { stream => stream.iterator.asScala.toSeq.reverse.foreach(Files.deleteIfExists) }
+      Using.resource(Files.walk(dir)) { stream =>
+        stream.sorted(Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
+      }
 end ScaladocService
 
 object ScaladocService:

--- a/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
@@ -62,8 +62,8 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
             false
     }
 
-  /** Unpacks into a sibling temp directory, then atomically moves it into place - so a concurrent request never sees
-    * a partially-unpacked directory.
+  /** Unpacks into a sibling temp directory, then atomically moves it into place - so a concurrent request never sees a
+    * partially-unpacked directory.
     */
   private def unpack(bytes: Array[Byte], destination: Path): Unit =
     val staging = Files.createTempDirectory(cacheDir, "unpacking-")
@@ -86,14 +86,13 @@ class ScaladocService(cacheDir: Path, mavenCentralClient: MavenCentralClient)(us
       Files.createDirectories(destination.getParent)
       Files.move(staging, destination, StandardCopyOption.ATOMIC_MOVE)
     finally deleteRecursively(staging)
+    end try
   end unpack
 
   // no-op once `unpack` has already moved `staging` away; only cleans up on failure
   private def deleteRecursively(dir: Path): Unit =
     if Files.exists(dir) then
-      Using.resource(Files.walk(dir)) { stream =>
-        stream.iterator.asScala.toSeq.reverse.foreach(Files.deleteIfExists)
-      }
+      Using.resource(Files.walk(dir)) { stream => stream.iterator.asScala.toSeq.reverse.foreach(Files.deleteIfExists) }
 end ScaladocService
 
 object ScaladocService:

--- a/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/ScaladocService.scala
@@ -1,18 +1,22 @@
 package scaladex.server.service
 
-import com.typesafe.scalalogging.LazyLogging
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.Comparator
+import java.util.zip.ZipInputStream
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Using
+import scala.util.control.NonFatal
+
 import scaladex.core.model.Artifact
 import scaladex.core.service.MavenCentralClient
 
-import java.io.ByteArrayInputStream
-import java.nio.file.{Files, Path, StandardCopyOption}
-import java.util.zip.ZipInputStream
-import java.util.Comparator
-import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters.*
-import scala.util.Using
-import scala.util.control.NonFatal
+import com.typesafe.scalalogging.LazyLogging
 
 /** Serves a project's scaladoc by lazily downloading and unpacking its `-javadoc.jar` from Maven Central on first
   * request, then serving the unpacked files from disk on every subsequent request. There is deliberately no eviction:

--- a/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
@@ -51,5 +51,10 @@ trait ControllerBaseSuite extends AsyncFunSpec with Matchers with ScalatestRoute
 
   val dataPaths: DataPaths = DataPaths.from(config.filesystem)
   val localStorage: FilesystemStorage = FilesystemStorage(config.filesystem)
-  val scaladocService: ScaladocService = ScaladocService(config.filesystem.scaladoc, NoopMavenCentralClient)
+  val scaladocService: ScaladocService = ScaladocService(
+    config.filesystem.scaladoc,
+    NoopMavenCentralClient,
+    config.scaladoc.maxCacheBytes,
+    config.scaladoc.maxUnpackedBytes
+  )
 end ControllerBaseSuite

--- a/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ControllerBaseSuite.scala
@@ -2,7 +2,13 @@ package scaladex.server.route
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
+import scala.concurrent.Future
+
+import scaladex.core.model.Artifact
+import scaladex.core.model.Version
+import scaladex.core.service.MavenCentralClient
 import scaladex.core.service.ProjectService
 import scaladex.core.service.SearchEngine
 import scaladex.core.test.InMemoryDatabase
@@ -13,17 +19,26 @@ import scaladex.infra.FilesystemStorage
 import scaladex.server.config.ServerConfig
 import scaladex.server.service.ArtifactService
 import scaladex.server.service.ProjectSettingsService
+import scaladex.server.service.ScaladocService
 import scaladex.server.service.SearchSynchronizer
 
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.funspec.AsyncFunSpec
 import org.scalatest.matchers.should.Matchers
 
+private object NoopMavenCentralClient extends MavenCentralClient:
+  def getAllArtifactIds(groupId: Artifact.GroupId): Future[Seq[Artifact.ArtifactId]] = Future.successful(Seq.empty)
+  def getAllVersions(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Version]] =
+    Future.successful(Seq.empty)
+  def getPomFile(ref: Artifact.Reference): Future[Option[(String, Instant)]] = Future.successful(None)
+  def getJavadocJar(ref: Artifact.Reference): Future[Option[Array[Byte]]] = Future.successful(None)
+
 trait ControllerBaseSuite extends AsyncFunSpec with Matchers with ScalatestRouteTest:
   val index: Path = Files.createTempDirectory("scaladex-index")
+  val scaladoc: Path = Files.createTempDirectory("scaladex-scaladoc")
   val config: ServerConfig =
     val realConfig = ServerConfig.load()
-    realConfig.copy(filesystem = realConfig.filesystem.copy(index = index))
+    realConfig.copy(filesystem = realConfig.filesystem.copy(index = index, scaladoc = scaladoc))
 
   val githubAuth = MockGithubAuth
   val database: InMemoryDatabase = new InMemoryDatabase()
@@ -36,4 +51,5 @@ trait ControllerBaseSuite extends AsyncFunSpec with Matchers with ScalatestRoute
 
   val dataPaths: DataPaths = DataPaths.from(config.filesystem)
   val localStorage: FilesystemStorage = FilesystemStorage(config.filesystem)
+  val scaladocService: ScaladocService = ScaladocService(config.filesystem.scaladoc, NoopMavenCentralClient)
 end ControllerBaseSuite

--- a/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
+++ b/modules/server/src/test/scala/scaladex/server/route/ProjectPagesTests.scala
@@ -31,7 +31,7 @@ class ProjectPagesTests extends ControllerBaseSuite with BeforeAndAfterEach:
     yield ()
 
   val projectPages = new ProjectPages(config.env, projectService, settingsService, database)
-  val artifactPages = new ArtifactPages(config.env, database)
+  val artifactPages = new ArtifactPages(config.env, database, scaladocService)
   val route: Route = projectPages.route(None) ~ artifactPages.route(None)
 
   it("should return NotFound") {

--- a/modules/template/src/main/scala/scaladex/view/html/package.scala
+++ b/modules/template/src/main/scala/scaladex/view/html/package.scala
@@ -8,6 +8,7 @@ import java.util.Locale
 import scaladex.core.model.Artifact
 import scaladex.core.model.BinaryVersion
 import scaladex.core.model.Category
+import scaladex.core.model.LabeledLink
 import scaladex.core.model.Project
 import scaladex.core.model.search.AwesomeParams
 import scaladex.core.model.search.SearchParams
@@ -38,6 +39,10 @@ package object html:
   def ensureUri(in: String): String =
     if in.startsWith("https://") || in.startsWith("http://") then in
     else "http://" + in
+
+  // The "Scaladoc" entry is routed through our own hosting page instead of linking straight out.
+  def docHref(artifact: Artifact, doc: LabeledLink): String =
+    if doc.label == "Scaladoc" then artifact.scaladocPath else doc.link
 
   def paginationUri(params: SearchParams, uri: Uri, you: Boolean)(page: Int): Uri =
     val newUri = uri

--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -101,7 +101,7 @@
       <h4>Documentation</h4>
       <ul>
         @for(doc <- documentationLinks){
-          <li><a href="@doc.link" rel="nofollow">@doc.label</a></li>
+          <li><a href="@docHref(artifact, doc)" rel="nofollow">@doc.label</a></li>
         }
       </ul>
     </div>

--- a/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/project.scala.html
@@ -2,6 +2,7 @@
 @import scaladex.view.Formats
 @import scaladex.view.ProjectTab
 @import scaladex.view.html.main
+@import scaladex.view.html._
 
 
 @(
@@ -28,6 +29,7 @@
         </div>
         <div class="col-md-4">
           <div class="sidebar-project">
+            @documentationBox
             @communityBox
             @project.githubInfo.map(gh => statisticsBox(gh, project.reference, reverseDependencyCount))
             @commitActivityBox
@@ -65,6 +67,21 @@
     <div class="box commit-activities">
       <h4>Commit Activity</h4>
       <div class="commit-activity-container"><canvas id="commit-activity" data-commit-activity-count=@{commitActivities.map(_.total).mkString(",")} data-commit-activity-starting-day=@{startingDay} /></div>
+    </div>
+  }
+}
+
+@defaultArtifact = @{ header.map(_.defaultArtifact) }
+@documentationLinks = @{ defaultArtifact.toSeq.flatMap(project.artifactDocumentation) }
+@documentationBox = {
+  @if(documentationLinks.nonEmpty) {
+    <div class="documentation box">
+      <h4>Documentation</h4>
+      <ul>
+        @for(doc <- documentationLinks){
+          <li><a href="@docHref(defaultArtifact.get, doc)" rel="nofollow">@doc.label</a></li>
+        }
+      </ul>
     </div>
   }
 }

--- a/modules/template/src/main/twirl/scaladex/view/project/scaladoc.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/scaladoc.scala.html
@@ -1,0 +1,62 @@
+@import scaladex.core.model.Artifact
+@import scaladex.core.model.Project
+
+@(project: Project, artifact: Artifact)
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>@artifact.name @artifact.version.value scaladoc</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { height: 100%; margin: 0; }
+    body { display: flex; flex-direction: column; font-family: "Lato", sans-serif; }
+    .scaladoc-bar {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 1rem;
+      background: rgb(0, 43, 55);
+      color: rgb(229, 234, 234);
+      font-size: 0.9rem;
+    }
+    .scaladoc-bar a {
+      color: rgb(229, 234, 234);
+      text-decoration: none;
+    }
+    .scaladoc-bar a:hover { text-decoration: underline; }
+    .scaladoc-bar .back-to-scaladex {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      color: rgb(242, 101, 39);
+      font-weight: 600;
+      flex: none;
+    }
+    .scaladoc-bar .back-to-scaladex img {
+      height: 1.1rem;
+      width: auto;
+    }
+    .scaladoc-bar .coordinates {
+      color: rgb(137, 146, 149);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin-left: auto;
+    }
+    .scaladoc-frame { flex: 1; border: none; width: 100%; }
+  </style>
+</head>
+<body>
+  <div class="scaladoc-bar">
+    <a class="back-to-scaladex" href="/@artifact.projectRef" title="Back to @artifact.projectRef on Scaladex">
+      <img src="/assets/img/scaladex-brand.svg" alt="">
+      &larr; Back to @artifact.projectRef
+    </a>
+    <span class="coordinates">@artifact.name @artifact.version.value &middot; @artifact.groupId</span>
+  </div>
+  <iframe class="scaladoc-frame" src="/artifacts/@artifact.groupId/@artifact.artifactId/@artifact.version/scaladoc-content/" title="@artifact.name scaladoc"></iframe>
+</body>
+</html>

--- a/scripts/PublishMissingArtifacts.scala
+++ b/scripts/PublishMissingArtifacts.scala
@@ -1,7 +1,3 @@
-//> using scala 3.3.8
-//> using dep org.jsoup:jsoup:1.22.2
-//> using dep org.scala-lang.modules:scala-xml_3:2.2.0
-
 /** Download POMs from Maven Central and publish them to Scaladex `/publish`.
   *
   * Same idea as the admin "find-missing-artifacts" task: list Scala artifacts for a group ID (optionally filtered),


### PR DESCRIPTION
Scaladex currently links out to the artifact's own Scaladoc (javadoc.io by default, or a custom pattern from project settings). This PR adds first-class scaladoc hosting: we fetch the artifact's already-published `-javadoc.jar` classifier directly from Maven Central, unpack it once, and serve it ourselves through a thin Scaladex-branded shell.