### PR TITLE
Stop hiding non-business errors in the GitHub client

### DIFF
--- a/modules/core/shared/src/main/scala/scaladex/core/model/GithubResponse.scala
+++ b/modules/core/shared/src/main/scala/scaladex/core/model/GithubResponse.scala
@@ -17,4 +17,5 @@ end GithubResponse
 object GithubResponse:
   case class Ok[+T](res: T) extends GithubResponse[T]
   case class MovedPermanently[+T](res: T) extends GithubResponse[T]
+  case class NotFound(code: Int) extends GithubResponse[Nothing]
   case class Failed(code: Int, errorMessage: String) extends GithubResponse[Nothing]

--- a/modules/infra-it/src/test/scala/scaladex/infra/GithubClientImplTests.scala
+++ b/modules/infra-it/src/test/scala/scaladex/infra/GithubClientImplTests.scala
@@ -28,6 +28,7 @@ class GithubClientImplTests extends AsyncFunSpec with Matchers:
     else
       Await.result(client.getUserState(), 30.seconds) match
         case Failed(code, errorMessage) => throw new Exception(s"$code $errorMessage")
+        case NotFound(code) => throw new Exception(s"not found: $code")
         case MovedPermanently(userState) => Some(userState)
         case Ok(userState) => Some(userState)
 
@@ -52,10 +53,9 @@ class GithubClientImplTests extends AsyncFunSpec with Matchers:
   it("getCommunity") {
     for communityProfile <- client.getCommunityProfile(Cats.reference)
     yield
-      communityProfile shouldBe defined
-      communityProfile.flatMap(_.licenceFile) shouldBe defined
-      communityProfile.flatMap(_.codeOfConductFile) shouldBe defined
-      communityProfile.flatMap(_.contributingFile) shouldBe defined
+      communityProfile.licenceFile shouldBe defined
+      communityProfile.codeOfConductFile shouldBe defined
+      communityProfile.contributingFile shouldBe defined
   }
   it("getContributors") {
     for contributors <- client.getContributors(Cats.reference)

--- a/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/GithubClientImpl.scala
@@ -32,6 +32,7 @@ import org.apache.pekko.http.scaladsl.model.HttpMethods
 import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.model.ResponseEntity
+import org.apache.pekko.http.scaladsl.model.StatusCode
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.http.scaladsl.model.headers.Authorization
@@ -76,6 +77,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
   override def getProjectInfo(ref: Project.Reference): Future[GithubResponse[(Project.Reference, GithubInfo)]] =
     getRepository(ref).flatMap {
       case GithubResponse.Failed(code, reason) => Future.successful(GithubResponse.Failed(code, reason))
+      case GithubResponse.NotFound(code) => Future.successful(GithubResponse.NotFound(code))
       case GithubResponse.Ok(repo) =>
         getRepoInfo(repo).map(info => GithubResponse.Ok(repo.ref -> info))
       case GithubResponse.MovedPermanently(repo) =>
@@ -103,8 +105,8 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
       contributors = contributors.map(_.toGithubContributor),
       commits = Some(contributors.foldLeft(0)(_ + _.contributions)),
       topics = repo.topics.toSet,
-      contributingGuide = communityProfile.flatMap(_.contributingFile).map(Url.apply),
-      codeOfConduct = communityProfile.flatMap(_.codeOfConductFile).map(Url.apply),
+      contributingGuide = communityProfile.contributingFile.map(Url.apply),
+      codeOfConduct = communityProfile.codeOfConductFile.map(Url.apply),
       openIssues = openIssues.map(_.toGithubIssue).toList,
       scalaPercentage = Option(scalaPercentage),
       license = repo.licenseName.flatMap(License.get),
@@ -116,21 +118,16 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
       .addCredentials(credentials)
       .addHeader(acceptHtmlVersion)
 
-    getRaw(request)
-      .flatMap {
-        case (_, entity) =>
-          entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String).map(Option.apply)
-      }
-      .fallbackTo(Future.successful(None))
+    getOrDefault(request, None) { (_, entity) =>
+      entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String).map(Option.apply)
+    }
   end getReadme
 
