### PR TITLE
Revert jQuery 4.0.0 -> 3.7.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val server = project
       "org.webjars.npm" % "date-fns" % "4.4.0",
       "org.webjars.npm" % "chartjs-adapter-date-fns" % "3.0.0",
       "org.webjars" % "font-awesome" % "7.3.0",
-      "org.webjars" % "jquery" % "4.0.0",
+      "org.webjars" % "jquery" % "3.7.1",
       "org.webjars.bower" % "select2" % "4.0.13",
       "org.webjars" % "swagger-ui" % "5.20.8"
     ),


### PR DESCRIPTION
Bootstrap 3 requires jQuery >= 1.9.1  and < 4, so the app crashes

<img width="1060" height="51" alt="image" src="https://github.com/user-attachments/assets/d8ae0752-a9d2-4e3c-81c0-dabbf95b74c4" />
