### PR TITLE
Stop hiding non-business errors in the Maven Central client

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralClient.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/service/MavenCentralClient.scala
@@ -10,4 +10,4 @@ import scaladex.core.model.Version
 trait MavenCentralClient:
   def getAllArtifactIds(groupId: Artifact.GroupId): Future[Seq[Artifact.ArtifactId]]
   def getAllVersions(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Version]]
-  def getPomFile(mavenReference: Artifact.Reference): Future[Option[(String, Instant)]]
+  def getPomFile(mavenReference: Artifact.Reference): Future[(String, Instant)]

--- a/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/MavenCentralClientImpl.scala
@@ -8,7 +8,6 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Try
-import scala.util.control.NonFatal
 
 import scaladex.core.model.Artifact
 import scaladex.core.model.SbtPlugin
@@ -59,57 +58,50 @@ class MavenCentralClientImpl(config: HttpClientConfig = HttpClientConfig.default
   def getAllVersions(groupId: Artifact.GroupId, artifactId: Artifact.ArtifactId): Future[Seq[Version]] =
     val uri = s"$baseUri/${groupId.mavenUrl}/${artifactId.value}/"
     val request = HttpRequest(uri = uri)
-    val future = for
+    for
       response <- queueRequestWithRetry(request)
       directories <- listDirectories(uri, response)
     yield directories.map(Version.apply)
-    future.recoverWith {
-      case NonFatal(exception) =>
-        logger.warn(s"failed to retrieve versions from $uri because ${exception.getMessage}")
-        Future.successful(Nil)
-    }
   end getAllVersions
 
-  override def getPomFile(ref: Artifact.Reference): Future[Option[(String, Instant)]] =
+  override def getPomFile(ref: Artifact.Reference): Future[(String, Instant)] =
     val pomUri = getPomUri(ref)
-    val future = for
+    for
       response <- queueRequestWithRetry(HttpRequest(uri = pomUri))
       res <- getPomFileWithLastModifiedTime(response, pomUri)
     yield res
-    future.recoverWith {
-      case NonFatal(exception) =>
-        logger.warn(s"Could not get pom file of $ref because of $exception")
-        Future.successful(None)
-    }
   end getPomFile
 
-  private def getPomFileWithLastModifiedTime(response: HttpResponse, uri: String): Future[Option[(String, Instant)]] =
+  private def getPomFileWithLastModifiedTime(response: HttpResponse, uri: String): Future[(String, Instant)] =
     response match
       case _ @HttpResponse(StatusCodes.OK, headers: Seq[model.HttpHeader], entity, _) =>
-        val lastModified = headers.find(_.is("last-modified")).map(header => parseDate(header.value))
-        Unmarshaller
-          .stringUnmarshaller(entity)
-          .map(page => lastModified.map(page -> _))
+        headers.find(_.is("last-modified")).map(header => parseDate(header.value)) match
+          case Some(lastModified) =>
+            Unmarshaller.stringUnmarshaller(entity).map(page => page -> lastModified)
+          case None =>
+            entity.discardBytes()
+            Future.failed(new Exception(s"Missing last-modified header for $uri"))
       case _ =>
-        logger.warn(s"Cannot get $uri: ${response.status}")
         response.discardEntityBytes()
-        Future.successful(None)
+        Future.failed(new Exception(s"Cannot get $uri: ${response.status}"))
 
-  private def listDirectories(uri: String, response: HttpResponse) =
-    if response.status != StatusCodes.OK
-    then
-      logger.warn(s"Cannot list $uri: ${response.status}")
-      response.discardEntityBytes()
-      Future.successful(Seq.empty)
-    else
-      Unmarshaller
-        .stringUnmarshaller(response.entity)
-        .map(page =>
-          val directories = JsoupUtils.listDirectories(uri, page)
-          if directories.isEmpty then
-            logger.warn(s"No directories parsed from $uri (HTTP ${response.status}): ${preview(page)}")
-          directories
-        )
+  private def listDirectories(uri: String, response: HttpResponse): Future[Seq[String]] =
+    response.status match
+      case StatusCodes.OK =>
+        Unmarshaller
+          .stringUnmarshaller(response.entity)
+          .map(page =>
+            val directories = JsoupUtils.listDirectories(uri, page)
+            if directories.isEmpty then
+              logger.warn(s"No directories parsed from $uri (HTTP ${response.status}): ${preview(page)}")
+            directories
+          )
+      case StatusCodes.NotFound =>
+        response.discardEntityBytes()
+        Future.successful(Seq.empty)
+      case status =>
+        response.discardEntityBytes()
+        Future.failed(new Exception(s"Cannot list $uri: $status"))
   end listDirectories
 
   private def preview(page: String): String =

--- a/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
+++ b/modules/infra/src/test/scala/scaladex/infra/MavenCentralClientImplTests.scala
@@ -43,22 +43,22 @@ class MavenCentralClientImplTests extends AsyncFunSpec with Matchers:
 
   it(s"retrieve pomfile for maven reference of sbt plugin") {
     for res <- client.getPomFile(Artifact.Reference.from("org.jetbrains.scala", "sbt-idea-plugin_2.12_1.0", "5.0.6"))
-    yield res.get._1.startsWith("<?xml") shouldBe true
+    yield res._1.startsWith("<?xml") shouldBe true
   }
 
   it(s"retrieve pomfile for maven reference of jvm") {
     for res <- client.getPomFile(Artifact.Reference.from("ch.epfl.scala", "scalafix-core_2.13", "0.9.23"))
-    yield res.get._1.startsWith("<?xml") shouldBe true
+    yield res._1.startsWith("<?xml") shouldBe true
   }
 
   it(s"retrieve pomfile for maven reference of ScalaJs") {
     for res <- client.getPomFile(Artifact.Reference.from("ch.epfl.scala", "bloop-config_sjs1_2.13", "1.4.11"))
-    yield res.get._1.startsWith("<?xml") shouldBe true
+    yield res._1.startsWith("<?xml") shouldBe true
   }
 
   it(s"retrieve pomfile for maven reference of Scala Native") {
     for res <- client.getPomFile(Artifact.Reference.from("ch.epfl.scala", "bloop-native-bridge-0-4_2.12", "1.3.4"))
-    yield res.get._1.startsWith("<?xml") shouldBe true
+    yield res._1.startsWith("<?xml") shouldBe true
   }
 
   it(s"parse date time") {

--- a/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
@@ -188,7 +188,8 @@ class MavenCentralService(
       (successes, failures)
 
   private def republishArtifact(projectRef: Project.Reference, ref: Artifact.Reference): Future[PublishResult] =
-    mavenCentralClient.getPomFile(ref).flatMap { case (pomFile, creationDate) =>
-      publishProcess.republishPom(projectRef, ref, pomFile, creationDate)
+    mavenCentralClient.getPomFile(ref).flatMap {
+      case (pomFile, creationDate) =>
+        publishProcess.republishPom(projectRef, ref, pomFile, creationDate)
     }
 end MavenCentralService

--- a/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/MavenCentralService.scala
@@ -64,7 +64,7 @@ class MavenCentralService(
       missingPomFiles <- missingVersions.mapSync(ref =>
         mavenCentralClient
           .getPomFile(ref)
-          .map(_.map(ref -> _))
+          .map(res => Option(ref -> res))
           .recover(tolerateHttpClientErrors(None))
       )
       publishResult <- missingPomFiles.flatten.mapSync {
@@ -188,8 +188,7 @@ class MavenCentralService(
       (successes, failures)
 
   private def republishArtifact(projectRef: Project.Reference, ref: Artifact.Reference): Future[PublishResult] =
-    mavenCentralClient.getPomFile(ref).flatMap {
-      case Some((pomFile, creationDate)) => publishProcess.republishPom(projectRef, ref, pomFile, creationDate)
-      case _ => Future.successful(PublishResult.InvalidPom)
+    mavenCentralClient.getPomFile(ref).flatMap { case (pomFile, creationDate) =>
+      publishProcess.republishPom(projectRef, ref, pomFile, creationDate)
     }
 end MavenCentralService


### PR DESCRIPTION
Per-item tolerance is already in place at the job level (`Resilience.tolerateHttpClientErrors`), so the Maven Central client shouldn't swallow errors anymore.

- Non-200 responses other than 404, and missing `last-modified` headers, now fail the `Future` instead of being disguised as empty results — so real server errors reach the job-level tolerance (and circuit breaker) rather than looking like "no versions" / "no pom".
- 404 stays modeled as an empty directory listing (legitimate business "not found").
- `getPomFile` drops its now-meaningless `Option`; `republishArtifact` no longer mislabels a fetch failure as `InvalidPom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)