-  def getCommunityProfile(ref: Project.Reference): Future[Option[GithubModel.CommunityProfile]] =
+  def getCommunityProfile(ref: Project.Reference): Future[GithubModel.CommunityProfile] =
     val request = HttpRequest(uri = s"${repoUrl(ref)}/community/profile")
       .addCredentials(credentials)
       .addHeader(RawHeader("Accept", "application/vnd.github.black-panther-preview+json"))
     get[GithubModel.CommunityProfile](request)
-      .map(Some.apply)
-      .fallbackTo(Future.successful(None))
 
   def getContributors(ref: Project.Reference): Future[List[GithubModel.Contributor]] =
     def request(page: Int) =
@@ -141,21 +138,18 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
     def getContributionPage(page: Int): Future[List[GithubModel.Contributor]] =
       get[List[GithubModel.Contributor]](request(page))
 
-    getRaw(request(page = 1))
-      .flatMap {
-        case (headers, entity) =>
-          val lastPage = headers.find(_.is("link")).map(_.value()).flatMap(extractLastPage)
-          val contributors = Unmarshal(entity).to[List[GithubModel.Contributor]]
-          lastPage match
-            case Some(lastPage) if lastPage > 1 =>
-              for
-                page1 <- contributors
-                nextPages <- (2 to lastPage).mapSync(getContributionPage).map(_.flatten)
-              yield page1 ++ nextPages
+    getOrDefault(request(page = 1), List.empty) { (headers, entity) =>
+      val lastPage = headers.find(_.is("link")).map(_.value()).flatMap(extractLastPage)
+      val contributors = Unmarshal(entity).to[List[GithubModel.Contributor]]
+      lastPage match
+        case Some(lastPage) if lastPage > 1 =>
+          for
+            page1 <- contributors
+            nextPages <- (2 to lastPage).mapSync(getContributionPage).map(_.flatten)
+          yield page1 ++ nextPages
 
-            case _ => contributors
-      }
-      .fallbackTo(Future.successful(List.empty))
+        case _ => contributors
+    }
   end getContributors
 
   def getRepository(ref: Project.Reference): Future[GithubResponse[GithubModel.Repository]] =
@@ -165,8 +159,10 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
         Unmarshal(entity).to[GithubModel.Repository].map(GithubResponse.Ok(_))
       case GithubResponse.MovedPermanently((_, entity)) =>
         Unmarshal(entity).to[GithubModel.Repository].map(GithubResponse.MovedPermanently(_))
+      case GithubResponse.NotFound(code) => Future.successful(GithubResponse.NotFound(code))
       case GithubResponse.Failed(code, reason) => Future.successful(GithubResponse.Failed(code, reason))
     }
+  end getRepository
 
   def getOpenIssues(ref: Project.Reference): Future[Seq[GithubModel.OpenIssue]] =
     def request(page: Int) =
@@ -177,21 +173,18 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
     def getOpenIssuePage(page: Int): Future[Seq[GithubModel.OpenIssue]] =
       get[Seq[Option[GithubModel.OpenIssue]]](request(page)).map(_.flatten)
 
-    getRaw(request(page = 1))
-      .flatMap {
-        case (headers, entity) =>
-          val lastPage = headers.find(_.is("link")).map(_.value()).flatMap(extractLastPage)
-          val issues = Unmarshal(entity).to[Seq[Option[GithubModel.OpenIssue]]]
-          lastPage match
-            case Some(lastPage) if lastPage > 1 =>
-              for
-                page1 <- issues
-                nextPages <- (2 to lastPage).mapSync(getOpenIssuePage).map(_.flatten)
-              yield page1.flatten ++ nextPages
+    getOrDefault(request(page = 1), Seq.empty) { (headers, entity) =>
+      val lastPage = headers.find(_.is("link")).map(_.value()).flatMap(extractLastPage)
+      val issues = Unmarshal(entity).to[Seq[Option[GithubModel.OpenIssue]]]
+      lastPage match
+        case Some(lastPage) if lastPage > 1 =>
+          for
+            page1 <- issues
+            nextPages <- (2 to lastPage).mapSync(getOpenIssuePage).map(_.flatten)
+          yield page1.flatten ++ nextPages
 
-            case _ => issues.map(_.flatten)
-      }
-      .fallbackTo(Future.successful(Seq.empty))
+        case _ => issues.map(_.flatten)
+    }
   end getOpenIssues
 
   def getPercentageOfLanguage(ref: Project.Reference, language: String): Future[Int] =
