### PR TITLE
Fix artifact install-snippet tabs to match the site's tab styling

### DIFF
--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -8,6 +8,13 @@
     border-top-left-radius: 0;
     margin-bottom: 10px;
     margin-top: -40px;
+
+    // On the single-artifact page, .content-project is a bare wrapper around
+    // separate boxes rather than the box itself - the first one needs the
+    // same square-top-left treatment so it still lines up with the tab above.
+    > .box:first-child {
+      border-top-left-radius: 0;
+    }
   }
 
   @media screen and (min-width: $screen-md-min) {
@@ -237,23 +244,19 @@
   }
 
   .install {
-    .nav-tabs {
-      margin-bottom: 0;
-      border-bottom: none;
-      > li > a {
-        background: transparent;
-        border: none;
-        color: $gray;
-      }
-      > li.active > a {
-        &,
-        &:hover,
-        &:focus {
-          background: #fff;
-          border: none;
-          color: $brand-primary;
-        }
-      }
+    // Same treatment as .project-nav-bar's tabs: only recolor the text,
+    // everything else (background, spacing) is the site's global .nav-tabs style.
+    .nav-tabs > li > a {
+      color: $gray;
+    }
+
+    .nav-tabs > li.active > a {
+      color: $brand-primary;
+      cursor: pointer;
+    }
+
+    .box.tab-content {
+      border-top-left-radius: 0;
     }
 
     .tab-pane {

--- a/modules/server/src/main/assets/css/partials/_project.scss
+++ b/modules/server/src/main/assets/css/partials/_project.scss
@@ -237,16 +237,25 @@
   }
 
   .install {
-    .nav-tabs>li>a {
-      background: transparent;
+    .nav-tabs {
+      margin-bottom: 0;
+      border-bottom: none;
+      > li > a {
+        background: transparent;
+        border: none;
+        color: $gray;
+      }
+      > li.active > a {
+        &,
+        &:hover,
+        &:focus {
+          background: #fff;
+          border: none;
+          color: $brand-primary;
+        }
+      }
     }
-    .nav-tabs>li.active {
-      background: white;
-    }
-    .nav-tabs.nav-justified>.active>a {
-      border: none;
-    }
-  
+
     .tab-pane {
       overflow: hidden;
       pre {

--- a/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
+++ b/modules/template/src/main/twirl/scaladex/view/project/artifact.scala.html
@@ -183,7 +183,7 @@
 
 @installBox(tabs: Seq[InstallTab]) = {
   <div class="install">
-    <ul class="nav nav-tabs nav-justified">
+    <ul class="nav nav-tabs">
       @for((tab, i) <- tabs.zipWithIndex) {
         <li role="presentation" @if(i == 0 ){ class="active" }>
           <a href="#@tab.ref" aria-controls="@tab.ref" role="tab" data-toggle="tab">@tab.title</a>


### PR DESCRIPTION
## Summary

On an artifact page (e.g. `/cquiroz/scala-java-time/artifacts/scala-java-time/2.5.0-M2`), the install-snippet tabs (sbt/mill/gradle/...) used a different, inconsistent visual style compared to the rest of the site's tabs (Project/Artifacts/Versions in the header nav):

- `nav-justified` stretched the (usually 2-3) tabs to fill the full width, unlike anywhere else tabs are used.
- The active-state background was applied to the `<li>` instead of the `<a>` it contains, fighting the site's global flat `nav-tabs` styling.

This PR drops `nav-justified` and restyles `.install .nav-tabs` to match the site's flat tab look: transparent/neutral text for inactive tabs, brand-colored text for the active one, with a white background on the active tab so it still visually merges into the content panel directly below it (unlike the header nav, these tabs sit right above a bordered `.box`).