### PR TITLE
Add per-item tolerance to Maven and GitHub jobs

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/Resilience.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/Resilience.scala
@@ -2,17 +2,27 @@ package scaladex.infra
 
 import scala.util.control.NonFatal
 
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.pattern.CircuitBreakerOpenException
 
 /** Error-recovery policy for batch jobs backed by HTTP clients. Use with `Future.recover`: an individual item is
   * recovered from any non-fatal failure, while an open circuit breaker (and fatal errors) is left unhandled so it
   * propagates and aborts the whole job.
   */
-object Resilience:
-  def tolerate[B](fallback: Throwable => B): PartialFunction[Throwable, B] =
+object Resilience extends LazyLogging:
+  /** Recover to a fixed `fallback` value, logging the error with a default message. */
+  def tolerateHttpClientErrors[B](fallback: => B): PartialFunction[Throwable, B] =
+    tolerateHttpClientErrorsWith { error =>
+      logger.error("Recovered from an HTTP client error", error)
+      fallback
+    }
+
+  /** Recover using `fallback` to derive the value from the error (and do any logging itself). */
+  def tolerateHttpClientErrorsWith[B](fallback: Throwable => B): PartialFunction[Throwable, B] =
     case error if isTolerable(error) => fallback(error)
 
   private def isTolerable(error: Throwable): Boolean = error match
     case _: CircuitBreakerOpenException => false
     case NonFatal(_) => true
     case _ => false
+end Resilience

--- a/modules/infra/src/main/scala/scaladex/infra/Resilience.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/Resilience.scala
@@ -1,0 +1,18 @@
+package scaladex.infra
+
+import scala.util.control.NonFatal
+
+import org.apache.pekko.pattern.CircuitBreakerOpenException
+
+/** Error-recovery policy for batch jobs backed by HTTP clients. Use with `Future.recover`: an individual item is
+  * recovered from any non-fatal failure, while an open circuit breaker (and fatal errors) is left unhandled so it
+  * propagates and aborts the whole job.
+  */
+object Resilience:
+  def tolerate[B](fallback: Throwable => B): PartialFunction[Throwable, B] =
+    case error if isTolerable(error) => fallback(error)
+
+  private def isTolerable(error: Throwable): Boolean = error match
+    case _: CircuitBreakerOpenException => false
+    case NonFatal(_) => true
+    case _ => false

--- a/modules/infra/src/test/scala/scaladex/infra/ResilienceTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/ResilienceTests.scala
@@ -1,0 +1,23 @@
+package scaladex.infra
+
+import scala.concurrent.duration.*
+
+import org.apache.pekko.pattern.CircuitBreakerOpenException
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ResilienceTests extends AnyFunSpec with Matchers:
+  private val recover = Resilience.tolerate[Int](_ => 0)
+
+  describe("Resilience.tolerate") {
+    it("recovers non-fatal failures to the fallback value") {
+      val error = new RuntimeException("boom")
+      recover.isDefinedAt(error) shouldBe true
+      recover(error) shouldBe 0
+    }
+
+    it("leaves an open circuit breaker unhandled so it propagates and aborts the batch") {
+      recover.isDefinedAt(new CircuitBreakerOpenException(1.second)) shouldBe false
+    }
+  }
+end ResilienceTests

--- a/modules/infra/src/test/scala/scaladex/infra/ResilienceTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/ResilienceTests.scala
@@ -7,9 +7,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class ResilienceTests extends AnyFunSpec with Matchers:
-  private val recover = Resilience.tolerate[Int](_ => 0)
+  private val recover = Resilience.tolerateHttpClientErrors(0)
 
-  describe("Resilience.tolerate") {
+  describe("Resilience.tolerateHttpClientErrors") {
     it("recovers non-fatal failures to the fallback value") {
       val error = new RuntimeException("boom")
       recover.isDefinedAt(error) shouldBe true
@@ -18,6 +18,14 @@ class ResilienceTests extends AnyFunSpec with Matchers:
 
     it("leaves an open circuit breaker unhandled so it propagates and aborts the batch") {
       recover.isDefinedAt(new CircuitBreakerOpenException(1.second)) shouldBe false
+    }
+  }
+
+  describe("Resilience.tolerateHttpClientErrorsWith") {
+    it("derives the fallback value from the error") {
+      val recoverWith = Resilience.tolerateHttpClientErrorsWith[String](_.getMessage)
+      recoverWith(new RuntimeException("boom")) shouldBe "boom"
+      recoverWith.isDefinedAt(new CircuitBreakerOpenException(1.second)) shouldBe false
     }
   }
 end ResilienceTests

--- a/modules/server/src/main/scala/scaladex/server/route/api/PublishApi.scala
+++ b/modules/server/src/main/scala/scaladex/server/route/api/PublishApi.scala
@@ -79,6 +79,7 @@ class PublishApi(githubAuth: GithubAuth, publishProcess: PublishProcess)(using E
                     case PublishResult.Success => (StatusCodes.Created, "pom published successfully")
                     case PublishResult.Forbidden(login, repo) =>
                       (StatusCodes.Forbidden, s"$login cannot publish to $repo")
+                    case PublishResult.Failed(reason) => (StatusCodes.InternalServerError, s"publish failed: $reason")
                   }
                 )
               }