@@ -207,7 +200,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
   def getCommitActivity(ref: Project.Reference): Future[Seq[GithubCommitActivity]] =
     val request =
       HttpRequest(uri = s"${repoUrl(ref)}/stats/commit_activity").addHeader(acceptJson).addCredentials(credentials)
-    get[Seq[GithubCommitActivity]](request).fallbackTo(Future.successful(Seq.empty))
+    getOrDefault(request, Seq.empty) { (_, entity) => Unmarshal(entity).to[Seq[GithubCommitActivity]] }
 
   def getUserOrganizations(user: String): Future[Seq[Project.Organization]] =
     getAllRecursively(getUserOrganizationsPage(user))
@@ -324,6 +317,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
     getUserInfo().flatMap {
       case GithubResponse.Ok(info) => getUserState(info).map(GithubResponse.Ok.apply)
       case GithubResponse.MovedPermanently(info) => getUserState(info).map(GithubResponse.MovedPermanently.apply)
+      case notFound: GithubResponse.NotFound => Future.successful(notFound)
       case failed: GithubResponse.Failed => Future.successful(failed)
     }
 
@@ -350,6 +344,7 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
         Unmarshal(entity).to[GithubModel.UserInfo].map(res => GithubResponse.Ok(res.toCoreUserInfo(token)))
       case GithubResponse.MovedPermanently((_, entity)) =>
         Unmarshal(entity).to[GithubModel.UserInfo].map(res => GithubResponse.Ok(res.toCoreUserInfo(token)))
+      case GithubResponse.NotFound(code) => Future.successful(GithubResponse.NotFound(code))
       case GithubResponse.Failed(code, errorMessage) =>
         Future.successful(GithubResponse.Failed(code, errorMessage))
     }
@@ -375,12 +370,28 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
   )(using io.circe.Decoder[A]): Future[A] =
     getRaw(request).flatMap { case (_, entity) => Unmarshal(entity).to[A] }
 
+  /** Ok/Moved → parse; NotFound (no data) → default; Failed (real error) → fail the Future. */
+  private def getOrDefault[A](request: HttpRequest, default: => A)(
+      parse: (Seq[HttpHeader], ResponseEntity) => Future[A]
+  ): Future[A] =
+    process(request).flatMap {
+      case GithubResponse.Ok((headers, entity)) => parse(headers, entity)
+      case GithubResponse.MovedPermanently((headers, entity)) => parse(headers, entity)
+      case GithubResponse.NotFound(_) => Future.successful(default)
+      case GithubResponse.Failed(code, reason) => Future.failed(new Exception(s"$code: $reason"))
+    }
+
   private def getRaw(request: HttpRequest): Future[(Seq[HttpHeader], ResponseEntity)] =
     process(request).map {
       case GithubResponse.Ok((headers, entity)) => (headers, entity)
       case GithubResponse.MovedPermanently((headers, entity)) => (headers, entity)
+      case GithubResponse.NotFound(code) => throw new Exception(s"$code: not found")
       case GithubResponse.Failed(code, reason) => throw new Exception(s"$code: $reason")
     }
+
+  /** Status codes that mean "understood, but there is no data" rather than an error. */
+  private val emptyDataStatusCodes: Set[StatusCode] =
+    Set(StatusCodes.NoContent, StatusCodes.Accepted, StatusCodes.NotFound, StatusCodes.Gone)
 
   private def process(request: HttpRequest): Future[GithubResponse[(Seq[HttpHeader], ResponseEntity)]] =
     assert(request.headers.contains(Authorization(credentials)))
@@ -394,6 +405,9 @@ class GithubClientImpl(token: Secret, config: HttpClientConfig = HttpClientConfi
           case GithubResponse.Ok(res) => GithubResponse.MovedPermanently(res)
           case other => other
         }
+      case HttpResponse(status, _, entity, _) if emptyDataStatusCodes(status) =>
+        entity.discardBytes()
+        Future.successful(GithubResponse.NotFound(status.intValue))
       case _ @HttpResponse(code, _, entity, _) =>
         if entity.contentType.mediaType.isApplication
         then // we need to parse as json when the mediaType is application/json

