### PR TITLE
Strip distributionManagement when reading POMs

### DIFF
--- a/modules/data/src/main/scala/scaladex/data/maven/PomsReader.scala
+++ b/modules/data/src/main/scala/scaladex/data/maven/PomsReader.scala
@@ -82,7 +82,6 @@ class PomsReader(resolver: PomResolver) extends LazyLogging:
       .setTwoPhaseBuilding(true)
 
     val partial = builder.build(request)
-    // Drop deploy-time metadata Scaladex ignores but Maven may reject (e.g. distributionManagement.status).
     partial.getEffectiveModel.setDistributionManagement(null)
 
     builder.build(request, partial).getEffectiveModel

--- a/modules/data/src/main/scala/scaladex/data/maven/PomsReader.scala
+++ b/modules/data/src/main/scala/scaladex/data/maven/PomsReader.scala
@@ -79,7 +79,12 @@ class PomsReader(resolver: PomResolver) extends LazyLogging:
       .setModelResolver(modelResolver)
       .setSystemProperties(jdk)
       .setPomFile(path.toFile)
+      .setTwoPhaseBuilding(true)
 
-    builder.build(request).getEffectiveModel
+    val partial = builder.build(request)
+    // Drop deploy-time metadata Scaladex ignores but Maven may reject (e.g. distributionManagement.status).
+    partial.getEffectiveModel.setDistributionManagement(null)
+
+    builder.build(request, partial).getEffectiveModel
   }.map(pom => PomConvert(pom))
 end PomsReader

--- a/modules/data/src/test/scala/scaladex/data/maven/PomsReaderTests.scala
+++ b/modules/data/src/test/scala/scaladex/data/maven/PomsReaderTests.scala
@@ -1,0 +1,89 @@
+package scaladex.data
+package maven
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.concurrent.Future
+
+import scaladex.core.service.PomResolver
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PomsReaderTests extends AnyFunSpec with Matchers:
+  // No parent resolution is needed for these self-contained POMs.
+  private val noopResolver = new PomResolver:
+    def resolve(groupId: String, artifactId: String, version: String): Future[Option[Path]] =
+      Future.successful(None)
+
+  private val reader = new PomsReader(noopResolver)
+
+  private def readPom(content: String): scala.util.Try[ArtifactModel] =
+    val file = Files.createTempFile("scaladex-pom", ".pom")
+    Files.writeString(file, content)
+    try reader.loadOne(file)
+    finally Files.deleteIfExists(file)
+
+  describe("PomsReader") {
+    it("reads a POM that carries a forbidden distributionManagement.status") {
+      val pom =
+        """<?xml version="1.0" encoding="UTF-8"?>
+          |<project xmlns="http://maven.apache.org/POM/4.0.0">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>org.scala-lang</groupId>
+          |  <artifactId>scala-compiler</artifactId>
+          |  <version>2.3.1</version>
+          |  <distributionManagement>
+          |    <status>deployed</status>
+          |  </distributionManagement>
+          |</project>
+          |""".stripMargin
+
+      val result = readPom(pom)
+      result.isSuccess shouldBe true
+      val model = result.get
+      model.groupId shouldBe "org.scala-lang"
+      model.artifactId shouldBe "scala-compiler"
+      model.version shouldBe "2.3.1"
+    }
+
+    it("reads a POM whose distributionManagement uses the reserved 'local' repository id") {
+      val pom =
+        """<?xml version="1.0" encoding="UTF-8"?>
+          |<project xmlns="http://maven.apache.org/POM/4.0.0">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>lib</artifactId>
+          |  <version>1.0.0</version>
+          |  <distributionManagement>
+          |    <repository>
+          |      <id>local</id>
+          |      <url>file:///tmp/repo</url>
+          |    </repository>
+          |  </distributionManagement>
+          |</project>
+          |""".stripMargin
+
+      val result = readPom(pom)
+      result.isSuccess shouldBe true
+      result.get.artifactId shouldBe "lib"
+    }
+
+    it("reads a regular POM without distributionManagement") {
+      val pom =
+        """<?xml version="1.0" encoding="UTF-8"?>
+          |<project xmlns="http://maven.apache.org/POM/4.0.0">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>lib</artifactId>
+          |  <version>1.0.0</version>
+          |</project>
+          |""".stripMargin
+
+      val result = readPom(pom)
+      result.isSuccess shouldBe true
+      result.get.artifactId shouldBe "lib"
+    }
+  }
+end PomsReaderTests


### PR DESCRIPTION
## Problem

Publishing certain legacy artifacts fails in the dev environment. `PomsReader.loadOne` builds the Maven **effective** model with strict validation, which rejects any POM carrying `distributionManagement.status` — a reserved, deploy-time field written by old publishing tooling (e.g. old `org.scala-lang` releases). The artifact is then dropped as an invalid POM.

Observed in dev logs:

```
2026-05-07 16:28:33,099 ERROR s.server.service.PublishProcess:56  - Invalid POM org.scala-lang:scala-compiler:2.3.1
org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for org.scala-lang:scala-compiler:2.3.1
[ERROR] 'distributionManagement.status' must not be specified. @

        at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException(DefaultModelProblemCollector.java:176)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:552)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:421)
        at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:250)
        at scaladex.data.maven.PomsReader.loadOne$$anonfun$1(PomsReader.scala:83)
        at scala.util.Try$.apply(Try.scala:217)
        at scaladex.data.maven.PomsReader.loadOne(PomsReader.scala:84)
        at scaladex.server.service.PublishProcess.loadPom(PublishProcess.scala:121)
        at scaladex.server.service.PublishProcess.publishPom$$anonfun$1(PublishProcess.scala:53)
        ...
```

## Fix

Scaladex never reads `distributionManagement` (it's not part of `ArtifactModel` and `PomConvert` ignores it). So the model is now built in **two phases**, dropping the whole `distributionManagement` element between them:

```scala
val partial = builder.build(request)
partial.getEffectiveModel.setDistributionManagement(null)
builder.build(request, partial).getEffectiveModel
```

This is lossless (nothing under `distributionManagement` reaches the artifact model) and also neutralizes the reserved `local` repository-id error that lives in the same subtree.

## Tests

Added `PomsReaderTests` covering:
- a POM with the forbidden `distributionManagement.status`
- a POM whose `distributionManagement` uses the reserved `local` repository id
- a plain POM without `distributionManagement` (happy-path guard)

Verified the `status` test fails on the pre-fix single-phase build and passes with the fix. Full `data` and `coreJVM` suites are green; the container-based `infra`/`server` suites were not run locally (Docker unavailable) and rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)