### PR TITLE
Discard entity bytes on non-OK POM response

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -92,6 +92,7 @@ class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default
           .map(page => lastModified.map(page -> _))
       case _ =>
         logger.warn(s"Cannot get $uri: ${response.status}")
+        response.discardEntityBytes()
         Future.successful(None)
 
   private def listDirectories(uri: String, response: HttpResponse) =


### PR DESCRIPTION
`getPomFileWithLastModifiedTime`'s fallback branch logged and returned without draining the response entity, so Pekko's pooled connection was held until the 1s timeout:

```
WARN  s.infra.MavenCentralClientImpl - Cannot get https://repo1.maven.org/maven2/.../elements_2.13-0.4.0-RC1.pom: 404 Not Found
WARN  o.a.p.http.impl.engine.client.PoolId - [0 (WaitingForResponseEntitySubscription)]Response entity was not subscribed after 1 second. ... GET /maven2/.../elements_2.13-0.4.0-RC1.pom Empty -> 404 Not Found Chunked
```

Fix: call `response.discardEntityBytes()` in that branch, matching what `listDirectories` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)