--- a/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
+++ b/modules/server/src/main/scala/scaladex/server/GithubAuthImpl.scala
@@ -60,10 +60,13 @@ private class GithubAuthImpl(clientId: String, clientSecret: String, redirectUri
     githubClient.getUserInfo().map {
       case GithubResponse.Ok(res) => res
       case GithubResponse.MovedPermanently(res) => res
+      case GithubResponse.NotFound(code) =>
+        throw new Exception(s"Failed to get user: not found ($code)")
       case GithubResponse.Failed(errorCode, errorMessage) =>
         val message = s"Failed to get user state: $errorCode, $errorMessage"
         throw new Exception(message)
     }
+  end getUser
 
   def getUserState(token: Secret): Future[Option[UserState]] =
     val githubClient = githubClients.getOrElseUpdate(token, new GithubClientImpl(token))
@@ -74,6 +77,8 @@ private class GithubAuthImpl(clientId: String, clientSecret: String, redirectUri
       case GithubResponse.Failed(StatusCodes.Unauthorized.intValue, errorMessage) =>
         logger.warn(s"Rejected invalid GitHub token: $errorMessage")
         None
+      case GithubResponse.NotFound(code) =>
+        throw Exception(s"Failed to get user state from GitHub: not found ($code)")
       case GithubResponse.Failed(errorCode, errorMessage) =>
         throw Exception(s"Failed to get user state from GitHub: $errorCode, $errorMessage")
     }

--- a/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/AdminService.scala
@@ -98,6 +98,8 @@ class AdminService(
         githubClient.getProjectInfo(reference).flatMap {
           case GithubResponse.Failed(code, errorMessage) =>
             throw new Exception(s"Failed to add project due to GitHub error $code : $errorMessage")
+          case GithubResponse.NotFound(code) =>
+            throw new Exception(s"Failed to add project. Repository not found on GitHub (HTTP $code)")
           case GithubResponse.MovedPermanently(res) =>
             throw new Exception(s"Failed to add project. Project moved to ${res._1.repository}")
           case GithubResponse.Ok((_, info)) =>

--- a/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/GithubUpdater.scala
@@ -65,9 +65,13 @@ class GithubUpdater(database: WebDatabase, github: GithubClient)(using Execution
         logger.info(s"$repo moved to $destination")
         database.moveProject(repo, info, status).map(_ => status)
 
+      case GithubResponse.NotFound(_) =>
+        val status = GithubStatus.NotFound(now)
+        logger.info(s"$repo not found on GitHub")
+        database.updateGithubStatus(repo, status).map(_ => status)
+
       case GithubResponse.Failed(code, reason) =>
-        val status =
-          if code == 404 then GithubStatus.NotFound(now) else GithubStatus.Failed(now, code, reason)
+        val status = GithubStatus.Failed(now, code, reason)
         logger.info(s"Failed to download github info for $repo because of $status")
         database.updateGithubStatus(repo, status).map(_ => status)
     end match

--- a/modules/server/src/main/scala/scaladex/server/service/UserSessionService.scala
+++ b/modules/server/src/main/scala/scaladex/server/service/UserSessionService.scala
@@ -39,6 +39,7 @@ class UserSessionService(database: SchedulerDatabase)(using system: ActorSystem)
       _ <- response match
         case GithubResponse.Ok(state) => database.updateUser(userId, state)
         case GithubResponse.MovedPermanently(state) => database.updateUser(userId, state)
+        case GithubResponse.NotFound(_) => Future.successful(())
         case GithubResponse.Failed(code, errorMessage) =>
           if code == StatusCodes.Unauthorized.intValue then
             logger.info(s"Token for user with id: '$userId' is likely expired, with error: $errorMessage")


### PR DESCRIPTION
Per-item tolerance is already in place at the job level (`Resilience.tolerateHttpClientErrors` in `GithubUpdater`), so the GitHub client shouldn't collapse every failure into a default value.

- Adds `GithubResponse.NotFound(code)` for "understood, but no data" status codes (404/410/204/202).
- Replaces the five `.fallbackTo(default)` calls with a `getOrDefault` helper: legit empty responses (no README, empty repo, issues disabled, stats warming up) map to the endpoint default; real errors (5xx, exhausted rate-limit, network, open circuit breaker) now fail the `Future` and reach the per-project tolerance instead of silently storing partial `GithubInfo`.
- `getRepository`'s 404 flows as `NotFound`, so `GithubUpdater` drops its magic `if code == 404` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)