### PR TITLE
Don't trip circuit breaker on non-transient errors like 404

### DIFF
--- a/modules/infra/src/main/scala/scaladex/infra/CommonAkkaHttpClient.scala
+++ b/modules/infra/src/main/scala/scaladex/infra/CommonAkkaHttpClient.scala
@@ -74,24 +74,22 @@ abstract class CommonAkkaHttpClient(config: HttpClientConfig = HttpClientConfig.
     }
   end tryEnqueue
 
-  private val retryableStatusCodes: Set[StatusCode] = Set(
+  private val retryableClientErrors: Set[StatusCode] = Set(
     StatusCodes.RequestTimeout,
-    StatusCodes.TooManyRequests,
-    StatusCodes.InternalServerError,
-    StatusCodes.BadGateway,
-    StatusCodes.ServiceUnavailable,
-    StatusCodes.GatewayTimeout
+    StatusCodes.TooManyRequests
   )
 
   private val breaker: Option[CircuitBreaker] =
     config.circuitBreaker.map(cb => CircuitBreaker(system.scheduler, cb.maxFailures, cb.callTimeout, cb.resetTimeout))
 
   protected def isRetryable(response: HttpResponse): Boolean =
-    retryableStatusCodes(response.status)
+    response.status match
+      case _: StatusCodes.ServerError => true
+      case status => retryableClientErrors(status)
 
   protected def isBreakerFailure(result: Try[HttpResponse]): Boolean =
     result match
-      case Success(response) => response.status.isFailure
+      case Success(response) => isRetryable(response)
       case Failure(_) => true
 
   private def retryLoop(request: HttpRequest, attempt: Int)(using ExecutionContextExecutor): Future[HttpResponse] =


### PR DESCRIPTION
`isBreakerFailure` counted every failure status (including 404/410) as a circuit-breaker failure. In the sequential `github-info` job a cluster of not-found repos could open the breaker and abort the whole run with a bare `CircuitBreakerOpenException`.

Now the breaker (and retries) trip only on transient/upstream-distress conditions: any 5xx, plus 408 and 429. Non-transient client errors (404/410/401/403) no longer open it. `isRetryable` is also broadened to cover all 5xx codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)