--- a/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
@@ -12,7 +12,7 @@ import scaladex.core.model.Project
 import scaladex.core.service.GithubClient
 import scaladex.core.service.WebDatabase
 import scaladex.core.util.ScalaExtensions.*
-import scaladex.infra.Resilience
+import scaladex.infra.Resilience.tolerateHttpClientErrors
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -29,10 +29,11 @@ class GithubUpdater(database: WebDatabase, github: GithubClient)(using Execution
       logger.info(s"Updating github info of ${projectToUpdate.size} projects")
       projectToUpdate
         .mapSync { ref =>
-          update(ref).recover(Resilience.tolerate { cause =>
-            logger.error(s"Failed to update github info of $ref", cause)
-            GithubStatus.Failed(Instant.now(), errorCode = -1, errorMessage = cause.getMessage)
-          })
+          update(ref).recover(
+            tolerateHttpClientErrors(
+              GithubStatus.Failed(Instant.now(), errorCode = -1, errorMessage = "unexpected error")
+            )
+          )
         }
         .map { statuses =>
           val totalOk = statuses.count(_.isOk)

--- a/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
@@ -12,6 +12,7 @@ import scaladex.core.model.Project
 import scaladex.core.service.GithubClient
 import scaladex.core.service.WebDatabase
 import scaladex.core.util.ScalaExtensions.*
+import scaladex.infra.Resilience
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -26,13 +27,20 @@ class GithubUpdater(database: WebDatabase, github: GithubClient)(using Execution
           .map(_._1)
 
       logger.info(s"Updating github info of ${projectToUpdate.size} projects")
-      projectToUpdate.mapSync(update).map { statuses =>
-        val totalOk = statuses.count(_.isOk)
-        val totalNotFound = statuses.count(_.isNotFound)
-        val totalFailed = statuses.count(_.isFailed)
-        val totalMoved = statuses.count(_.isMoved)
-        s"Updated ${projectToUpdate.size} projects: $totalOk OK, $totalNotFound Not Found, $totalFailed Failed, $totalMoved Moved"
-      }
+      projectToUpdate
+        .mapSync { ref =>
+          update(ref).recover(Resilience.tolerate { cause =>
+            logger.error(s"Failed to update github info of $ref", cause)
+            GithubStatus.Failed(Instant.now(), errorCode = -1, errorMessage = cause.getMessage)
+          })
+        }
+        .map { statuses =>
+          val totalOk = statuses.count(_.isOk)
+          val totalNotFound = statuses.count(_.isNotFound)
+          val totalFailed = statuses.count(_.isFailed)
+          val totalMoved = statuses.count(_.isMoved)
+          s"Updated ${projectToUpdate.size} projects: $totalOk OK, $totalNotFound Not Found, $totalFailed Failed, $totalMoved Moved"
+        }
     }
 
   def update(ref: Project.Reference): Future[GithubStatus] =

--- a/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
@@ -12,7 +12,8 @@ import scaladex.core.service.SchedulerDatabase
 import scaladex.core.util.ScalaExtensions.*
 import scaladex.data.cleanup.NonStandardLib
 import scaladex.infra.DataPaths
-import scaladex.infra.Resilience
+import scaladex.infra.Resilience.tolerateHttpClientErrors
+import scaladex.infra.Resilience.tolerateHttpClientErrorsWith
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
@@ -43,10 +44,7 @@ class MavenCentralService(
           knownRefs <- loadKnownRefs(groupId)
           inserted <- findAndIndexMissingArtifacts(groupId, artifactId, knownRefs)
         yield inserted
-        indexed.recover(Resilience.tolerate { cause =>
-          logger.error(s"Failed to index ${lib.groupId}:${lib.artifactId}", cause)
-          0
-        })
+        indexed.recover(tolerateHttpClientErrors(0))
       }
     yield s"Inserted ${result.sum} missing poms"
   end findNonStandard
@@ -67,10 +65,7 @@ class MavenCentralService(
         mavenCentralClient
           .getPomFile(ref)
           .map(_.map(ref -> _))
-          .recover(Resilience.tolerate { cause =>
-            logger.error(s"Failed to fetch pom of $ref", cause)
-            None
-          })
+          .recover(tolerateHttpClientErrors(None))
       )
       publishResult <- missingPomFiles.flatten.mapSync {
         case (mavenRef, (pomFile, creationDate)) =>
@@ -78,10 +73,7 @@ class MavenCentralService(
             _ <- delay(publishDelay)
             result <- publishProcess.publishPom(mavenRef.toString(), pomFile, creationDate, None)
           yield result
-          published.recover(Resilience.tolerate { cause =>
-            logger.error(s"Failed to publish pom of $mavenRef", cause)
-            PublishResult.Failed(cause.getMessage)
-          })
+          published.recover(tolerateHttpClientErrors(PublishResult.Failed("unexpected error")))
       }
     yield publishResult.count {
       case PublishResult.Success => true
@@ -94,12 +86,7 @@ class MavenCentralService(
         batch <- database.getGroupIds(limit = groupIdPageSize, offset = page * groupIdPageSize)
         _ = logger.info(s"Processing group ID page $page (${batch.size} groups)")
         inserted <- batch
-          .mapSync(g =>
-            findAndIndexMissingArtifacts(g, None).recover(Resilience.tolerate { cause =>
-              logger.error(s"Failed to index group ${g.value}", cause)
-              0
-            })
-          )
+          .mapSync(g => findAndIndexMissingArtifacts(g, None).recover(tolerateHttpClientErrors(0)))
           .map(_.sum)
         total = totalInserted + inserted
         result <-
@@ -131,12 +118,7 @@ class MavenCentralService(
         )
       result <- processPages(scalaArtifactIds, artifactIdPageSize) { batch =>
         batch
-          .mapSync(id =>
-            findAndIndexMissingArtifacts(groupId, id, knownRefs).recover(Resilience.tolerate { cause =>
-              logger.error(s"Failed to index ${groupId.value}:${id.value}", cause)
-              0
-            })
-          )
+          .mapSync(id => findAndIndexMissingArtifacts(groupId, id, knownRefs).recover(tolerateHttpClientErrors(0)))
           .map(_.sum)
       }
     yield result
@@ -186,12 +168,7 @@ class MavenCentralService(
     for
       projectStatuses <- database.getAllProjectsStatuses()
       refs = projectStatuses.collect { case (ref, status) if status.isOk || status.isUnknown || status.isFailed => ref }
-      counts <- refs.mapSync(ref =>
-        republishArtifacts(ref).recover(Resilience.tolerate { cause =>
-          logger.error(s"Failed to re-publish artifacts of $ref", cause)
-          (0, 0)
-        })
-      )
+      counts <- refs.mapSync(republishArtifacts)
     yield
       val successes = counts.map(_._1).sum
       val failures = counts.map(_._2).sum
@@ -201,10 +178,8 @@ class MavenCentralService(
     for
       refs <- database.getProjectArtifactRefs(projectRef, stableOnly = false)
       publishResult <- refs.mapSync(ref =>
-        republishArtifact(projectRef, ref).recover(Resilience.tolerate { cause =>
-          logger.error(s"Failed to re-publish $ref", cause)
-          PublishResult.Failed(cause.getMessage)
-        })
+        republishArtifact(projectRef, ref)
+          .recover(tolerateHttpClientErrorsWith(t => PublishResult.Failed(t.getMessage)))
       )
     yield
       val successes = publishResult.count(_ == PublishResult.Success)

--- a/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
@@ -12,6 +12,7 @@ import scaladex.core.service.SchedulerDatabase
 import scaladex.core.util.ScalaExtensions.*
 import scaladex.data.cleanup.NonStandardLib
 import scaladex.infra.DataPaths
+import scaladex.infra.Resilience
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
@@ -38,10 +39,14 @@ class MavenCentralService(
         val groupId = Artifact.GroupId(lib.groupId)
         // get should not throw: it is a fixed set of artifactIds
         val artifactId = Artifact.ArtifactId(lib.artifactId)
-        for
+        val indexed = for
           knownRefs <- loadKnownRefs(groupId)
           inserted <- findAndIndexMissingArtifacts(groupId, artifactId, knownRefs)
         yield inserted
+        indexed.recover(Resilience.tolerate { cause =>
+          logger.error(s"Failed to index ${lib.groupId}:${lib.artifactId}", cause)
+          0
+        })
       }
     yield s"Inserted ${result.sum} missing poms"
   end findNonStandard
@@ -58,13 +63,25 @@ class MavenCentralService(
         if missingVersions.nonEmpty then
           logger.info(s"${missingVersions.size} artifacts are missing for ${groupId.value}:${artifactId.value}")
         else if versions.isEmpty then logger.warn(s"No versions listed for ${groupId.value}:${artifactId.value}")
-      missingPomFiles <- missingVersions.mapSync(ref => mavenCentralClient.getPomFile(ref).map(_.map(ref -> _)))
+      missingPomFiles <- missingVersions.mapSync(ref =>
+        mavenCentralClient
+          .getPomFile(ref)
+          .map(_.map(ref -> _))
+          .recover(Resilience.tolerate { cause =>
+            logger.error(s"Failed to fetch pom of $ref", cause)
+            None
+          })
+      )
       publishResult <- missingPomFiles.flatten.mapSync {
         case (mavenRef, (pomFile, creationDate)) =>
-          for
+          val published = for
             _ <- delay(publishDelay)
             result <- publishProcess.publishPom(mavenRef.toString(), pomFile, creationDate, None)
           yield result
+          published.recover(Resilience.tolerate { cause =>
+            logger.error(s"Failed to publish pom of $mavenRef", cause)
+            PublishResult.Failed(cause.getMessage)
+          })
       }
     yield publishResult.count {
       case PublishResult.Success => true
@@ -76,7 +93,14 @@ class MavenCentralService(
       for
         batch <- database.getGroupIds(limit = groupIdPageSize, offset = page * groupIdPageSize)
         _ = logger.info(s"Processing group ID page $page (${batch.size} groups)")
-        inserted <- batch.mapSync(g => findAndIndexMissingArtifacts(g, None)).map(_.sum)
+        inserted <- batch
+          .mapSync(g =>
+            findAndIndexMissingArtifacts(g, None).recover(Resilience.tolerate { cause =>
+              logger.error(s"Failed to index group ${g.value}", cause)
+              0
+            })
+          )
+          .map(_.sum)
         total = totalInserted + inserted
         result <-
           if batch.size == groupIdPageSize then delay(pageDelay).flatMap(_ => loop(page + 1, total))
@@ -106,7 +130,14 @@ class MavenCentralService(
           s"All artifact IDs for ${groupId.value} were filtered out: ${artifactIds.map(_.value).mkString(", ")}"
         )
       result <- processPages(scalaArtifactIds, artifactIdPageSize) { batch =>
-        batch.mapSync(id => findAndIndexMissingArtifacts(groupId, id, knownRefs)).map(_.sum)
+        batch
+          .mapSync(id =>
+            findAndIndexMissingArtifacts(groupId, id, knownRefs).recover(Resilience.tolerate { cause =>
+              logger.error(s"Failed to index ${groupId.value}:${id.value}", cause)
+              0
+            })
+          )
+          .map(_.sum)
       }
     yield result
 
@@ -155,7 +186,12 @@ class MavenCentralService(
     for
       projectStatuses <- database.getAllProjectsStatuses()
       refs = projectStatuses.collect { case (ref, status) if status.isOk || status.isUnknown || status.isFailed => ref }
-      counts <- refs.mapSync(republishArtifacts)
+      counts <- refs.mapSync(ref =>
+        republishArtifacts(ref).recover(Resilience.tolerate { cause =>
+          logger.error(s"Failed to re-publish artifacts of $ref", cause)
+          (0, 0)
+        })
+      )
     yield
       val successes = counts.map(_._1).sum
       val failures = counts.map(_._2).sum
@@ -164,7 +200,12 @@ class MavenCentralService(
   private def republishArtifacts(projectRef: Project.Reference): Future[(Int, Int)] =
     for
       refs <- database.getProjectArtifactRefs(projectRef, stableOnly = false)
-      publishResult <- refs.mapSync(republishArtifact(projectRef, _))
+      publishResult <- refs.mapSync(ref =>
+        republishArtifact(projectRef, ref).recover(Resilience.tolerate { cause =>
+          logger.error(s"Failed to re-publish $ref", cause)
+          PublishResult.Failed(cause.getMessage)
+        })
+      )
     yield
       val successes = publishResult.count(_ == PublishResult.Success)
       val failures = publishResult.size - successes

--- a/modules/server/src/main/scala/scaladex/server/service/PublishProcess.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/PublishProcess.scala
@@ -30,6 +30,7 @@ object PublishResult:
   object NoGithubRepo extends PublishResult
   object Success extends PublishResult
   case class Forbidden(login: String, repo: Project.Reference) extends PublishResult
+  case class Failed(reason: String) extends PublishResult
 
 class PublishProcess(
     filesystem: Storage,


### PR DESCRIPTION
Wrap each item's future in the Maven and GitHub jobs with `recover(Resilience.tolerateHttpClientErrors(...))`: a non-fatal per-item failure is recovered to a fallback value so the batch continues, while an open circuit breaker (and fatal errors) propagates through `mapSync` and aborts the whole job. `tolerateHttpClientErrorsWith` is the variant that derives the fallback from the error.

Adds `PublishResult.Failed` to represent a tolerated publish failure in job summaries.

Note: HTTP clients still swallow the circuit-breaker exception via `fallbackTo`/`recoverWith`, so the abort-on-circuit-breaker branch is latent until a follow-up PR stops masking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)